### PR TITLE
fix(build): drop rimraf/cross-env shell-outs after ts-builds 2.8.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,5 +3,3 @@ public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*prettier*
 public-hoist-pattern[]=*vitest*
 public-hoist-pattern[]=typescript
-public-hoist-pattern[]=*rimraf*
-public-hoist-pattern[]=*cross-env*

--- a/packages/functype/ts-builds.config.json
+++ b/packages/functype/ts-builds.config.json
@@ -5,7 +5,7 @@
     "extract:interfaces": "tsx scripts/extract-interfaces.ts",
     "docs": "pnpm docs:preprocess && typedoc",
     "docs:validate": "tsx scripts/validate-docs.ts && tsx scripts/sync-docs.ts",
-    "build": "rimraf dist && tsx scripts/extract-interfaces.ts && cross-env NODE_ENV=production tsdown"
+    "build": "tsx scripts/extract-interfaces.ts && NODE_ENV=production tsdown"
   },
   "chains": {
     "validate": ["format", "lint", "compile", "test", "build"]


### PR DESCRIPTION
## Summary

Local `pnpm validate` started failing after ts-builds 2.8.0 landed in the workspace (Dependabot bumped it across all packages). The bump dropped \`rimraf\` and \`cross-env\` as direct dependencies — they were implementation details ts-builds no longer ships — but \`packages/functype/ts-builds.config.json\` still had them in its build override:

\`\`\`
"build": "rimraf dist && tsx scripts/extract-interfaces.ts && cross-env NODE_ENV=production tsdown"
\`\`\`

With nothing in the workspace graph pulling rimraf/cross-env in, the \`public-hoist-pattern\` entries in \`.npmrc\` have nothing to hoist. CI passed because setup-node's global tool cache provides rimraf; local installs don't.

## Changes

- \`packages/functype/ts-builds.config.json\`: \`build\` becomes \`tsx scripts/extract-interfaces.ts && NODE_ENV=production tsdown\`. Drops \`rimraf dist &&\` (tsdown overwrites its outputs) and \`cross-env\` (POSIX env prefix works on macOS/Linux/CI; Windows isn't a target).
- \`.npmrc\`: removes the two now-dead \`public-hoist-pattern\` entries (\`*rimraf*\`, \`*cross-env*\`). Keeps the live ones.

## Verification

\`pnpm install && pnpm turbo run validate --force\` → 7/7 packages green locally.

## Test plan

- [ ] CI \`validate\` workflow exits 0
- [ ] CodeQL re-runs cleanly (no new alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)