### PR TITLE
fix(readme): repoint Node.js Build badge to ci.yml

### DIFF
--- a/packages/functype/README.md
+++ b/packages/functype/README.md
@@ -1,7 +1,7 @@
 # Functype
 
-![NPM Version](https://img.shields.io/npm/v/functype?link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2Ffunctype)
-[![Node.js Build](https://github.com/jordanburke/functype/actions/workflows/pnpm-build.yml/badge.svg)](https://github.com/jordanburke/functype/actions/workflows/pnpm-build.yml)
+[![NPM Version](https://img.shields.io/npm/v/functype)](https://www.npmjs.com/package/functype)
+[![CI](https://github.com/jordanburke/functype/actions/workflows/ci.yml/badge.svg)](https://github.com/jordanburke/functype/actions/workflows/ci.yml)
 
 ## A Functional Programming Library for TypeScript
 


### PR DESCRIPTION
## Summary

\`packages/functype/README.md\` had two slightly-broken badges:

1. **Node.js Build** — pointed at \`.github/workflows/pnpm-build.yml\`, which was removed in Phase 6 of the monorepo migration when the seven scattered workflows got consolidated. The badge rendered as "no status" and the click-through 404'd. Repointed to \`ci.yml\` and renamed the label to **CI** to match.

2. **NPM Version** — was using shields.io's deprecated \`?link=...\` query param. Newer shields.io versions ignore it. Replaced with an explicit markdown link wrapper, which is the modern pattern.

## Test plan

- [ ] Badges render correctly on this PR's README preview
- [ ] After merge, the badges on npmjs.com (NPM Version), pulled from the published README, reflect the fixes on the next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)