### PR TITLE
chore(site): mark private so pnpm -r publish skips it

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -2,6 +2,7 @@
   "name": "site",
   "type": "module",
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "dev": "astro dev",
     "prebuild": "cp src/content/*.md public/ && tsx scripts/generate-llms-full.ts",


### PR DESCRIPTION
## Summary

In the latest Release workflow run (post trusted-publisher fix), \`functype@0.60.4\` published successfully — sigstore log entry 1513898780. Then \`pnpm -r publish\` moved on to \`site@0.0.1\` and failed with E404, which stopped the publish loop before reaching \`functype-mcp-server@0.60.4\`.

\`site/\` is the Astro docs app — not an npm-publishable package. It should have had \`"private": true\` from Phase 1 of the monorepo migration but didn't (site never published from the old layout either, so this never surfaced before).

## Fix

Add \`"private": true\` to \`site/package.json\`. pnpm-r now correctly skips it.

## State on npm right now

| Package | Published | Notes |
|---|---|---|
| \`functype\` | **0.60.4** ✅ | Just published this run |
| \`functype-os\` | 0.60.0 | No-op (already at latest) |
| \`functype-log\` | 0.60.0 | No-op |
| \`functype-mcp-server\` | 0.60.3 | Still needs to bump to 0.60.4 (uses token auth, not OIDC) |
| \`functype-react\` | (not published) | Marked private in PR #120 |
| \`site\` | (not published) | This PR marks private |

## Test plan

- [ ] CI validate passes
- [ ] After merge, re-run release.yml on main → site skipped, mcp-server@0.60.4 publishes via NODE_AUTH_TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)