### PR TITLE
chore(release): bump publishable packages to 0.60.5 + add functype keywords

### DIFF
--- a/packages/functype-log/package.json
+++ b/packages/functype-log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functype-log",
-  "version": "0.60.0",
+  "version": "0.60.5",
   "description": "IO-native logging for functype — wraps LogLayer with Tag/Layer DI, structured logging, and test utilities",
   "keywords": [
     "functype",

--- a/packages/functype-os/package.json
+++ b/packages/functype-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functype-os",
-  "version": "0.60.0",
+  "version": "0.60.5",
   "description": "Functional OS utilities using functype data structures — env vars, path expansion, file ops, platform detection",
   "keywords": [
     "functype",

--- a/packages/functype/.prettierignore
+++ b/packages/functype/.prettierignore
@@ -4,3 +4,5 @@ dist
 node_modules/*
 lib
 pnpm-lock.yaml
+typedocs
+coverage

--- a/packages/functype/package.json
+++ b/packages/functype/package.json
@@ -1,8 +1,24 @@
 {
   "name": "functype",
-  "version": "0.60.4",
+  "version": "0.60.5",
   "type": "module",
   "description": "A functional programming library for TypeScript, using immutable data structures and type classes",
+  "keywords": [
+    "functype",
+    "functional",
+    "functional-programming",
+    "typescript",
+    "monad",
+    "adt",
+    "option",
+    "either",
+    "try",
+    "task",
+    "io",
+    "list",
+    "immutable",
+    "scala"
+  ],
   "author": "jordan.burke@gmail.com",
   "license": "MIT",
   "repository": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functype-mcp-server",
-  "version": "0.60.4",
+  "version": "0.60.5",
   "description": "MCP server for functype documentation lookup and TypeScript code validation",
   "keywords": [
     "mcp",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/jordanburke/functype",
     "source": "github"
   },
-  "version": "0.60.4",
+  "version": "0.60.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "functype-mcp-server",
-      "version": "0.60.4",
+      "version": "0.60.5",
       "transport": {
         "type": "stdio"
       },

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -1,4 +1,4 @@
-# Functype v0.60.4
+# Functype v0.60.5
 
 > A functional programming library for TypeScript with immutable data structures, type-safe error handling, and Scala-inspired patterns.
 


### PR DESCRIPTION
## Summary

End-to-end test of the monorepo publish pipeline against main, and a fix for npmjs.com's family-link discoverability.

## What changed

- **All four publishable packages → 0.60.5.** functype was at 0.60.4; functype-os and functype-log were at 0.60.0; functype-mcp-server was at 0.60.4. Now uniformly at 0.60.5.
- **\`packages/functype/package.json\` gets a \`keywords\` field** — it had none. Now includes \`functype\`, \`functional\`, \`functional-programming\`, \`typescript\`, \`monad\`, \`adt\`, \`option\`, \`either\`, \`try\`, \`task\`, \`io\`, \`list\`, \`immutable\`, \`scala\`. The four siblings already declared the \`functype\` keyword; this missing field was why npmjs.com didn't surface the family from the core package's page.
- **\`packages/mcp-server/server.json\` auto-synced via \`pnpm -F functype-mcp-server sync:registry\`** so the MCP registry manifest tracks the new version.
- **\`packages/functype/.prettierignore\` adds \`typedocs\` and \`coverage\`** — local generated artifacts started tripping the format step after the monorepo restructure put them in scope.

## How the publish actually happens

This PR does not include a changeset file. When it merges to main:

1. \`publish.yml\` runs.
2. Sees no queued changesets in \`.changeset/\`.
3. Goes straight to \`pnpm -r publish --no-git-checks\`.
4. pnpm compares each package's local version to npm:
   - \`functype\` 0.60.5 > 0.60.4 → **publish**
   - \`functype-os\` 0.60.5 > 0.60.0 → **publish**
   - \`functype-log\` 0.60.5 > 0.60.0 → **publish**
   - \`functype-mcp-server\` 0.60.5 > 0.60.4 → **publish**
   - \`functype-react\` private → skip
   - \`site\` private → skip
5. All four publish with provenance via the existing OIDC trusted publishers.

## Verification

- \`pnpm validate\` → 7/7 packages green locally
- \`pnpm -F functype-mcp-server sync:registry:check\` → "already in sync (version=0.60.5)"

## Test plan

- [ ] CI \`Validate\` passes on the PR
- [ ] Merge → \`publish.yml\` runs → all four 0.60.5 land on npm
- [ ] \`npm view functype@0.60.5 keywords\` returns the new keyword array
- [ ] functype's page on npmjs.com now shows links to functype-os, functype-log, functype-mcp-server via the \`functype\` keyword

🤖 Generated with [Claude Code](https://claude.com/claude-code)