### PR TITLE
chore(functype-react): mark private until first real release

### DIFF
--- a/packages/functype-react/README.md
+++ b/packages/functype-react/README.md
@@ -2,7 +2,7 @@
 
 React bindings for the [functype](../functype) functional programming library — ADT-aware hooks and exhaustive pattern matching components.
 
-> **v0.1: scaffold only.** The primitives that carry the package's thesis are tracked in a separate spec. This package currently exists to reserve the npm name, lock the family conventions, and unblock cross-package iteration during functype core development.
+> **v0.1: scaffold only — not yet published.** The primitives that carry the package's thesis are tracked in a separate spec. This package currently exists in-tree to lock the family conventions and unblock cross-package iteration during functype core development. It's marked `private: true` in `package.json` so it's skipped by the workspace's release flow until there's real content to ship; first publish + npm trusted-publisher setup happen at the same time.
 
 ## Thesis
 

--- a/packages/functype-react/package.json
+++ b/packages/functype-react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "functype-react",
   "version": "0.1.0",
+  "private": true,
   "description": "React bindings for functype — ADT-aware hooks and exhaustive pattern matching components",
   "keywords": [
     "functype",


### PR DESCRIPTION
## Summary

\`functype-react@0.1.0\` is a scaffold with no real functionality. Setting up the npmjs.com "pending publisher" flow for a never-before-published package didn't pan out cleanly on the first attempt, and there's no benefit to shipping an empty 3 kB package now — the npm name is largely squat-safe under the \`functype-*\` prefix.

Marking \`"private": true\` so \`pnpm -r publish\` skips it. README updated to make the state explicit (not yet published, scaffold-only) and to document the unblock path: first publish + npm trusted-publisher setup happen together when there's real content.

When v0.1's actual primitives ship (Match family, useTask, Validated, lifecycle helpers — per the in-flight v0.1 spec), drop \`private\` and configure the trusted publisher in the same PR.

## Verification

\`pnpm -F functype-react publish --dry-run --no-git-checks\` → "There are no new packages that should be published".

## Test plan

- [ ] CI \`validate\` still passes (functype-react validate doesn't change — only its publish status)
- [ ] After merge, re-run the previously-failed Release workflow and watch it skip functype-react cleanly (\`functype\`, \`functype-os\`, \`functype-log\`, \`functype-mcp-server\` should publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)