### PR TITLE
fix(ci): run docs-ci.js from packages/functype so npx finds typedoc

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -51,12 +51,13 @@ jobs:
         run: pnpm --filter site build
 
       - name: Build TypeDoc
+        working-directory: packages/functype
         env:
           BROWSER: none
           CI: true
         run: |
           npm config set browser false
-          node packages/functype/docs-ci.js
+          node docs-ci.js
 
       - name: Prepare combined deployment
         run: |


### PR DESCRIPTION
## Summary

\`deploy-docs.yml\`'s "Build TypeDoc" step invoked \`node packages/functype/docs-ci.js\` from the workspace root. The script internally calls \`execSync('npx typedoc')\`, which looks for typedoc in \`\$cwd/node_modules/.bin/\` — i.e., the workspace root's \`.bin/\`, which doesn't have it. typedoc lives in \`packages/functype/node_modules/.bin/typedoc\`.

Before the monorepo migration this worked because the repo root WAS the functype package, so node and npx resolved against the same \`node_modules/\`. Phase 6 of the migration kept the script call but didn't set the cwd.

## Fix

Add \`working-directory: packages/functype\` to that step and drop the now-redundant \`packages/functype/\` prefix from the script path.

\`\`\`diff
       - name: Build TypeDoc
+        working-directory: packages/functype
         env:
           BROWSER: none
           CI: true
         run: |
           npm config set browser false
-          node packages/functype/docs-ci.js
+          node docs-ci.js
\`\`\`

## Verification

Smoke-tested locally: \`cd packages/functype && node docs-ci.js\` exits 0 and regenerates \`packages/functype/typedocs/\` from scratch.

## Test plan

- [ ] Deploy Docs workflow runs and succeeds on this PR's push to main
- [ ] GitHub Pages deployment publishes API docs at /api-docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)