### PR TITLE
chore(monorepo): import eslint-functype as eslint-{config,plugin}-functype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run turbo validate
         run: pnpm turbo run validate
 
+      - name: Check eslint-mirror invariant
+        run: pnpm check-eslint-mirror
+
   bundle-size:
     name: Bundle size report (packages/functype)
     runs-on: ubuntu-latest

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,10 +43,22 @@ For each of the four provenance-enabled packages, log into [npmjs.com](https://w
 | `functype-os` | `jordanburke/functype` | `publish.yml` | Was scoped to `jordanburke/functype-os` + `publish.yml`; repo updated to monorepo, filename unchanged. |
 | `functype-log` | `jordanburke/functype` | `publish.yml` | Was scoped to `jordanburke/functype-log` + `publish.yml`; repo updated to monorepo, filename unchanged. |
 | `functype-react` | `jordanburke/functype` | `publish.yml` | **Required before first publish.** v0.1 ships Tier 1–4 hooks/components; package was `private: true` through scaffolding and is now unblocked. Configure the trusted publisher on npmjs.com BEFORE merging the v0.1 PR or the first publish will be rejected by npm. |
+| `eslint-config-functype` | `jordanburke/functype` | `publish.yml` | Was scoped to `jordanburke/eslint-functype` + `publish.yml`; repo updated to monorepo, filename unchanged. **Required before first publish from the monorepo at `2.60.6`** (the cadence-mirror version — see *Mirror invariant* below). |
+| `eslint-plugin-functype` | `jordanburke/functype` | `publish.yml` | Same as above. |
 
 Environment: leave blank unless previously set. Already-published versions retain their existing provenance attestations (per-version, immutable) — only new publishes are affected.
 
 `functype-mcp-server` does **not** use trusted publishing today; it publishes via `NPM_TOKEN`. `publish.yml` preserves that pattern through the `NODE_AUTH_TOKEN` env var on the changesets step. No npm admin action needed for it.
+
+## Mirror invariant for eslint packages
+
+The two eslint packages mirror functype's minor and patch positions: `eslint-{config,plugin}-functype` versions are always `2.<functype-minor>.<functype-patch>`. Major stays at `2` until functype reaches `1.0`, at which point both eslint packages catch up to `3.0.0` and the family converges on a single version line.
+
+Enforcement: `scripts/check-eslint-mirror.ts` runs:
+- After every `changeset version` (chained into the `version-packages` script) — fails a release before publish if the mirror is broken.
+- On every PR via CI (`ci.yml` → `pnpm check-eslint-mirror`) — surfaces drift at PR-author time, not release-author time.
+
+**Rule for authoring changesets:** every release that touches functype must include all 7 publishable packages at the same bump level. Per-package or mismatched-level changesets break the mirror and the script will reject the release.
 
 ## Node version requirement
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "typecheck": "turbo run typecheck",
     "dev": "turbo run dev",
     "clean": "pnpm -r clean && rm -rf .turbo",
-    "version-packages": "changeset version && pnpm -F functype-mcp-server sync:registry"
+    "version-packages": "changeset version && tsx scripts/check-eslint-mirror.ts && pnpm -F functype-mcp-server sync:registry",
+    "check-eslint-mirror": "tsx scripts/check-eslint-mirror.ts"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "engines": {
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
+    "tsx": "^4.21.0",
     "turbo": "^2.9.14"
   }
 }

--- a/packages/eslint-config-functype/CHANGELOG.md
+++ b/packages/eslint-config-functype/CHANGELOG.md
@@ -1,0 +1,9 @@
+# eslint-config-functype
+
+## 2.60.6
+
+Moved to the `functype` monorepo. Versioning now mirrors `functype`'s minor and patch — `eslint-config-functype@2.<functype-minor>.<functype-patch>` (major stays at `2` until functype reaches `1.0`, at which point the eslint packages catch up to `3.0.0` and the family converges on a single version line). No code changes.
+
+## 2.3.0
+
+Last version published from the standalone `jordanburke/eslint-functype` repo. Required `eslint-plugin-simple-import-sort` ^13.

--- a/packages/eslint-config-functype/README.md
+++ b/packages/eslint-config-functype/README.md
@@ -1,11 +1,11 @@
 # eslint-config-functype
 
-Curated ESLint flat config for functional TypeScript with [functype](https://github.com/jordanburke/functype). Composes rules from `eslint-plugin-functional`, `typescript-eslint`, `prettier`, and `simple-import-sort` into opinionated `recommended` and `strict` presets.
+Curated ESLint flat config for functional TypeScript with [functype](https://github.com/jordanburke/functype). Composes rules from `typescript-eslint`, `prettier`, and `simple-import-sort` into opinionated `recommended` and `strict` presets.
 
 ## Install
 
 ```bash
-npm install -D eslint-config-functype eslint eslint-plugin-functional @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-plugin-prettier prettier eslint-plugin-simple-import-sort
+npm install -D eslint-config-functype eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-plugin-prettier prettier eslint-plugin-simple-import-sort
 ```
 
 ## Usage
@@ -15,10 +15,7 @@ npm install -D eslint-config-functype eslint eslint-plugin-functional @typescrip
 import recommended from "eslint-config-functype/recommended"
 import testOverrides from "eslint-config-functype/test-overrides"
 
-export default [
-  recommended,
-  testOverrides, // relaxes functional rules for test files
-]
+export default [recommended, testOverrides]
 ```
 
 ### Strict mode
@@ -36,23 +33,35 @@ export default [strict, testOverrides]
 
 - `prefer-const`, `no-var`, `no-throw-literal`
 - `@typescript-eslint/consistent-type-imports`, `no-explicit-any`, `no-floating-promises`, `await-thenable`
-- `functional/no-let`, `functional/immutable-data` (warn), `functional/no-throw-statements` (warn, allows reject)
-- `functional/prefer-immutable-types` is **off** - functype types are immutable by design
+- `@typescript-eslint/strict-boolean-expressions` (warn, relaxed for functional patterns)
 - Prettier formatting and import sorting
 
 ### `strict`
 
 Everything in `recommended` plus:
 
-- `functional/no-loop-statements` (error)
-- `functional/immutable-data` (error)
-- `functional/prefer-immutable-types` (warn)
 - `@typescript-eslint/explicit-function-return-type` (error)
+- `@typescript-eslint/no-non-null-assertion` (error)
 - `@typescript-eslint/strict-boolean-expressions` (error, default strict)
 
 ### `test-overrides`
 
-Disables `functional/no-let`, `immutable-data`, `no-throw-statements`, and `no-try-statements` for test files (`*.test.ts`, `*.spec.ts`, `test/**`, `tests/**`, `__tests__/**`).
+Extension point for test files (`*.test.ts`, `*.spec.ts`, `test/**`, `tests/**`, `__tests__/**`).
+
+## Pairing with eslint-plugin-functype
+
+For functype-specific rules (prefer-option, prefer-either, prefer-fold, etc.):
+
+```bash
+npm install -D eslint-plugin-functype
+```
+
+```js
+import recommended from "eslint-config-functype/recommended"
+import functype from "eslint-plugin-functype"
+
+export default [recommended, functype.configs.recommended]
+```
 
 ## CLI
 

--- a/packages/eslint-config-functype/README.md
+++ b/packages/eslint-config-functype/README.md
@@ -1,0 +1,67 @@
+# eslint-config-functype
+
+Curated ESLint flat config for functional TypeScript with [functype](https://github.com/jordanburke/functype). Composes rules from `eslint-plugin-functional`, `typescript-eslint`, `prettier`, and `simple-import-sort` into opinionated `recommended` and `strict` presets.
+
+## Install
+
+```bash
+npm install -D eslint-config-functype eslint eslint-plugin-functional @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-plugin-prettier prettier eslint-plugin-simple-import-sort
+```
+
+## Usage
+
+```js
+// eslint.config.mjs
+import recommended from "eslint-config-functype/recommended"
+import testOverrides from "eslint-config-functype/test-overrides"
+
+export default [
+  recommended,
+  testOverrides, // relaxes functional rules for test files
+]
+```
+
+### Strict mode
+
+```js
+import strict from "eslint-config-functype/strict"
+import testOverrides from "eslint-config-functype/test-overrides"
+
+export default [strict, testOverrides]
+```
+
+## Configs
+
+### `recommended`
+
+- `prefer-const`, `no-var`, `no-throw-literal`
+- `@typescript-eslint/consistent-type-imports`, `no-explicit-any`, `no-floating-promises`, `await-thenable`
+- `functional/no-let`, `functional/immutable-data` (warn), `functional/no-throw-statements` (warn, allows reject)
+- `functional/prefer-immutable-types` is **off** - functype types are immutable by design
+- Prettier formatting and import sorting
+
+### `strict`
+
+Everything in `recommended` plus:
+
+- `functional/no-loop-statements` (error)
+- `functional/immutable-data` (error)
+- `functional/prefer-immutable-types` (warn)
+- `@typescript-eslint/explicit-function-return-type` (error)
+- `@typescript-eslint/strict-boolean-expressions` (error, default strict)
+
+### `test-overrides`
+
+Disables `functional/no-let`, `immutable-data`, `no-throw-statements`, and `no-try-statements` for test files (`*.test.ts`, `*.spec.ts`, `test/**`, `tests/**`, `__tests__/**`).
+
+## CLI
+
+```bash
+npx functype-list-rules              # list all configured rules
+npx functype-list-rules --verbose    # with rule details
+npx functype-list-rules --check-deps # verify peer dependencies
+```
+
+## License
+
+MIT

--- a/packages/eslint-config-functype/eslint.config.mjs
+++ b/packages/eslint-config-functype/eslint.config.mjs
@@ -1,0 +1,4 @@
+// Use ts-builds/eslint base (NOT functype's own config) to avoid circular dependency
+import config from "ts-builds/eslint"
+
+export default config

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -76,14 +76,14 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
-    "@typescript-eslint/eslint-plugin": "^8.57.0",
-    "@typescript-eslint/parser": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^8.57.1",
+    "@typescript-eslint/parser": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-functional": "^9.0.4",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "ts-builds": "^2.5.1",
-    "tsdown": "^0.21.2"
+    "ts-builds": "^2.5.2",
+    "tsdown": "^0.21.4"
   },
   "author": "Jordan Burke",
   "repository": {

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -65,7 +65,6 @@
     "@typescript-eslint/eslint-plugin": "^8.38.0 || ^8.39.0 || ^9.0.0",
     "@typescript-eslint/parser": "^8.38.0 || ^8.39.0 || ^9.0.0",
     "eslint": "^10.0.3",
-    "eslint-plugin-functional": "^9.0.2",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "prettier": "^3.0.0"
@@ -79,7 +78,6 @@
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-functional": "^9.0.4",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "ts-builds": "^2.5.2",

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -75,13 +75,13 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
-    "@typescript-eslint/eslint-plugin": "^8.57.2",
-    "@typescript-eslint/parser": "^8.57.2",
+    "@typescript-eslint/eslint-plugin": "^8.58.0",
+    "@typescript-eslint/parser": "^8.58.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "ts-builds": "^2.6.1",
-    "tsdown": "^0.21.5"
+    "ts-builds": "^2.6.2",
+    "tsdown": "^0.21.7"
   },
   "author": "Jordan Burke",
   "repository": {

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -66,7 +66,7 @@
     "@typescript-eslint/parser": "^8.38.0 || ^8.39.0 || ^9.0.0",
     "eslint": "^10.0.3",
     "eslint-plugin-prettier": "^5.0.0",
-    "eslint-plugin-simple-import-sort": "^12.0.0",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
     "prettier": "^3.0.0"
   },
   "dependencies": {
@@ -75,13 +75,13 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
-    "@typescript-eslint/eslint-plugin": "^8.58.2",
-    "@typescript-eslint/parser": "^8.58.2",
+    "@typescript-eslint/eslint-plugin": "^8.59.1",
+    "@typescript-eslint/parser": "^8.59.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "ts-builds": "^2.7.0",
-    "tsdown": "^0.21.9"
+    "ts-builds": "^2.7.1",
+    "tsdown": "^0.21.10"
   },
   "author": "Jordan Burke",
   "repository": {
@@ -95,6 +95,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   }
 }

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -75,13 +75,13 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
-    "@typescript-eslint/eslint-plugin": "^8.57.1",
-    "@typescript-eslint/parser": "^8.57.1",
+    "@typescript-eslint/eslint-plugin": "^8.57.2",
+    "@typescript-eslint/parser": "^8.57.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "ts-builds": "^2.5.2",
-    "tsdown": "^0.21.4"
+    "ts-builds": "^2.6.1",
+    "tsdown": "^0.21.5"
   },
   "author": "Jordan Burke",
   "repository": {

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -74,13 +74,13 @@
     "@eslint/js": "^10.0.1"
   },
   "devDependencies": {
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.2",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "ts-builds": "^2.6.2",
+    "ts-builds": "^2.6.3",
     "tsdown": "^0.21.7"
   },
   "author": "Jordan Burke",

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -75,13 +75,13 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
-    "@typescript-eslint/eslint-plugin": "^8.58.0",
-    "@typescript-eslint/parser": "^8.58.0",
+    "@typescript-eslint/eslint-plugin": "^8.58.2",
+    "@typescript-eslint/parser": "^8.58.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
-    "ts-builds": "^2.6.3",
-    "tsdown": "^0.21.7"
+    "eslint-plugin-simple-import-sort": "^13.0.0",
+    "ts-builds": "^2.7.0",
+    "tsdown": "^0.21.9"
   },
   "author": "Jordan Burke",
   "repository": {

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,0 +1,101 @@
+{
+  "name": "eslint-config-functype",
+  "version": "2.0.0",
+  "type": "module",
+  "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./recommended": {
+      "types": "./dist/configs/recommended.d.ts",
+      "import": "./dist/configs/recommended.js",
+      "default": "./dist/configs/recommended.js"
+    },
+    "./strict": {
+      "types": "./dist/configs/strict.d.ts",
+      "import": "./dist/configs/strict.js",
+      "default": "./dist/configs/strict.js"
+    },
+    "./test-overrides": {
+      "types": "./dist/configs/test-overrides.d.ts",
+      "import": "./dist/configs/test-overrides.js",
+      "default": "./dist/configs/test-overrides.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "functype-list-rules": "dist/cli/list-rules.js"
+  },
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin",
+    "functional",
+    "typescript",
+    "immutable"
+  ],
+  "prettier": "ts-builds/prettier",
+  "scripts": {
+    "validate": "ts-builds validate",
+    "format": "ts-builds format",
+    "format:check": "ts-builds format:check",
+    "lint": "ts-builds lint",
+    "lint:check": "ts-builds lint:check",
+    "typecheck": "ts-builds typecheck",
+    "build": "ts-builds build",
+    "dev": "ts-builds dev",
+    "prepublishOnly": "pnpm validate",
+    "list-rules": "node dist/cli/list-rules.js",
+    "list-rules:verbose": "node dist/cli/list-rules.js --verbose",
+    "list-rules:usage": "node dist/cli/list-rules.js --usage",
+    "check-deps": "node dist/cli/list-rules.js --check-deps",
+    "cli:help": "node dist/cli/list-rules.js --help",
+    "diff": "node dist/cli/list-rules.js --diff"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.38.0 || ^8.39.0 || ^9.0.0",
+    "@typescript-eslint/parser": "^8.38.0 || ^8.39.0 || ^9.0.0",
+    "eslint": "^10.0.3",
+    "eslint-plugin-functional": "^9.0.2",
+    "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-simple-import-sort": "^12.0.0",
+    "prettier": "^3.0.0"
+  },
+  "dependencies": {
+    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/js": "^10.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.0",
+    "@typescript-eslint/eslint-plugin": "^8.57.0",
+    "@typescript-eslint/parser": "^8.57.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-functional": "^9.0.4",
+    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "ts-builds": "^2.5.1",
+    "tsdown": "^0.21.2"
+  },
+  "author": "Jordan Burke",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jordanburke/eslint-functype",
+    "directory": "packages/config"
+  },
+  "homepage": "https://github.com/jordanburke/eslint-functype",
+  "bugs": {
+    "url": "https://github.com/jordanburke/eslint-functype/issues"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -29,7 +29,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "bin": {
     "functype-list-rules": "dist/cli/list-rules.js"

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-functype",
-  "version": "2.3.0",
+  "version": "2.60.6",
   "type": "module",
   "description": "Curated ESLint flat config bundle for functional TypeScript programming (ESLint 9.x+)",
   "main": "dist/index.js",
@@ -80,18 +80,22 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "ts-builds": "^2.7.1",
-    "tsdown": "^0.21.10"
+    "ts-builds": "^2.8.0",
+    "tsdown": "^0.22.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "author": "Jordan Burke",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jordanburke/eslint-functype",
-    "directory": "packages/config"
+    "url": "git+https://github.com/jordanburke/functype.git",
+    "directory": "packages/eslint-config-functype"
   },
-  "homepage": "https://github.com/jordanburke/eslint-functype",
+  "homepage": "https://github.com/jordanburke/functype/tree/main/packages/eslint-config-functype",
   "bugs": {
-    "url": "https://github.com/jordanburke/eslint-functype/issues"
+    "url": "https://github.com/jordanburke/functype/issues"
   },
   "license": "MIT",
   "engines": {

--- a/packages/eslint-config-functype/src/cli/list-rules.ts
+++ b/packages/eslint-config-functype/src/cli/list-rules.ts
@@ -1,0 +1,532 @@
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import { validatePeerDependencies, type ValidationResult } from "../utils/dependency-validator"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Types for better type safety
+type RuleSeverity = "off" | "warn" | "error" | 0 | 1 | 2
+type RuleConfig = RuleSeverity | [RuleSeverity, ...unknown[]]
+
+interface RuleData {
+  severity: RuleSeverity
+  options: unknown[]
+  source: string
+}
+
+interface Config {
+  rules?: Record<string, RuleConfig>
+  extends?: string[]
+  plugins?: string[]
+}
+
+interface LoadedConfig {
+  name: string
+  rules: Map<string, RuleData>
+}
+
+interface RuleDiff {
+  name: string
+  status: "added" | "removed" | "different" | "same"
+  localSeverity?: RuleSeverity
+  functypeSeverity?: RuleSeverity
+  localOptions?: unknown[]
+  functypeOptions?: unknown[]
+}
+
+// Colors for console output
+const colors = {
+  reset: "\x1b[0m",
+  bright: "\x1b[1m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+} as const
+
+function colorize(text: string, color: keyof typeof colors): string {
+  return colors[color] + text + colors.reset
+}
+
+async function loadConfig(configPath: string): Promise<Config | null> {
+  try {
+    const resolvedPath = path.resolve(configPath)
+    const configModule = await import(pathToFileURL(resolvedPath).href)
+    return configModule.default || configModule
+  } catch (error) {
+    console.error(colorize(`Error loading config from ${configPath}:`, "red"), (error as Error).message)
+    return null
+  }
+}
+
+function extractRules(config: Config): Map<string, RuleData> {
+  const rules = new Map<string, RuleData>()
+
+  if (config.rules) {
+    Object.entries(config.rules).forEach(([ruleName, ruleConfig]) => {
+      const severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig
+      const options = Array.isArray(ruleConfig) ? ruleConfig.slice(1) : []
+
+      rules.set(ruleName, {
+        severity,
+        options,
+        source: getRuleSource(ruleName),
+      })
+    })
+  }
+
+  return rules
+}
+
+function getRuleSource(ruleName: string): string {
+  if (ruleName.startsWith("functional/")) return "eslint-plugin-functional"
+  if (ruleName.startsWith("@typescript-eslint/")) return "@typescript-eslint/eslint-plugin"
+  return "eslint (core)"
+}
+
+function getSeverityColor(severity: RuleSeverity): keyof typeof colors {
+  switch (severity) {
+    case "error":
+    case 2:
+      return "red"
+    case "warn":
+    case 1:
+      return "yellow"
+    case "off":
+    case 0:
+      return "cyan"
+    default:
+      return "reset"
+  }
+}
+
+function formatSeverity(severity: RuleSeverity): string {
+  const severityMap: Record<string, string> = {
+    "0": "off",
+    "1": "warn",
+    "2": "error",
+    off: "off",
+    warn: "warn",
+    error: "error",
+  }
+  return severityMap[String(severity)] || String(severity)
+}
+
+function printRules(configName: string, rules: Map<string, RuleData>): void {
+  console.log(colorize(`\n📋 ${configName} Configuration Rules:`, "bright"))
+  console.log(colorize("=".repeat(50), "blue"))
+
+  // Group rules by source
+  const rulesBySource = new Map<string, Map<string, RuleData>>()
+  rules.forEach((ruleData, ruleName) => {
+    const source = ruleData.source
+    if (!rulesBySource.has(source)) {
+      rulesBySource.set(source, new Map())
+    }
+    rulesBySource.get(source)!.set(ruleName, ruleData)
+  })
+
+  // Print rules grouped by source
+  rulesBySource.forEach((sourceRules, source) => {
+    console.log(colorize(`\n📦 ${source}:`, "magenta"))
+
+    sourceRules.forEach((ruleData, ruleName) => {
+      const shortName = ruleName.replace(/^.*\//, "")
+      const severity = formatSeverity(ruleData.severity)
+      const severityColored = colorize(`[${severity.toUpperCase()}]`, getSeverityColor(ruleData.severity))
+      const hasOptions = ruleData.options && ruleData.options.length > 0
+      const optionsText = hasOptions ? colorize(" (with options)", "cyan") : ""
+
+      console.log(`  ${severityColored} ${colorize(shortName, "green")}${optionsText}`)
+
+      if (hasOptions && process.argv.includes("--verbose")) {
+        console.log(`    ${colorize("Options:", "cyan")} ${JSON.stringify(ruleData.options)}`)
+      }
+    })
+  })
+}
+
+function printSummary(configs: LoadedConfig[]): void {
+  console.log(colorize("\n📊 Summary:", "bright"))
+  console.log(colorize("=".repeat(30), "blue"))
+
+  configs.forEach(({ name, rules }) => {
+    const totalRules = rules.size
+    const errorRules = Array.from(rules.values()).filter((r) => r.severity === "error" || r.severity === 2).length
+    const warnRules = Array.from(rules.values()).filter((r) => r.severity === "warn" || r.severity === 1).length
+    const offRules = Array.from(rules.values()).filter((r) => r.severity === "off" || r.severity === 0).length
+
+    console.log(`\n${colorize(name, "bright")}: ${totalRules} total rules`)
+    console.log(`  ${colorize("●", "red")} ${errorRules} errors`)
+    console.log(`  ${colorize("●", "yellow")} ${warnRules} warnings`)
+    console.log(`  ${colorize("●", "cyan")} ${offRules} disabled`)
+  })
+}
+
+function printUsageInfo(): void {
+  console.log(colorize("\n💡 Usage Information:", "bright"))
+  console.log(colorize("=".repeat(30), "blue"))
+  console.log("\n📖 How to use these configurations:")
+  console.log("\n" + colorize("ESLint 8 (.eslintrc):", "green"))
+  console.log('  extends: ["plugin:functype/recommended"]')
+  console.log("\n" + colorize("ESLint 9+ (flat config):", "green"))
+  console.log("  Copy the rules from our documentation into your eslint.config.js")
+  console.log("\n" + colorize("Individual rules:", "green"))
+  console.log("  You can enable any rule individually in your rules section")
+}
+
+function printDependencyStatus(result: ValidationResult): void {
+  console.log(colorize("\n🔍 Dependency Status Check:", "bright"))
+  console.log(colorize("=".repeat(40), "blue"))
+
+  // Show available dependencies
+  if (result.available.length > 0) {
+    console.log(colorize("\n✅ Available:", "green"))
+    result.available.forEach((dep) => {
+      const icon = dep.required ? "🔧" : "🔌"
+      console.log(`  ${icon} ${colorize(dep.name, "green")} - ${dep.description}`)
+    })
+  }
+
+  // Show missing dependencies
+  if (result.missing.length > 0) {
+    console.log(colorize("\n❌ Missing:", "red"))
+    result.missing.forEach((dep) => {
+      const icon = dep.required ? "⚠️ " : "💡"
+      const color = dep.required ? "red" : "yellow"
+      console.log(`  ${icon} ${colorize(dep.name, color)} - ${dep.description}`)
+    })
+
+    if (result.installCommand) {
+      console.log(colorize("\n📦 Install missing dependencies:", "bright"))
+      console.log(`   ${colorize(result.installCommand, "cyan")}`)
+    }
+  }
+
+  // Show warnings
+  if (result.warnings.length > 0) {
+    console.log(colorize("\n⚠️  Warnings:", "yellow"))
+    result.warnings.forEach((warning) => console.log(`   ${warning}`))
+  }
+
+  // Overall status
+  const status = result.isValid ? "✅ Ready to use" : "❌ Configuration will fail"
+  const statusColor = result.isValid ? "green" : "red"
+  console.log(colorize(`\n${status}`, statusColor))
+}
+
+async function loadLocalESLintConfig(configPath: string): Promise<Config | null> {
+  try {
+    // Try common ESLint config file names if no path provided
+    const possibleConfigs = [
+      "eslint.config.js",
+      "eslint.config.mjs",
+      "eslint.config.ts",
+      ".eslintrc.js",
+      ".eslintrc.json",
+    ]
+
+    let actualPath = configPath
+    if (!configPath) {
+      // Search for config file in current directory
+      for (const filename of possibleConfigs) {
+        if (fs.existsSync(filename)) {
+          actualPath = filename
+          break
+        }
+      }
+      if (!actualPath) {
+        console.log(colorize("❌ No ESLint config file found. Searched for:", "red"))
+        possibleConfigs.forEach((f) => console.log(`  • ${f}`))
+        return null
+      }
+    }
+
+    console.log(colorize(`📖 Loading local config: ${actualPath}`, "cyan"))
+
+    // Handle flat config (eslint.config.js)
+    if (actualPath.includes("eslint.config")) {
+      const configModule = await import(path.resolve(actualPath))
+      const config = configModule.default || configModule
+
+      // Flat config is array of config objects, merge rules
+      if (Array.isArray(config)) {
+        const mergedRules: Record<string, RuleConfig> = {}
+        config.forEach((cfg: unknown) => {
+          if (cfg && typeof cfg === "object" && "rules" in cfg) {
+            const configObj = cfg as Config
+            if (configObj.rules) {
+              Object.assign(mergedRules, configObj.rules)
+            }
+          }
+        })
+        return { rules: mergedRules }
+      }
+      return config
+    }
+
+    // Handle legacy config (.eslintrc.*)
+    return await loadConfig(actualPath)
+  } catch (error) {
+    console.error(colorize(`Error loading local config:`, "red"), (error as Error).message)
+    return null
+  }
+}
+
+function compareRules(localRules: Map<string, RuleData>, functypeRules: Map<string, RuleData>): RuleDiff[] {
+  const allRules = new Set([...localRules.keys(), ...functypeRules.keys()])
+  const diffs: RuleDiff[] = []
+
+  allRules.forEach((ruleName) => {
+    const localRule = localRules.get(ruleName)
+    const functypeRule = functypeRules.get(ruleName)
+
+    if (!localRule && functypeRule) {
+      // Rule added by functype
+      diffs.push({
+        name: ruleName,
+        status: "added",
+        functypeSeverity: functypeRule.severity,
+        functypeOptions: functypeRule.options,
+      })
+    } else if (localRule && !functypeRule) {
+      // Rule exists locally but not in functype
+      diffs.push({
+        name: ruleName,
+        status: "removed",
+        localSeverity: localRule.severity,
+        localOptions: localRule.options,
+      })
+    } else if (localRule && functypeRule) {
+      // Compare configurations
+      const severityDifferent = localRule.severity !== functypeRule.severity
+      const optionsDifferent = JSON.stringify(localRule.options) !== JSON.stringify(functypeRule.options)
+
+      if (severityDifferent || optionsDifferent) {
+        diffs.push({
+          name: ruleName,
+          status: "different",
+          localSeverity: localRule.severity,
+          functypeSeverity: functypeRule.severity,
+          localOptions: localRule.options,
+          functypeOptions: functypeRule.options,
+        })
+      } else {
+        diffs.push({
+          name: ruleName,
+          status: "same",
+          localSeverity: localRule.severity,
+          functypeSeverity: functypeRule.severity,
+        })
+      }
+    }
+  })
+
+  return diffs.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function printDiff(diffs: RuleDiff[], functypeConfigName: string): void {
+  console.log(colorize(`\n🔄 Config Comparison vs ${functypeConfigName}:`, "bright"))
+  console.log(colorize("=".repeat(60), "blue"))
+
+  const categories = {
+    removed: diffs.filter((d) => d.status === "removed"),
+    added: diffs.filter((d) => d.status === "added"),
+    different: diffs.filter((d) => d.status === "different"),
+    same: diffs.filter((d) => d.status === "same"),
+  }
+
+  // Rules you can remove (covered by functype)
+  if (categories.same.length > 0) {
+    console.log(colorize("\n✅ Rules you can remove (covered by functype):", "green"))
+    categories.same.forEach((diff) => {
+      const severity = formatSeverity(diff.functypeSeverity!)
+      console.log(`  • ${diff.name} (${severity})`)
+    })
+  }
+
+  // New rules functype adds
+  if (categories.added.length > 0) {
+    console.log(colorize("\n➕ New rules functype adds:", "blue"))
+    categories.added.forEach((diff) => {
+      const severity = formatSeverity(diff.functypeSeverity!)
+      const severityColored = colorize(`[${severity.toUpperCase()}]`, getSeverityColor(diff.functypeSeverity!))
+      console.log(`  • ${diff.name} ${severityColored}`)
+    })
+  }
+
+  // Rules with conflicts
+  if (categories.different.length > 0) {
+    console.log(colorize("\n🔀 Conflicting rules (will override functype):", "yellow"))
+    categories.different.forEach((diff) => {
+      const localSeverity = formatSeverity(diff.localSeverity!)
+      const functypeSeverity = formatSeverity(diff.functypeSeverity!)
+      console.log(`  • ${diff.name}`)
+      console.log(`    Local:    ${localSeverity}`)
+      console.log(`    Functype: ${functypeSeverity}`)
+    })
+  }
+
+  // Rules you have that functype doesn't
+  if (categories.removed.length > 0) {
+    console.log(colorize("\n➖ Your additional rules (not in functype):", "magenta"))
+    categories.removed.forEach((diff) => {
+      const severity = formatSeverity(diff.localSeverity!)
+      console.log(`  • ${diff.name} (${severity})`)
+    })
+  }
+
+  // Summary stats
+  console.log(colorize("\n📊 Migration Summary:", "bright"))
+  console.log(`  ${categories.same.length} rules can be removed`)
+  console.log(`  ${categories.added.length} new rules will be added`)
+  console.log(`  ${categories.different.length} rules have conflicts`)
+  console.log(`  ${categories.removed.length} additional rules you keep`)
+
+  // Migration suggestions
+  if (categories.same.length > 0 || categories.different.length > 0) {
+    console.log(colorize("\n💡 Suggested migration steps:", "bright"))
+    if (categories.same.length > 0) {
+      console.log("1. Remove duplicate rules from your config (they match functype)")
+    }
+    if (categories.different.length > 0) {
+      console.log("2. Review conflicting rules - decide if you want local overrides")
+    }
+    console.log('3. Add functype config: extends: ["plugin:functype/recommended"]')
+  }
+}
+
+async function runDiffMode(configPath: string): Promise<void> {
+  console.log(colorize("🔄 ESLint Config Diff Mode", "bright"))
+
+  // Load local config
+  const localConfig = await loadLocalESLintConfig(configPath)
+  if (!localConfig) {
+    console.error(colorize("❌ Could not load local ESLint config", "red"))
+    process.exit(1)
+  }
+
+  const localRules = extractRules(localConfig)
+  console.log(colorize(`Found ${localRules.size} rules in local config`, "cyan"))
+
+  // Load functype configs
+  const distPath = path.join(__dirname, "..", "..", "dist")
+  const configs = [
+    { name: "Recommended", path: path.join(distPath, "configs", "recommended.js") },
+    { name: "Strict", path: path.join(distPath, "configs", "strict.js") },
+  ]
+
+  for (const { name, path: configPath } of configs) {
+    const functypeConfig = await loadConfig(configPath)
+    if (functypeConfig) {
+      const functypeRules = extractRules(functypeConfig)
+      const diffs = compareRules(localRules, functypeRules)
+      printDiff(diffs, name)
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2)
+  const showHelp = args.includes("--help") || args.includes("-h")
+  const showUsage = args.includes("--usage") || args.includes("-u")
+  const checkDeps = args.includes("--check-deps") || args.includes("--check")
+  const diffMode = args.includes("--diff")
+  const diffConfigIndex = args.findIndex((arg) => arg === "--diff")
+  const diffConfigPath = diffConfigIndex !== -1 && args[diffConfigIndex + 1] ? args[diffConfigIndex + 1] : ""
+
+  if (showHelp) {
+    console.log(colorize("📋 ESLint Plugin Functype - Rule Lister", "bright"))
+    console.log("\nUsage: pnpm run list-rules [options]")
+    console.log("\nOptions:")
+    console.log("  --verbose, -v      Show rule options")
+    console.log("  --usage, -u        Show usage examples")
+    console.log("  --check-deps       Check peer dependency status")
+    console.log("  --diff [config]    Compare local ESLint config with functype")
+    console.log("  --help, -h         Show this help message")
+    console.log("\nThis command lists all rules configured in the functype plugin configurations.")
+    console.log("\nDiff mode:")
+    console.log("  --diff             Auto-detect local ESLint config file")
+    console.log("  --diff <path>      Compare specific config file with functype")
+    return
+  }
+
+  // Handle diff mode
+  if (diffMode) {
+    await runDiffMode(diffConfigPath)
+    return
+  }
+
+  // Handle dependency check
+  if (checkDeps) {
+    console.log(colorize("🔧 ESLint Plugin Functype - Dependency Check", "bright"))
+    const result = validatePeerDependencies()
+    printDependencyStatus(result)
+
+    if (!result.isValid) {
+      process.exit(1)
+    }
+    return
+  }
+
+  console.log(colorize("🔧 ESLint Plugin Functype - Supported Rules", "bright"))
+
+  const distPath = path.join(__dirname, "..", "..", "dist")
+
+  if (!fs.existsSync(distPath)) {
+    console.error(colorize("❌ Build directory not found. Run `pnpm run build` first.", "red"))
+    process.exit(1)
+  }
+
+  const configs = [
+    {
+      name: "Recommended",
+      path: path.join(distPath, "configs", "recommended.js"),
+    },
+    {
+      name: "Strict",
+      path: path.join(distPath, "configs", "strict.js"),
+    },
+  ]
+
+  const loadedConfigs: LoadedConfig[] = []
+
+  for (const { name, path: configPath } of configs) {
+    const config = await loadConfig(configPath)
+    if (config) {
+      const rules = extractRules(config)
+      loadedConfigs.push({ name, rules })
+      printRules(name, rules)
+    }
+  }
+
+  if (loadedConfigs.length > 0) {
+    printSummary(loadedConfigs)
+
+    if (showUsage) {
+      printUsageInfo()
+    }
+
+    console.log(colorize("\n💡 Tips:", "bright"))
+    console.log("• Use --verbose to see rule options")
+    console.log("• Use --usage to see configuration examples")
+    console.log("• Red rules will cause build failures")
+    console.log("• Yellow rules are warnings only")
+    console.log("• Blue rules are disabled by default")
+
+    console.log(colorize("\n🔗 Links:", "bright"))
+    console.log("• Documentation: https://github.com/jordanburke/eslint-config-functype")
+    console.log("• eslint-plugin-functional: https://github.com/eslint-functional/eslint-plugin-functional")
+    console.log("• @typescript-eslint: https://typescript-eslint.io/")
+  }
+}
+
+// Run the CLI
+main().catch((error) => {
+  console.error(colorize("❌ Unexpected error:", "red"), error)
+  process.exit(1)
+})

--- a/packages/eslint-config-functype/src/cli/list-rules.ts
+++ b/packages/eslint-config-functype/src/cli/list-rules.ts
@@ -83,7 +83,6 @@ function extractRules(config: Config): Map<string, RuleData> {
 }
 
 function getRuleSource(ruleName: string): string {
-  if (ruleName.startsWith("functional/")) return "eslint-plugin-functional"
   if (ruleName.startsWith("@typescript-eslint/")) return "@typescript-eslint/eslint-plugin"
   return "eslint (core)"
 }
@@ -520,7 +519,6 @@ async function main(): Promise<void> {
 
     console.log(colorize("\n🔗 Links:", "bright"))
     console.log("• Documentation: https://github.com/jordanburke/eslint-config-functype")
-    console.log("• eslint-plugin-functional: https://github.com/eslint-functional/eslint-plugin-functional")
     console.log("• @typescript-eslint: https://typescript-eslint.io/")
   }
 }

--- a/packages/eslint-config-functype/src/configs/recommended.ts
+++ b/packages/eslint-config-functype/src/configs/recommended.ts
@@ -88,21 +88,6 @@ export default {
       },
     ],
 
-    // Functional programming rules (when eslint-plugin-functional is available)
-    "functional/no-let": "error",
-    "functional/immutable-data": "warn",
-    "functional/no-loop-statements": "off", // Start disabled, can enable later
-    "functional/prefer-immutable-types": "off",
-    "functional/no-mixed-types": "off",
-    "functional/functional-parameters": "off",
-    "functional/no-throw-statements": ["warn", { allowToRejectPromises: true }],
-    "functional/no-try-statements": ["warn", { allowCatch: true }],
-
-    // Allow some flexibility
-    "functional/no-conditional-statements": "off",
-    "functional/no-expression-statements": "off",
-    "functional/no-return-void": "off",
-
     // Code formatting (when eslint-plugin-prettier is available)
     "prettier/prettier": [
       "error",

--- a/packages/eslint-config-functype/src/configs/recommended.ts
+++ b/packages/eslint-config-functype/src/configs/recommended.ts
@@ -1,0 +1,119 @@
+import {
+  createValidationError,
+  shouldValidateDependencies,
+  validatePeerDependencies,
+} from "../utils/dependency-validator"
+
+// Validate peer dependencies on config load
+if (shouldValidateDependencies()) {
+  const result = validatePeerDependencies()
+  if (!result.isValid) {
+    throw createValidationError(result)
+  }
+
+  // Log warnings for missing optional dependencies
+  if (result.warnings.length > 0) {
+    console.warn("\n⚠️  eslint-config-functype warnings:")
+    result.warnings.forEach((warning) => console.warn(`   ${warning}`))
+    console.warn("")
+  }
+}
+
+// ESLint 9.x Flat Config Format
+// Complete functional TypeScript config with formatting and import organization
+export default {
+  name: "functype/recommended",
+  rules: {
+    // Core JavaScript immutability
+    "prefer-const": "error",
+    "no-var": "error",
+    "no-throw-literal": "error",
+    "no-mixed-spaces-and-tabs": "error",
+    "no-extra-semi": "error",
+    "object-shorthand": "error",
+    "prefer-template": "error",
+    "prefer-destructuring": [
+      "error",
+      {
+        array: false,
+        object: true,
+      },
+    ],
+
+    // TypeScript functional patterns (when @typescript-eslint is available)
+    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_", // Only underscore-prefixed parameters
+        varsIgnorePattern: "^(_|[A-Z]$)", // Allow underscore-prefixed vars and single uppercase letters (interface generics)
+        caughtErrors: "all", // Require using catch block errors or prefix with _
+        caughtErrorsIgnorePattern: "^_", // Allow _error, _e, etc. in catch blocks
+        destructuredArrayIgnorePattern: "^_",
+        ignoreRestSiblings: true,
+        args: "after-used",
+      },
+    ],
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+      {
+        allowShortCircuit: true,
+        allowTernary: true,
+      },
+    ],
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/no-misused-promises": "error",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/no-unnecessary-condition": "warn",
+    // Relax strict-boolean-expressions for functional library patterns
+    // This rule is valuable for applications but creates excessive noise in a functional library where:
+    // 1. Optional chaining patterns like `if (options?.prop)` are idiomatic and safe
+    // 2. String/object truthiness checks are common and intentional (e.g., `if (message)`)
+    // 3. The functional design already provides safety through Option/Either patterns
+    // 4. Library code often needs flexibility for performance and interoperability
+    "@typescript-eslint/strict-boolean-expressions": [
+      "warn",
+      {
+        allowString: true, // Allow `if (str)` patterns
+        allowNumber: true, // Allow `if (num)` patterns
+        allowNullableObject: true, // Allow `if (obj?.prop)` patterns
+        allowNullableBoolean: true, // Allow `if (bool)` where bool might be null/undefined
+        allowNullableString: true, // Allow `if (str)` where str might be null/undefined
+        allowNullableNumber: true, // Allow `if (num)` where num might be null/undefined
+        allowAny: true, // Allow `if (value)` where value is any type
+      },
+    ],
+
+    // Functional programming rules (when eslint-plugin-functional is available)
+    "functional/no-let": "error",
+    "functional/immutable-data": "warn",
+    "functional/no-loop-statements": "off", // Start disabled, can enable later
+    "functional/prefer-immutable-types": "off",
+    "functional/no-mixed-types": "off",
+    "functional/functional-parameters": "off",
+    "functional/no-throw-statements": ["warn", { allowToRejectWith: true }],
+    "functional/no-try-statements": ["warn", { allowCatch: true }],
+
+    // Allow some flexibility
+    "functional/no-conditional-statements": "off",
+    "functional/no-expression-statements": "off",
+    "functional/no-return-void": "off",
+
+    // Code formatting (when eslint-plugin-prettier is available)
+    "prettier/prettier": [
+      "error",
+      {},
+      {
+        usePrettierrc: true,
+      },
+    ],
+
+    // Import organization (when eslint-plugin-simple-import-sort is available)
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+  },
+}

--- a/packages/eslint-config-functype/src/configs/recommended.ts
+++ b/packages/eslint-config-functype/src/configs/recommended.ts
@@ -95,7 +95,7 @@ export default {
     "functional/prefer-immutable-types": "off",
     "functional/no-mixed-types": "off",
     "functional/functional-parameters": "off",
-    "functional/no-throw-statements": ["warn", { allowToRejectWith: true }],
+    "functional/no-throw-statements": ["warn", { allowToRejectPromises: true }],
     "functional/no-try-statements": ["warn", { allowCatch: true }],
 
     // Allow some flexibility

--- a/packages/eslint-config-functype/src/configs/strict.ts
+++ b/packages/eslint-config-functype/src/configs/strict.ts
@@ -8,12 +8,6 @@ export default {
   rules: {
     ...recommended.rules,
 
-    // Enable stricter functional rules
-    "functional/no-loop-statements": "error",
-    "functional/immutable-data": "error",
-    "functional/prefer-immutable-types": "warn",
-    "functional/functional-parameters": "warn",
-
     // Stricter TypeScript rules (non-type-aware)
     "@typescript-eslint/explicit-function-return-type": "error",
     "@typescript-eslint/no-non-null-assertion": "error",

--- a/packages/eslint-config-functype/src/configs/strict.ts
+++ b/packages/eslint-config-functype/src/configs/strict.ts
@@ -1,0 +1,22 @@
+import recommended from "./recommended"
+
+// ESLint 9.x Flat Config Format - Strict rules overlay
+// Note: Peer dependency validation is inherited from recommended config
+export default {
+  ...recommended,
+  name: "functype/strict",
+  rules: {
+    ...recommended.rules,
+
+    // Enable stricter functional rules
+    "functional/no-loop-statements": "error",
+    "functional/immutable-data": "error",
+    "functional/prefer-immutable-types": "warn",
+    "functional/functional-parameters": "warn",
+
+    // Stricter TypeScript rules (non-type-aware)
+    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/strict-boolean-expressions": "error", // Default strict
+  },
+}

--- a/packages/eslint-config-functype/src/configs/test-overrides.ts
+++ b/packages/eslint-config-functype/src/configs/test-overrides.ts
@@ -1,10 +1,5 @@
 export default {
   name: "functype/test-overrides",
   files: ["**/*.test.ts", "**/*.spec.ts", "**/test/**", "**/tests/**", "**/__tests__/**"],
-  rules: {
-    "functional/no-let": "off",
-    "functional/immutable-data": "off",
-    "functional/no-throw-statements": "off",
-    "functional/no-try-statements": "off",
-  },
+  rules: {},
 }

--- a/packages/eslint-config-functype/src/configs/test-overrides.ts
+++ b/packages/eslint-config-functype/src/configs/test-overrides.ts
@@ -1,0 +1,10 @@
+export default {
+  name: "functype/test-overrides",
+  files: ["**/*.test.ts", "**/*.spec.ts", "**/test/**", "**/tests/**", "**/__tests__/**"],
+  rules: {
+    "functional/no-let": "off",
+    "functional/immutable-data": "off",
+    "functional/no-throw-statements": "off",
+    "functional/no-try-statements": "off",
+  },
+}

--- a/packages/eslint-config-functype/src/index.ts
+++ b/packages/eslint-config-functype/src/index.ts
@@ -1,0 +1,19 @@
+import recommended from "./configs/recommended"
+import strict from "./configs/strict"
+import testOverrides from "./configs/test-overrides"
+
+// ESLint 9.x Flat Config Plugin
+const plugin = {
+  configs: {
+    recommended,
+    strict,
+    testOverrides,
+  },
+  // Meta information
+  meta: {
+    name: "eslint-config-functype",
+    version: "2.0.0",
+  },
+}
+
+export default plugin

--- a/packages/eslint-config-functype/src/utils/dependency-validator.ts
+++ b/packages/eslint-config-functype/src/utils/dependency-validator.ts
@@ -21,12 +21,6 @@ const PEER_DEPENDENCIES: PeerDependency[] = [
     required: true,
   },
   {
-    name: "eslint-plugin-functional",
-    packageName: "eslint-plugin-functional",
-    description: "Functional programming ESLint rules",
-    required: true,
-  },
-  {
     name: "eslint-plugin-prettier",
     packageName: "eslint-plugin-prettier",
     description: "Code formatting rules",

--- a/packages/eslint-config-functype/src/utils/dependency-validator.ts
+++ b/packages/eslint-config-functype/src/utils/dependency-validator.ts
@@ -1,0 +1,127 @@
+// Utility to validate peer dependencies and provide helpful error messages
+
+interface PeerDependency {
+  name: string
+  packageName: string
+  description: string
+  required: boolean
+}
+
+const PEER_DEPENDENCIES: PeerDependency[] = [
+  {
+    name: "@typescript-eslint/eslint-plugin",
+    packageName: "@typescript-eslint/eslint-plugin",
+    description: "TypeScript-aware ESLint rules",
+    required: true,
+  },
+  {
+    name: "@typescript-eslint/parser",
+    packageName: "@typescript-eslint/parser",
+    description: "TypeScript parser for ESLint",
+    required: true,
+  },
+  {
+    name: "eslint-plugin-functional",
+    packageName: "eslint-plugin-functional",
+    description: "Functional programming ESLint rules",
+    required: true,
+  },
+  {
+    name: "eslint-plugin-prettier",
+    packageName: "eslint-plugin-prettier",
+    description: "Code formatting rules",
+    required: false,
+  },
+  {
+    name: "eslint-plugin-simple-import-sort",
+    packageName: "eslint-plugin-simple-import-sort",
+    description: "Import sorting rules",
+    required: false,
+  },
+  {
+    name: "prettier",
+    packageName: "prettier",
+    description: "Code formatter",
+    required: false,
+  },
+]
+
+export interface ValidationResult {
+  isValid: boolean
+  missing: PeerDependency[]
+  available: PeerDependency[]
+  installCommand: string
+  warnings: string[]
+}
+
+function tryResolve(packageName: string): boolean {
+  try {
+    import.meta.resolve(packageName)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function validatePeerDependencies(): ValidationResult {
+  const missing: PeerDependency[] = []
+  const available: PeerDependency[] = []
+  const warnings: string[] = []
+
+  for (const dep of PEER_DEPENDENCIES) {
+    if (tryResolve(dep.packageName)) {
+      available.push(dep)
+    } else {
+      missing.push(dep)
+      if (dep.required) {
+        // Required dependency is missing - this will cause errors
+      } else {
+        // Optional dependency is missing - add warning
+        warnings.push(`Optional plugin '${dep.name}' not found. Some rules will be skipped.`)
+      }
+    }
+  }
+
+  const requiredMissing = missing.filter((dep) => dep.required)
+  const isValid = requiredMissing.length === 0
+
+  // Generate install command for missing dependencies
+  const missingPackageNames = missing.map((dep) => dep.packageName)
+  const installCommand = missingPackageNames.length > 0 ? `pnpm add -D ${missingPackageNames.join(" ")}` : ""
+
+  return {
+    isValid,
+    missing,
+    available,
+    installCommand,
+    warnings,
+  }
+}
+
+export function createValidationError(result: ValidationResult): Error {
+  const requiredMissing = result.missing.filter((dep) => dep.required)
+
+  if (requiredMissing.length === 0) {
+    return new Error("No validation errors")
+  }
+
+  const missingList = requiredMissing.map((dep) => `  • ${dep.name} - ${dep.description}`).join("\n")
+
+  const message = [
+    "❌ Missing required peer dependencies for eslint-config-functype:",
+    "",
+    missingList,
+    "",
+    "📦 Install missing dependencies:",
+    `   ${result.installCommand}`,
+    "",
+    "📖 See installation guide: https://github.com/jordanburke/eslint-config-functype#installation",
+  ].join("\n")
+
+  return new Error(message)
+}
+
+export function shouldValidateDependencies(): boolean {
+  // Skip validation in test environments or when explicitly disabled
+  return process.env.NODE_ENV !== "test" && process.env.FUNCTYPE_SKIP_VALIDATION !== "true"
+}

--- a/packages/eslint-config-functype/ts-builds.config.json
+++ b/packages/eslint-config-functype/ts-builds.config.json
@@ -1,0 +1,9 @@
+{
+  "srcDir": "./src",
+  "lint": {
+    "useProjectEslint": true
+  },
+  "chains": {
+    "validate": ["format", "lint", "typecheck", "build"]
+  }
+}

--- a/packages/eslint-config-functype/tsconfig.json
+++ b/packages/eslint-config-functype/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "ts-builds/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/eslint-config-functype/tsconfig.json
+++ b/packages/eslint-config-functype/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "ts-builds/tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/eslint-config-functype/tsdown.config.ts
+++ b/packages/eslint-config-functype/tsdown.config.ts
@@ -1,0 +1,48 @@
+import type { UserConfig } from "tsdown"
+
+const peerDeps = [
+  "eslint",
+  "@eslint/eslintrc",
+  "@eslint/js",
+  "@typescript-eslint/eslint-plugin",
+  "@typescript-eslint/parser",
+  "eslint-plugin-functional",
+  "eslint-plugin-prettier",
+  "eslint-plugin-simple-import-sort",
+  "prettier",
+]
+
+const library: UserConfig = {
+  entry: {
+    index: "src/index.ts",
+    "configs/recommended": "src/configs/recommended.ts",
+    "configs/strict": "src/configs/strict.ts",
+    "configs/test-overrides": "src/configs/test-overrides.ts",
+    "utils/dependency-validator": "src/utils/dependency-validator.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2020",
+  outDir: "dist",
+  external: peerDeps,
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
+}
+
+const cli: UserConfig = {
+  entry: {
+    "cli/list-rules": "src/cli/list-rules.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: false,
+  target: "es2020",
+  outDir: "dist",
+  external: peerDeps,
+  banner: { js: "#!/usr/bin/env node" },
+  outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
+}
+
+export default [library, cli]

--- a/packages/eslint-config-functype/tsdown.config.ts
+++ b/packages/eslint-config-functype/tsdown.config.ts
@@ -6,7 +6,6 @@ const peerDeps = [
   "@eslint/js",
   "@typescript-eslint/eslint-plugin",
   "@typescript-eslint/parser",
-  "eslint-plugin-functional",
   "eslint-plugin-prettier",
   "eslint-plugin-simple-import-sort",
   "prettier",

--- a/packages/eslint-config-functype/vitest.config.ts
+++ b/packages/eslint-config-functype/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "ts-builds/vitest"

--- a/packages/eslint-plugin-functype/CHANGELOG.md
+++ b/packages/eslint-plugin-functype/CHANGELOG.md
@@ -1,0 +1,9 @@
+# eslint-plugin-functype
+
+## 2.60.6
+
+Moved to the `functype` monorepo. Versioning now mirrors `functype`'s minor and patch — `eslint-plugin-functype@2.<functype-minor>.<functype-patch>` (major stays at `2` until functype reaches `1.0`, at which point the eslint packages catch up to `3.0.0` and the family converges on a single version line). No code changes.
+
+## 2.3.0
+
+Last version published from the standalone `jordanburke/eslint-functype` repo.

--- a/packages/eslint-plugin-functype/README.md
+++ b/packages/eslint-plugin-functype/README.md
@@ -1,0 +1,66 @@
+# eslint-plugin-functype
+
+Custom ESLint rules for functional TypeScript with [functype](https://github.com/jordanburke/functype). Encourages idiomatic functype patterns like `Option`, `Either`, `List`, `Do` notation, and safe data access.
+
+## Install
+
+```bash
+npm install -D eslint-plugin-functype eslint
+```
+
+## Usage
+
+```js
+// eslint.config.mjs
+import functype from "eslint-plugin-functype"
+
+export default [
+  functype.configs.recommended,
+]
+```
+
+### Strict mode
+
+```js
+import functype from "eslint-plugin-functype"
+
+export default [functype.configs.strict]
+```
+
+## Rules
+
+| Rule | Recommended | Strict | Description |
+|------|:-----------:|:------:|-------------|
+| `functype/prefer-option` | warn | error | Use `Option`/`Some`/`None` instead of `null`/`undefined` |
+| `functype/prefer-either` | warn | error | Use `Either`/`Right`/`Left` instead of throwing |
+| `functype/prefer-fold` | warn | warn | Use `fold`/`match` instead of manual unwrapping |
+| `functype/prefer-map` | warn | warn | Use `map` instead of manual option/either checks |
+| `functype/prefer-flatmap` | warn | warn | Use `flatMap` instead of nested `map` |
+| `functype/no-imperative-loops` | warn | warn | Use `List` methods instead of imperative loops |
+| `functype/prefer-do-notation` | warn | warn | Use `Do` notation for chained operations |
+| `functype/no-get-unsafe` | off | error | Disallow unsafe `.get()` on `Option`/`Either` |
+| `functype/prefer-list` | off | warn | Use `List` instead of native arrays |
+
+## Combining with eslint-config-functype
+
+For a complete setup with functional rules, TypeScript, Prettier, and import sorting:
+
+```bash
+npm install -D eslint-config-functype eslint-plugin-functype
+```
+
+```js
+import recommended from "eslint-config-functype/recommended"
+import testOverrides from "eslint-config-functype/test-overrides"
+import functype from "eslint-plugin-functype"
+
+export default [
+  recommended,
+  functype.configs.recommended,
+  testOverrides,
+]
+```
+
+## License
+
+MIT

--- a/packages/eslint-plugin-functype/README.md
+++ b/packages/eslint-plugin-functype/README.md
@@ -14,9 +14,7 @@ npm install -D eslint-plugin-functype eslint
 // eslint.config.mjs
 import functype from "eslint-plugin-functype"
 
-export default [
-  functype.configs.recommended,
-]
+export default [functype.configs.recommended]
 ```
 
 ### Strict mode
@@ -29,17 +27,17 @@ export default [functype.configs.strict]
 
 ## Rules
 
-| Rule | Recommended | Strict | Description |
-|------|:-----------:|:------:|-------------|
-| `functype/prefer-option` | warn | error | Use `Option`/`Some`/`None` instead of `null`/`undefined` |
-| `functype/prefer-either` | warn | error | Use `Either`/`Right`/`Left` instead of throwing |
-| `functype/prefer-fold` | warn | warn | Use `fold`/`match` instead of manual unwrapping |
-| `functype/prefer-map` | warn | warn | Use `map` instead of manual option/either checks |
-| `functype/prefer-flatmap` | warn | warn | Use `flatMap` instead of nested `map` |
-| `functype/no-imperative-loops` | warn | warn | Use `List` methods instead of imperative loops |
-| `functype/prefer-do-notation` | warn | warn | Use `Do` notation for chained operations |
-| `functype/no-get-unsafe` | off | error | Disallow unsafe `.get()` on `Option`/`Either` |
-| `functype/prefer-list` | off | warn | Use `List` instead of native arrays |
+| Rule                           | Recommended | Strict | Description                                              |
+| ------------------------------ | :---------: | :----: | -------------------------------------------------------- |
+| `functype/prefer-option`       |    warn     | error  | Use `Option`/`Some`/`None` instead of `null`/`undefined` |
+| `functype/prefer-either`       |    warn     | error  | Use `Either`/`Right`/`Left` instead of throwing          |
+| `functype/prefer-fold`         |    warn     |  warn  | Use `fold`/`match` instead of manual unwrapping          |
+| `functype/prefer-map`          |    warn     |  warn  | Use `map` instead of manual option/either checks         |
+| `functype/prefer-flatmap`      |    warn     |  warn  | Use `flatMap` instead of nested `map`                    |
+| `functype/no-imperative-loops` |    warn     |  warn  | Use `List` methods instead of imperative loops           |
+| `functype/prefer-do-notation`  |    warn     |  warn  | Use `Do` notation for chained operations                 |
+| `functype/no-get-unsafe`       |     off     | error  | Disallow unsafe `.get()` on `Option`/`Either`            |
+| `functype/prefer-list`         |     off     |  warn  | Use `List` instead of native arrays                      |
 
 ## Combining with eslint-config-functype
 
@@ -54,11 +52,7 @@ import recommended from "eslint-config-functype/recommended"
 import testOverrides from "eslint-config-functype/test-overrides"
 import functype from "eslint-plugin-functype"
 
-export default [
-  recommended,
-  functype.configs.recommended,
-  testOverrides,
-]
+export default [recommended, functype.configs.recommended, testOverrides]
 ```
 
 ## License

--- a/packages/eslint-plugin-functype/eslint.config.mjs
+++ b/packages/eslint-plugin-functype/eslint.config.mjs
@@ -1,0 +1,10 @@
+import baseConfig from "ts-builds/eslint"
+
+export default [
+  ...baseConfig,
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
+]

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -60,11 +60,11 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
-    "@typescript-eslint/rule-tester": "^8.57.0",
+    "@typescript-eslint/rule-tester": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
-    "functype": "^0.49.0",
-    "ts-builds": "^2.5.1",
-    "tsdown": "^0.21.2"
+    "functype": "^0.50.0",
+    "ts-builds": "^2.5.2",
+    "tsdown": "^0.21.4"
   },
   "author": {
     "name": "Jordan Burke",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",
@@ -59,11 +59,11 @@
     "eslint": "^10.0.3"
   },
   "devDependencies": {
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.2",
     "@typescript-eslint/rule-tester": "^8.58.0",
     "eslint-config-prettier": "^10.1.8",
-    "functype": "^0.54.0",
-    "ts-builds": "^2.6.2",
+    "functype": "^0.56.0",
+    "ts-builds": "^2.6.3",
     "tsdown": "^0.21.7"
   },
   "author": {

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "eslint-plugin-functype",
+  "version": "2.0.0",
+  "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "lib",
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "bin": {
+    "functype-list-rules": "dist/cli/list-rules.js"
+  },
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin",
+    "functional",
+    "typescript",
+    "immutable",
+    "functype",
+    "option",
+    "either",
+    "list"
+  ],
+  "scripts": {
+    "validate": "ts-builds validate",
+    "format": "ts-builds format",
+    "format:check": "ts-builds format:check",
+    "lint": "ts-builds lint",
+    "lint:check": "ts-builds lint:check",
+    "typecheck": "ts-builds typecheck",
+    "test": "ts-builds test",
+    "test:watch": "ts-builds test:watch",
+    "test:ui": "ts-builds test:ui",
+    "test:coverage": "ts-builds test:coverage",
+    "build": "ts-builds build",
+    "dev": "ts-builds dev",
+    "prepublishOnly": "pnpm validate",
+    "list-rules": "node dist/cli/list-rules.js",
+    "list-rules:verbose": "node dist/cli/list-rules.js --verbose",
+    "list-rules:usage": "node dist/cli/list-rules.js --usage",
+    "check-deps": "node dist/cli/list-rules.js --check-deps",
+    "cli:help": "node dist/cli/list-rules.js --help"
+  },
+  "prettier": "ts-builds/prettier",
+  "peerDependencies": {
+    "eslint": "^10.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.0",
+    "@typescript-eslint/rule-tester": "^8.57.0",
+    "eslint-config-prettier": "^10.1.8",
+    "functype": "^0.49.0",
+    "ts-builds": "^2.5.1",
+    "tsdown": "^0.21.2"
+  },
+  "author": {
+    "name": "Jordan Burke",
+    "url": "https://github.com/jordanburke"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jordanburke/eslint-functype",
+    "directory": "packages/plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/jordanburke/eslint-functype/issues"
+  },
+  "homepage": "https://github.com/jordanburke/eslint-functype#readme",
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",
@@ -60,11 +60,11 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
-    "@typescript-eslint/rule-tester": "^8.57.2",
+    "@typescript-eslint/rule-tester": "^8.58.0",
     "eslint-config-prettier": "^10.1.8",
-    "functype": "^0.51.0",
-    "ts-builds": "^2.6.1",
-    "tsdown": "^0.21.5"
+    "functype": "^0.54.0",
+    "ts-builds": "^2.6.2",
+    "tsdown": "^0.21.7"
   },
   "author": {
     "name": "Jordan Burke",
@@ -82,5 +82,6 @@
   "homepage": "https://github.com/jordanburke/eslint-functype#readme",
   "engines": {
     "node": ">=22.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",
@@ -60,11 +60,11 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
-    "@typescript-eslint/rule-tester": "^8.57.1",
+    "@typescript-eslint/rule-tester": "^8.57.2",
     "eslint-config-prettier": "^10.1.8",
-    "functype": "^0.50.0",
-    "ts-builds": "^2.5.2",
-    "tsdown": "^0.21.4"
+    "functype": "^0.51.0",
+    "ts-builds": "^2.6.1",
+    "tsdown": "^0.21.5"
   },
   "author": {
     "name": "Jordan Burke",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",
@@ -56,15 +56,15 @@
   },
   "prettier": "ts-builds/prettier",
   "peerDependencies": {
-    "eslint": "^10.0.3"
+    "eslint": "^10.2.1"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
-    "@typescript-eslint/rule-tester": "^8.58.2",
+    "@typescript-eslint/rule-tester": "^8.59.1",
     "eslint-config-prettier": "^10.1.8",
-    "functype": "^0.57.0",
-    "ts-builds": "^2.7.0",
-    "tsdown": "^0.21.9"
+    "functype": "^0.60.2",
+    "ts-builds": "^2.7.1",
+    "tsdown": "^0.21.10"
   },
   "author": {
     "name": "Jordan Burke",
@@ -81,7 +81,7 @@
   },
   "homepage": "https://github.com/jordanburke/eslint-functype#readme",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",
@@ -60,11 +60,11 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
-    "@typescript-eslint/rule-tester": "^8.58.0",
+    "@typescript-eslint/rule-tester": "^8.58.2",
     "eslint-config-prettier": "^10.1.8",
-    "functype": "^0.56.0",
-    "ts-builds": "^2.6.3",
-    "tsdown": "^0.21.7"
+    "functype": "^0.57.0",
+    "ts-builds": "^2.7.0",
+    "tsdown": "^0.21.9"
   },
   "author": {
     "name": "Jordan Burke",

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-functype",
-  "version": "2.3.0",
+  "version": "2.60.6",
   "description": "Custom ESLint rules for functional TypeScript programming with functype library patterns including Do notation (ESLint 10+)",
   "type": "module",
   "main": "./dist/index.js",
@@ -62,9 +62,13 @@
     "@types/node": "^24.12.2",
     "@typescript-eslint/rule-tester": "^8.59.1",
     "eslint-config-prettier": "^10.1.8",
-    "functype": "^0.60.2",
-    "ts-builds": "^2.7.1",
-    "tsdown": "^0.21.10"
+    "functype": "workspace:^",
+    "ts-builds": "^2.8.0",
+    "tsdown": "^0.22.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "author": {
     "name": "Jordan Burke",
@@ -73,15 +77,14 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jordanburke/eslint-functype",
-    "directory": "packages/plugin"
+    "url": "git+https://github.com/jordanburke/functype.git",
+    "directory": "packages/eslint-plugin-functype"
   },
   "bugs": {
-    "url": "https://github.com/jordanburke/eslint-functype/issues"
+    "url": "https://github.com/jordanburke/functype/issues"
   },
-  "homepage": "https://github.com/jordanburke/eslint-functype#readme",
+  "homepage": "https://github.com/jordanburke/functype/tree/main/packages/eslint-plugin-functype#readme",
   "engines": {
     "node": ">=24.0.0"
-  },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  }
 }

--- a/packages/eslint-plugin-functype/src/cli/list-rules.ts
+++ b/packages/eslint-plugin-functype/src/cli/list-rules.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import plugin from "../index.js"
+import { validatePeerDependencies, type ValidationResult } from "../utils/dependency-validator.js"
+
+// Colors for console output
+const colors = {
+  reset: "\x1b[0m",
+  bright: "\x1b[1m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+} as const
+
+function colorize(text: string, color: keyof typeof colors): string {
+  return colors[color] + text + colors.reset
+}
+
+// Removed unused utility functions - they were for the old config-based approach
+
+function printDependencyStatus(result: ValidationResult): void {
+  console.log(colorize("\n🔍 Dependency Status Check:", "bright"))
+  console.log(colorize("=".repeat(40), "blue"))
+
+  // Show available dependencies
+  if (result.available.length > 0) {
+    console.log(colorize("\n✅ Available:", "green"))
+    result.available.forEach((dep) => {
+      const icon = dep.required ? "🔧" : "🔌"
+      console.log(`  ${icon} ${colorize(dep.name, "green")} - ${dep.description}`)
+    })
+  }
+
+  // Show missing dependencies
+  if (result.missing.length > 0) {
+    console.log(colorize("\n❌ Missing:", "red"))
+    result.missing.forEach((dep) => {
+      const icon = dep.required ? "⚠️ " : "💡"
+      const color = dep.required ? "red" : "yellow"
+      console.log(`  ${icon} ${colorize(dep.name, color)} - ${dep.description}`)
+    })
+
+    if (result.installCommand) {
+      console.log(colorize("\n📦 Install missing dependencies:", "bright"))
+      console.log(`   ${colorize(result.installCommand, "cyan")}`)
+    }
+  }
+
+  // Show warnings
+  if (result.warnings.length > 0) {
+    console.log(colorize("\n⚠️  Warnings:", "yellow"))
+    result.warnings.forEach((warning) => console.log(`   ${warning}`))
+  }
+
+  // Overall status
+  const status = result.isValid ? "✅ Ready to use" : "❌ Configuration will fail"
+  const statusColor = result.isValid ? "green" : "red"
+  console.log(colorize(`\n${status}`, statusColor))
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2)
+  const showHelp = args.includes("--help") || args.includes("-h")
+  const showUsage = args.includes("--usage") || args.includes("-u")
+  const checkDeps = args.includes("--check-deps") || args.includes("--check")
+
+  if (showHelp) {
+    console.log(colorize("📋 ESLint Plugin Functype - Custom Rules", "bright"))
+    console.log("\nUsage: pnpm run list-rules [options]")
+    console.log("\nOptions:")
+    console.log("  --verbose, -v      Show rule descriptions and schemas")
+    console.log("  --usage, -u        Show usage examples")
+    console.log("  --check-deps       Check peer dependency status")
+    console.log("  --help, -h         Show this help message")
+    console.log("\nThis command lists all custom rules provided by the functype plugin.")
+    return
+  }
+
+  // Handle dependency check
+  if (checkDeps) {
+    console.log(colorize("🔧 ESLint Plugin Functype - Dependency Check", "bright"))
+    const result = validatePeerDependencies()
+    printDependencyStatus(result)
+
+    if (!result.isValid) {
+      process.exit(1)
+    }
+    return
+  }
+
+  console.log(colorize("🔧 ESLint Plugin Functype - Custom Rules", "bright"))
+
+  if (!plugin.rules) {
+    console.error(colorize("❌ No rules found in plugin.", "red"))
+    process.exit(1)
+  }
+
+  console.log(colorize("\n📦 Available Custom Rules:", "bright"))
+  console.log(colorize("=".repeat(40), "blue"))
+
+  const rules = Object.keys(plugin.rules)
+
+  rules.forEach((ruleName) => {
+    const rule = plugin.rules[ruleName]
+    const fullName = `functype/${ruleName}`
+
+    console.log(`\n${colorize("●", "green")} ${colorize(fullName, "bright")}`)
+
+    if (rule.meta?.docs?.description) {
+      console.log(`  ${colorize("Description:", "cyan")} ${rule.meta.docs.description}`)
+    }
+
+    if (rule.meta?.type) {
+      const typeColor = rule.meta.type === "problem" ? "red" : rule.meta.type === "suggestion" ? "yellow" : "blue"
+      console.log(`  ${colorize("Type:", "cyan")} ${colorize(rule.meta.type, typeColor)}`)
+    }
+
+    if (rule.meta?.fixable) {
+      console.log(`  ${colorize("Fixable:", "cyan")} ${colorize("Yes", "green")}`)
+    }
+
+    if (showUsage) {
+      console.log(`  ${colorize("Usage:", "cyan")} "${fullName}": "error"`)
+    }
+  })
+
+  console.log(colorize(`\n📊 Summary: ${rules.length} custom rules available`, "bright"))
+
+  if (showUsage) {
+    printCustomUsageInfo()
+  }
+
+  console.log(colorize("\n💡 Tips:", "bright"))
+  console.log("• Use --verbose to see detailed rule information")
+  console.log("• Use --usage to see configuration examples")
+  console.log('• All rules are prefixed with "functype/"')
+  console.log("• Consider using eslint-config-functype for pre-configured setup")
+
+  console.log(colorize("\n🔗 Links:", "bright"))
+  console.log("• Documentation: https://github.com/jordanburke/eslint-plugin-functype")
+  console.log("• Configuration Bundle: https://github.com/jordanburke/eslint-config-functype")
+  console.log("• Functype Library: https://github.com/jordanburke/functype")
+}
+
+function printCustomUsageInfo(): void {
+  console.log(colorize("\n💡 Usage Examples:", "bright"))
+  console.log(colorize("=".repeat(30), "blue"))
+  console.log("\n" + colorize("ESLint 9+ (flat config):", "green"))
+  console.log('  import functypePlugin from "eslint-plugin-functype"')
+  console.log("  export default [")
+  console.log("    {")
+  console.log("      plugins: { functype: functypePlugin },")
+  console.log("      rules: {")
+  console.log('        "functype/prefer-option": "error",')
+  console.log('        "functype/prefer-either": "error",')
+  console.log('        "functype/no-get-unsafe": "error",')
+  console.log("      }")
+  console.log("    }")
+  console.log("  ]")
+  console.log("\n" + colorize("With eslint-config-functype (recommended):", "green"))
+  console.log('  import functypeConfig from "eslint-config-functype"')
+  console.log("  export default [functypeConfig.recommended]")
+}
+
+// Run the CLI
+main().catch((error) => {
+  console.error(colorize("❌ Unexpected error:", "red"), error)
+  process.exit(1)
+})

--- a/packages/eslint-plugin-functype/src/configs/recommended.ts
+++ b/packages/eslint-plugin-functype/src/configs/recommended.ts
@@ -1,0 +1,13 @@
+const recommendedRules = {
+  "functype/prefer-option": "warn",
+  "functype/prefer-either": "warn",
+  "functype/prefer-fold": "warn",
+  "functype/prefer-map": "warn",
+  "functype/prefer-flatmap": "warn",
+  "functype/no-imperative-loops": "warn",
+  "functype/prefer-do-notation": "warn",
+  "functype/no-get-unsafe": "off",
+  "functype/prefer-list": "off",
+}
+
+export default recommendedRules

--- a/packages/eslint-plugin-functype/src/configs/recommended.ts
+++ b/packages/eslint-plugin-functype/src/configs/recommended.ts
@@ -1,9 +1,12 @@
 const recommendedRules = {
+  "functype/no-let": "error",
   "functype/prefer-option": "warn",
   "functype/prefer-either": "warn",
   "functype/prefer-fold": "warn",
   "functype/prefer-map": "warn",
   "functype/prefer-flatmap": "warn",
+  "functype/prefer-functype-map": "warn",
+  "functype/prefer-functype-set": "warn",
   "functype/no-imperative-loops": "warn",
   "functype/prefer-do-notation": "warn",
   "functype/no-get-unsafe": "off",

--- a/packages/eslint-plugin-functype/src/configs/strict.ts
+++ b/packages/eslint-plugin-functype/src/configs/strict.ts
@@ -6,6 +6,9 @@ const strictRules = {
   "functype/prefer-either": "error",
   "functype/no-get-unsafe": "error",
   "functype/prefer-list": "warn",
+  "functype/prefer-functype-map": "error",
+  "functype/prefer-functype-set": "error",
+  "functype/no-imperative-loops": "error",
 }
 
 export default strictRules

--- a/packages/eslint-plugin-functype/src/configs/strict.ts
+++ b/packages/eslint-plugin-functype/src/configs/strict.ts
@@ -1,0 +1,11 @@
+import recommendedRules from "./recommended"
+
+const strictRules = {
+  ...recommendedRules,
+  "functype/prefer-option": "error",
+  "functype/prefer-either": "error",
+  "functype/no-get-unsafe": "error",
+  "functype/prefer-list": "warn",
+}
+
+export default strictRules

--- a/packages/eslint-plugin-functype/src/index.ts
+++ b/packages/eslint-plugin-functype/src/index.ts
@@ -1,0 +1,28 @@
+import recommendedRules from "./configs/recommended"
+import strictRules from "./configs/strict"
+import rules from "./rules"
+
+const plugin = {
+  rules,
+  meta: {
+    name: "eslint-plugin-functype",
+    version: "2.0.0",
+  },
+  configs: {} as Record<string, unknown>,
+}
+
+// Self-referencing plugin in configs (ESLint flat config pattern)
+plugin.configs = {
+  recommended: {
+    name: "functype-plugin/recommended",
+    plugins: { functype: plugin },
+    rules: recommendedRules,
+  },
+  strict: {
+    name: "functype-plugin/strict",
+    plugins: { functype: plugin },
+    rules: strictRules,
+  },
+}
+
+export default plugin

--- a/packages/eslint-plugin-functype/src/rules/index.ts
+++ b/packages/eslint-plugin-functype/src/rules/index.ts
@@ -1,9 +1,12 @@
 import noGetUnsafe from "./no-get-unsafe"
 import noImperativeLoops from "./no-imperative-loops"
+import noLet from "./no-let"
 import preferDoNotation from "./prefer-do-notation"
 import preferEither from "./prefer-either"
 import preferFlatmap from "./prefer-flatmap"
 import preferFold from "./prefer-fold"
+import preferFunctypeMap from "./prefer-functype-map"
+import preferFunctypeSet from "./prefer-functype-set"
 import preferList from "./prefer-list"
 import preferMap from "./prefer-map"
 import preferOption from "./prefer-option"
@@ -11,10 +14,13 @@ import preferOption from "./prefer-option"
 export {
   noGetUnsafe,
   noImperativeLoops,
+  noLet,
   preferDoNotation,
   preferEither,
   preferFlatmap,
   preferFold,
+  preferFunctypeMap,
+  preferFunctypeSet,
   preferList,
   preferMap,
   preferOption,
@@ -25,9 +31,12 @@ export default {
   "prefer-either": preferEither,
   "prefer-list": preferList,
   "no-get-unsafe": noGetUnsafe,
+  "no-let": noLet,
   "prefer-fold": preferFold,
   "prefer-map": preferMap,
   "prefer-flatmap": preferFlatmap,
+  "prefer-functype-map": preferFunctypeMap,
+  "prefer-functype-set": preferFunctypeSet,
   "no-imperative-loops": noImperativeLoops,
   "prefer-do-notation": preferDoNotation,
 }

--- a/packages/eslint-plugin-functype/src/rules/index.ts
+++ b/packages/eslint-plugin-functype/src/rules/index.ts
@@ -1,0 +1,33 @@
+import noGetUnsafe from "./no-get-unsafe"
+import noImperativeLoops from "./no-imperative-loops"
+import preferDoNotation from "./prefer-do-notation"
+import preferEither from "./prefer-either"
+import preferFlatmap from "./prefer-flatmap"
+import preferFold from "./prefer-fold"
+import preferList from "./prefer-list"
+import preferMap from "./prefer-map"
+import preferOption from "./prefer-option"
+
+export {
+  noGetUnsafe,
+  noImperativeLoops,
+  preferDoNotation,
+  preferEither,
+  preferFlatmap,
+  preferFold,
+  preferList,
+  preferMap,
+  preferOption,
+}
+
+export default {
+  "prefer-option": preferOption,
+  "prefer-either": preferEither,
+  "prefer-list": preferList,
+  "no-get-unsafe": noGetUnsafe,
+  "prefer-fold": preferFold,
+  "prefer-map": preferMap,
+  "prefer-flatmap": preferFlatmap,
+  "no-imperative-loops": noImperativeLoops,
+  "prefer-do-notation": preferDoNotation,
+}

--- a/packages/eslint-plugin-functype/src/rules/no-get-unsafe.ts
+++ b/packages/eslint-plugin-functype/src/rules/no-get-unsafe.ts
@@ -1,0 +1,142 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Avoid unsafe .get() calls on Option, Either, and other monadic types",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowInTests: {
+            type: "boolean",
+            default: true,
+          },
+          unsafeMethods: {
+            type: "array",
+            items: { type: "string" },
+            default: ["get", "getOrThrow", "unwrap", "expect"],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noUnsafeGet: "Avoid unsafe .{{method}}() call. Use .fold(), .map(), or .getOrElse() instead",
+      noUnsafeGetSuggestion: "Consider using .getOrElse(defaultValue) or .fold() for safe access",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const allowInTests = options.allowInTests !== false
+    const unsafeMethods = options.unsafeMethods || ["get", "getOrThrow", "unwrap", "expect"]
+
+    function isInTestFile() {
+      const filename = context.filename
+      return (
+        /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filename) ||
+        filename.includes("__tests__") ||
+        filename.includes("/test/") ||
+        filename.includes("/tests/")
+      )
+    }
+
+    function isMonadicType(node: ASTNode): boolean {
+      // This is a simplified check - in a real implementation, you'd want
+      // more sophisticated type checking using TypeScript's type checker
+      if (!node) return false
+
+      const sourceCode = context.sourceCode
+
+      // Check for common patterns that indicate monadic types
+      const text = sourceCode.getText(node)
+
+      // Direct type checks - constructors or type names
+      if (/\b(Option|Either|Maybe|Result|Some|None|Left|Right)\b/.test(text)) {
+        return true
+      }
+
+      // Method chains that suggest monadic operations
+      if (/\.(map|flatMap|filter|fold)\s*\(/.test(text)) {
+        return true
+      }
+
+      // Variable names that suggest monadic types (case insensitive)
+      if (/\b(option|either|maybe|result|some|none|left|right)\w*\b/i.test(text)) {
+        return true
+      }
+
+      // Check the specific node type and name
+      if (node.type === "Identifier") {
+        const varName = node.name.toLowerCase()
+        if (/(option|either|maybe|result|some|none|left|right|opt)/.test(varName)) {
+          return true
+        }
+      }
+
+      // Check for CallExpression pattern like Some("test").map()
+      if (node.type === "CallExpression" && node.callee.type === "MemberExpression" && node.callee.object) {
+        return isMonadicType(node.callee.object)
+      }
+
+      return false
+    }
+
+    return {
+      CallExpression(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        if (node.callee.type !== "MemberExpression") return
+
+        const property = node.callee.property
+        if (!property || property.type !== "Identifier") return
+
+        const methodName = property.name
+        if (!unsafeMethods.includes(methodName)) return
+
+        // Check if this looks like it's being called on a monadic type
+        if (isMonadicType(node.callee.object)) {
+          context.report({
+            node,
+            messageId: "noUnsafeGet",
+            data: { method: methodName },
+            fix(fixer) {
+              const sourceCode = context.sourceCode
+              const objectText = sourceCode.getText(node.callee.object)
+
+              // Choose safer alternative based on method name
+              let replacement: string
+              if (methodName === "get") {
+                // Replace .get() with .getOrElse(/* provide default */)
+                replacement = `${objectText}.getOrElse(/* TODO: provide default value */)`
+              } else if (methodName === "getOrThrow") {
+                // Replace .getOrThrow() with .getOrElse()
+                replacement = `${objectText}.getOrElse(/* TODO: provide default value */)`
+              } else if (methodName === "unwrap") {
+                // Replace .unwrap() with .getOrElse()
+                replacement = `${objectText}.getOrElse(/* TODO: provide default value */)`
+              } else if (methodName === "expect") {
+                // Replace .expect(msg) with .getOrElse()
+                replacement = `${objectText}.getOrElse(/* TODO: provide default value */)`
+              } else {
+                // Generic fallback
+                replacement = `${objectText}.getOrElse(/* TODO: provide default value */)`
+              }
+
+              return fixer.replaceText(node, replacement)
+            },
+          })
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/no-imperative-loops.ts
+++ b/packages/eslint-plugin-functype/src/rules/no-imperative-loops.ts
@@ -5,6 +5,7 @@ import type { ASTNode } from "../types/ast"
 const rule: Rule.RuleModule = {
   meta: {
     type: "suggestion",
+    hasSuggestions: true,
     docs: {
       description: "Prefer functional iteration methods over imperative for loops",
       recommended: true,
@@ -35,7 +36,8 @@ const rule: Rule.RuleModule = {
       noForOfLoop: "Prefer .forEach() or .map() over for..of loops",
       noWhileLoop: "Prefer functional iteration or recursion over while loops",
       noDoWhileLoop: "Prefer functional iteration or recursion over do..while loops",
-      suggestFunctional: "Consider: {{suggestion}}",
+      suggestForEach: "Replace with {{iterable}}.forEach(...)",
+      suggestObjectKeys: "Replace with Object.keys({{object}}).forEach(...)",
     },
   },
 
@@ -65,30 +67,26 @@ const rule: Rule.RuleModule = {
       return /\[\s*\w+\s*\]/.test(bodyText) && node.init && node.init.type === "VariableDeclaration"
     }
 
-    function getSuggestionForForLoop(node: ASTNode): string {
-      if (!node.body) return "functional iteration method"
-
-      const sourceCode = context.sourceCode
-      const bodyText = sourceCode.getText(node.body)
-
-      // Simple heuristics for suggestions
-      if (bodyText.includes("if") && bodyText.includes("push")) {
-        return "array.filter().map() for conditional transformation"
-      } else if (bodyText.includes("push")) {
-        return "array.map() to transform elements"
-      } else if (bodyText.includes("console.log") || bodyText.includes("print")) {
-        return "array.forEach() for side effects"
-      } else if (bodyText.includes("+=") || bodyText.includes("sum")) {
-        return "array.reduce() for accumulation"
-      }
-
-      return "functional iteration method (.map, .filter, .forEach, .reduce)"
+    function isSingleStatementBody(node: ASTNode): boolean {
+      if (!node.body || node.body.type !== "BlockStatement") return false
+      return node.body.body.length === 1
     }
 
-    // Remove unused function to fix lint error
-    // getSuggestionForForLoop could be used for better error messages in the future
-    // Mark as used to avoid lint error:
-    void getSuggestionForForLoop
+    function hasDestructuringVariable(node: ASTNode): boolean {
+      const left = node.left
+      if (!left) return false
+      if (left.type === "VariableDeclaration" && left.declarations[0]) {
+        const id = left.declarations[0].id
+        return id.type === "ObjectPattern" || id.type === "ArrayPattern"
+      }
+      return false
+    }
+
+    function bodyContainsBreakOrContinue(node: ASTNode): boolean {
+      const sourceCode = context.sourceCode
+      const bodyText = sourceCode.getText(node.body)
+      return /\b(break|continue)\b/.test(bodyText)
+    }
 
     return {
       ForStatement(node: ASTNode) {
@@ -97,8 +95,6 @@ const rule: Rule.RuleModule = {
         // Allow traditional for loops if they need index access and option is set
         if (allowForIndexAccess && needsIndexAccess(node)) return
 
-        // Remove unused suggestion variable
-        // const _suggestion = getSuggestionForForLoop(node)
         context.report({
           node,
           messageId: "noForLoop",
@@ -108,18 +104,78 @@ const rule: Rule.RuleModule = {
       ForInStatement(node: ASTNode) {
         if (allowInTests && isInTestFile()) return
 
+        const suggest: Rule.SuggestionReportDescriptor[] = []
+
+        if (isSingleStatementBody(node) && !hasDestructuringVariable(node) && !bodyContainsBreakOrContinue(node)) {
+          const sourceCode = context.sourceCode
+          const bodyStmt = node.body.body[0]
+
+          if (bodyStmt && bodyStmt.type === "ExpressionStatement") {
+            const stmtText = sourceCode.getText(bodyStmt)
+            const objText = sourceCode.getText(node.right)
+
+            const left = node.left
+            let keyVar: string
+            if (left.type === "VariableDeclaration" && left.declarations[0]) {
+              keyVar = sourceCode.getText(left.declarations[0].id)
+            } else {
+              keyVar = sourceCode.getText(left)
+            }
+
+            suggest.push({
+              messageId: "suggestObjectKeys",
+              data: { object: objText },
+              fix(fixer) {
+                return fixer.replaceText(node, `Object.keys(${objText}).forEach((${keyVar}) => {\n  ${stmtText}\n})`)
+              },
+            })
+          }
+        }
+
         context.report({
           node,
           messageId: "noForInLoop",
+          suggest: suggest.length > 0 ? suggest : undefined,
         })
       },
 
       ForOfStatement(node: ASTNode) {
         if (allowInTests && isInTestFile()) return
 
+        const suggest: Rule.SuggestionReportDescriptor[] = []
+
+        if (isSingleStatementBody(node) && !hasDestructuringVariable(node) && !bodyContainsBreakOrContinue(node)) {
+          const sourceCode = context.sourceCode
+          const bodyStmt = node.body.body[0]
+
+          if (bodyStmt && bodyStmt.type === "ExpressionStatement") {
+            const stmtText = sourceCode.getText(bodyStmt)
+            const iterableText = sourceCode.getText(node.right)
+
+            const varDecl = node.left
+            let varName: string
+            if (varDecl.type === "VariableDeclaration" && varDecl.declarations[0]) {
+              varName = sourceCode.getText(varDecl.declarations[0].id)
+            } else {
+              varName = sourceCode.getText(varDecl)
+            }
+
+            if (!stmtText.includes(".push(")) {
+              suggest.push({
+                messageId: "suggestForEach",
+                data: { iterable: iterableText },
+                fix(fixer) {
+                  return fixer.replaceText(node, `${iterableText}.forEach((${varName}) => {\n  ${stmtText}\n})`)
+                },
+              })
+            }
+          }
+        }
+
         context.report({
           node,
           messageId: "noForOfLoop",
+          suggest: suggest.length > 0 ? suggest : undefined,
         })
       },
 

--- a/packages/eslint-plugin-functype/src/rules/no-imperative-loops.ts
+++ b/packages/eslint-plugin-functype/src/rules/no-imperative-loops.ts
@@ -1,0 +1,149 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer functional iteration methods over imperative for loops",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowForIndexAccess: {
+            type: "boolean",
+            default: false,
+          },
+          allowWhileLoops: {
+            type: "boolean",
+            default: false,
+          },
+          allowInTests: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noForLoop: "Prefer functional methods (.map, .filter, .forEach, .reduce) over for loops",
+      noForInLoop: "Prefer Object.keys().forEach() or functional methods over for..in loops",
+      noForOfLoop: "Prefer .forEach() or .map() over for..of loops",
+      noWhileLoop: "Prefer functional iteration or recursion over while loops",
+      noDoWhileLoop: "Prefer functional iteration or recursion over do..while loops",
+      suggestFunctional: "Consider: {{suggestion}}",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const allowForIndexAccess = options.allowForIndexAccess || false
+    const allowWhileLoops = options.allowWhileLoops || false
+    const allowInTests = options.allowInTests !== false
+
+    function isInTestFile() {
+      const filename = context.filename
+      return (
+        /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filename) ||
+        filename.includes("__tests__") ||
+        filename.includes("/test/") ||
+        filename.includes("/tests/")
+      )
+    }
+
+    function needsIndexAccess(node: ASTNode): boolean {
+      if (!node.body || node.body.type !== "BlockStatement") return false
+
+      const sourceCode = context.sourceCode
+      const bodyText = sourceCode.getText(node.body)
+
+      // Look for array index access patterns like arr[i]
+      return /\[\s*\w+\s*\]/.test(bodyText) && node.init && node.init.type === "VariableDeclaration"
+    }
+
+    function getSuggestionForForLoop(node: ASTNode): string {
+      if (!node.body) return "functional iteration method"
+
+      const sourceCode = context.sourceCode
+      const bodyText = sourceCode.getText(node.body)
+
+      // Simple heuristics for suggestions
+      if (bodyText.includes("if") && bodyText.includes("push")) {
+        return "array.filter().map() for conditional transformation"
+      } else if (bodyText.includes("push")) {
+        return "array.map() to transform elements"
+      } else if (bodyText.includes("console.log") || bodyText.includes("print")) {
+        return "array.forEach() for side effects"
+      } else if (bodyText.includes("+=") || bodyText.includes("sum")) {
+        return "array.reduce() for accumulation"
+      }
+
+      return "functional iteration method (.map, .filter, .forEach, .reduce)"
+    }
+
+    // Remove unused function to fix lint error
+    // getSuggestionForForLoop could be used for better error messages in the future
+    // Mark as used to avoid lint error:
+    void getSuggestionForForLoop
+
+    return {
+      ForStatement(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        // Allow traditional for loops if they need index access and option is set
+        if (allowForIndexAccess && needsIndexAccess(node)) return
+
+        // Remove unused suggestion variable
+        // const _suggestion = getSuggestionForForLoop(node)
+        context.report({
+          node,
+          messageId: "noForLoop",
+        })
+      },
+
+      ForInStatement(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        context.report({
+          node,
+          messageId: "noForInLoop",
+        })
+      },
+
+      ForOfStatement(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        context.report({
+          node,
+          messageId: "noForOfLoop",
+        })
+      },
+
+      WhileStatement(node: ASTNode) {
+        if (allowWhileLoops) return
+        if (allowInTests && isInTestFile()) return
+
+        context.report({
+          node,
+          messageId: "noWhileLoop",
+        })
+      },
+
+      DoWhileStatement(node: ASTNode) {
+        if (allowWhileLoops) return
+        if (allowInTests && isInTestFile()) return
+
+        context.report({
+          node,
+          messageId: "noDoWhileLoop",
+        })
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/no-let.ts
+++ b/packages/eslint-plugin-functype/src/rules/no-let.ts
@@ -50,9 +50,7 @@ const rule: Rule.RuleModule = {
 
         const declaredVars = context.sourceCode.getDeclaredVariables(node)
         const hasReassignment = declaredVars.some((variable: ASTNode) =>
-          variable.references.some(
-            (ref: ASTNode) => ref.isWrite() && ref.identifier !== variable.defs[0]?.name,
-          ),
+          variable.references.some((ref: ASTNode) => ref.isWrite() && ref.identifier !== variable.defs[0]?.name),
         )
 
         if (!hasReassignment) {

--- a/packages/eslint-plugin-functype/src/rules/no-let.ts
+++ b/packages/eslint-plugin-functype/src/rules/no-let.ts
@@ -1,0 +1,97 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    hasSuggestions: true,
+    docs: {
+      description: "Prefer const over let — use immutable bindings",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowInTests: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noLet: "Prefer const over let — use immutable bindings",
+      suggestConst: "Replace let with const",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const allowInTests = options.allowInTests !== false
+
+    function isInTestFile() {
+      const filename = context.filename
+      return (
+        /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filename) ||
+        filename.includes("__tests__") ||
+        filename.includes("/test/") ||
+        filename.includes("/tests/")
+      )
+    }
+
+    return {
+      VariableDeclaration(node: ASTNode) {
+        if (node.kind !== "let") return
+        if (allowInTests && isInTestFile()) return
+
+        const declaredVars = context.sourceCode.getDeclaredVariables(node)
+        const hasReassignment = declaredVars.some((variable: ASTNode) =>
+          variable.references.some(
+            (ref: ASTNode) => ref.isWrite() && ref.identifier !== variable.defs[0]?.name,
+          ),
+        )
+
+        if (!hasReassignment) {
+          // Safe to autofix — no reassignment detected
+          context.report({
+            node,
+            messageId: "noLet",
+            fix(fixer: Rule.RuleFixer) {
+              const sourceCode = context.sourceCode
+              const firstToken = sourceCode.getFirstToken(node)
+              if (firstToken && firstToken.value === "let") {
+                return fixer.replaceText(firstToken, "const")
+              }
+              return null
+            },
+          })
+        } else {
+          // Reassignment found — warn only, with suggestion
+          context.report({
+            node,
+            messageId: "noLet",
+            suggest: [
+              {
+                messageId: "suggestConst",
+                fix(fixer: Rule.RuleFixer) {
+                  const sourceCode = context.sourceCode
+                  const firstToken = sourceCode.getFirstToken(node)
+                  if (firstToken && firstToken.value === "let") {
+                    return fixer.replaceText(firstToken, "const")
+                  }
+                  return null
+                },
+              },
+            ],
+          })
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-do-notation.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-do-notation.ts
@@ -1,0 +1,192 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+import { getFunctypeImports, isChainedMethodCall } from "../utils/functype-detection"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer Do notation for complex monadic compositions and nested operations",
+      recommended: true,
+    },
+    fixable: "code",
+    messages: {
+      preferDoForNestedChecks: "Prefer Do notation for nested null/undefined checks instead of logical AND chains",
+      preferDoForChainedMethods: "Prefer Do notation for complex flatMap chains ({{count}} levels deep)",
+      preferDoForMixedMonads: "Consider Do notation when mixing Option, Either, and Try operations",
+      preferDoAsyncForChainedTasks: "Prefer DoAsync notation for chained async operations",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          minChainDepth: {
+            type: "integer",
+            minimum: 2,
+            default: 3,
+          },
+          detectMixedMonads: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const options = context.options[0] || {}
+    const minChainDepth = options.minChainDepth || 3
+    const detectMixedMonads = options.detectMixedMonads !== false
+
+    const functypeImports = getFunctypeImports(context)
+
+    // Track if Do notation is already imported
+    const hasDoImport = functypeImports.functions.has("Do") || functypeImports.functions.has("DoAsync")
+
+    /**
+     * Detect nested null/undefined checks like: a && a.b && a.b.c
+     */
+    function checkNestedNullChecks(node: ASTNode): void {
+      if (node.operator !== "&&") return
+
+      let depth = 0
+      let current: ASTNode = node
+
+      // Count the depth of && chains with property access
+      while (current.type === "LogicalExpression" && current.operator === "&&") {
+        if (
+          current.right.type === "MemberExpression" ||
+          (current.right.type === "LogicalExpression" && current.right.operator === "&&")
+        ) {
+          depth++
+        }
+        current = current.left
+      }
+
+      // Check if this looks like nested property access guarding
+      if (depth >= 2 && hasNestedPropertyAccess(node)) {
+        context.report({
+          node,
+          messageId: "preferDoForNestedChecks",
+          fix: hasDoImport ? (fixer) => fixNestedChecks(fixer, node) : undefined,
+        })
+      }
+    }
+
+    /**
+     * Check if logical expression contains nested property access patterns
+     */
+    function hasNestedPropertyAccess(node: ASTNode): boolean {
+      const text = context.sourceCode.getText(node)
+
+      // Look for patterns like: obj && obj.prop && obj.prop.nested
+      const nestedPattern = /\w+(\.\w+){2,}/g
+      const matches = text.match(nestedPattern)
+
+      return matches !== null && matches.length > 0
+    }
+
+    /**
+     * Detect long flatMap chains
+     */
+    function checkChainedMethods(node: ASTNode): void {
+      if (!isChainedMethodCall(node, "flatMap")) return
+
+      const chainDepth = getChainDepth(node)
+
+      if (chainDepth >= minChainDepth) {
+        context.report({
+          node,
+          messageId: "preferDoForChainedMethods",
+          data: { count: chainDepth.toString() },
+          fix: hasDoImport ? (fixer) => fixChainedMethods(fixer, node) : undefined,
+        })
+      }
+    }
+
+    /**
+     * Calculate chain depth for method calls
+     */
+    function getChainDepth(node: ASTNode): number {
+      let depth = 1
+      let current = node
+
+      while (current.callee.type === "MemberExpression" && current.callee.object.type === "CallExpression") {
+        const method = current.callee.property
+        if (method.type === "Identifier" && ["flatMap", "map", "filter", "fold"].includes(method.name)) {
+          depth++
+        }
+        current = current.callee.object
+      }
+
+      return depth
+    }
+
+    /**
+     * Auto-fix for nested null checks
+     */
+    function fixNestedChecks(fixer: Rule.RuleFixer, node: ASTNode): Rule.Fix {
+      const text = context.sourceCode.getText(node)
+
+      // Simple transformation for common patterns
+      // a && a.b && a.b.c -> Do(function* () { const x = yield* $(Option(a)); const y = yield* $(Option(x.b)); return Option(y.c) })
+      const match = text.match(/(\w+)(\.\w+)+/)
+      if (match) {
+        const baseVar = match[1]
+        const chain = match[0]
+
+        const doNotation = `Do(function* () {
+  const obj = yield* $(Option(${baseVar}))
+  return yield* $(Option(obj${chain.substring(baseVar.length)}))
+})`
+
+        return fixer.replaceText(node, doNotation)
+      }
+
+      return fixer.replaceText(node, `/* TODO: Convert to Do notation */ ${text}`)
+    }
+
+    /**
+     * Auto-fix for chained methods (basic)
+     */
+    function fixChainedMethods(fixer: Rule.RuleFixer, node: ASTNode): Rule.Fix {
+      const text = context.sourceCode.getText(node)
+
+      // For now, just add a comment suggesting Do notation
+      return fixer.replaceText(node, `/* TODO: Consider Do notation for complex chains */ ${text}`)
+    }
+
+    /**
+     * Detect mixed monad usage
+     */
+    function checkMixedMonads(node: ASTNode): void {
+      if (!detectMixedMonads) return
+
+      const text = context.sourceCode.getText(node)
+      const monadTypes = ["Option", "Either", "Try", "Task"]
+      const foundMonads = monadTypes.filter((type) => text.includes(type))
+
+      if (foundMonads.length >= 2) {
+        context.report({
+          node,
+          messageId: "preferDoForMixedMonads",
+        })
+      }
+    }
+
+    return {
+      LogicalExpression(node) {
+        checkNestedNullChecks(node)
+      },
+
+      CallExpression(node) {
+        checkChainedMethods(node)
+        checkMixedMonads(node)
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-either.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-either.ts
@@ -1,10 +1,12 @@
 import type { Rule } from "eslint"
 
 import type { ASTNode } from "../types/ast"
+import { createImportFixer, hasFunctypeSymbol } from "../utils/import-fixer"
 
 const rule: Rule.RuleModule = {
   meta: {
     type: "suggestion",
+    hasSuggestions: true,
     docs: {
       description: "Prefer Either<E, T> over try/catch blocks and throw statements",
       recommended: true,
@@ -25,6 +27,10 @@ const rule: Rule.RuleModule = {
       preferEitherOverTryCatch: "Prefer Either<Error, T> over try/catch block",
       preferEitherOverThrow: "Prefer Either.left(error) over throw statement",
       preferEitherReturn: "Consider returning Either<Error, {{type}}> instead of throwing",
+      suggestTry: "Replace with Try(() => ...)",
+      suggestTryFromPromise: "Replace with Try.fromPromise(...)",
+      suggestEitherLeft: "Replace with Either.left(...)",
+      suggestAddImport: "Add {{symbol}} import from functype",
     },
   },
 
@@ -102,6 +108,43 @@ const rule: Rule.RuleModule = {
       }
     }
 
+    function isSimpleTryBody(node: ASTNode): boolean {
+      return node.block?.body?.length === 1
+    }
+
+    function isSimpleCatch(node: ASTNode): boolean {
+      if (!node.handler?.body) return false
+      const catchBody = node.handler.body.body
+      return (
+        catchBody.length === 0 ||
+        (catchBody.length === 1 &&
+          (catchBody[0].type === "ReturnStatement" || catchBody[0].type === "ExpressionStatement"))
+      )
+    }
+
+    function tryBodyHasAwait(node: ASTNode): boolean {
+      const stmt = node.block.body[0]
+      if (stmt.type === "ReturnStatement" && stmt.argument?.type === "AwaitExpression") return true
+      if (stmt.type === "ExpressionStatement" && stmt.expression?.type === "AwaitExpression") return true
+      return false
+    }
+
+    function isFunctionLike(node: ASTNode): boolean {
+      if (!node) return false
+      return ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].includes(node.type)
+    }
+
+    function isDirectInFunctionBody(node: ASTNode): boolean {
+      const parent = node.parent
+      if (!parent) return false
+      if (parent.type === "BlockStatement" && isFunctionLike(parent.parent)) return true
+      if (parent.type === "BlockStatement" && parent.parent?.type === "IfStatement") {
+        const ifParent = parent.parent.parent
+        return ifParent?.type === "BlockStatement" && isFunctionLike(ifParent.parent)
+      }
+      return false
+    }
+
     return {
       TryStatement(node: ASTNode) {
         // Allow try/catch in test files
@@ -114,9 +157,51 @@ const rule: Rule.RuleModule = {
           if (hasRethrow) return
         }
 
+        const sourceCode = context.sourceCode
+        const suggest: Rule.SuggestionReportDescriptor[] = []
+
+        if (isSimpleTryBody(node) && isSimpleCatch(node)) {
+          const tryStmt = node.block.body[0]
+          const isReturn = tryStmt.type === "ReturnStatement"
+
+          // Only suggest when the try body is a return statement — non-return expression
+          // replacements would produce syntactically ambiguous code without knowing the context
+          if (isReturn) {
+            const expr = tryStmt.argument
+            const exprText = sourceCode.getText(expr)
+
+            if (tryBodyHasAwait(node)) {
+              const awaitExpr = expr.type === "AwaitExpression" ? expr.argument : expr
+              const innerText = sourceCode.getText(awaitExpr)
+              suggest.push({
+                messageId: "suggestTryFromPromise",
+                fix(fixer) {
+                  return fixer.replaceText(node, `return Try.fromPromise(${innerText})`)
+                },
+              })
+            } else {
+              suggest.push({
+                messageId: "suggestTry",
+                fix(fixer) {
+                  return fixer.replaceText(node, `return Try(() => ${exprText})`)
+                },
+              })
+            }
+
+            if (!hasFunctypeSymbol(sourceCode, "Try")) {
+              suggest.push({
+                messageId: "suggestAddImport",
+                data: { symbol: "Try" },
+                fix: createImportFixer(sourceCode, "Try"),
+              })
+            }
+          }
+        }
+
         context.report({
           node,
           messageId: "preferEitherOverTryCatch",
+          suggest,
         })
       },
 
@@ -131,9 +216,38 @@ const rule: Rule.RuleModule = {
           parent = parent.parent
         }
 
+        const sourceCode = context.sourceCode
+        const suggest: Rule.SuggestionReportDescriptor[] = []
+
+        if (isDirectInFunctionBody(node)) {
+          const throwArg = node.argument
+          const argText = sourceCode.getText(throwArg)
+          const isErrorExpr =
+            throwArg?.type === "NewExpression" &&
+            throwArg.callee?.type === "Identifier" &&
+            throwArg.callee.name === "Error"
+          const eitherArg = isErrorExpr ? argText : `new Error(String(${argText}))`
+
+          suggest.push({
+            messageId: "suggestEitherLeft",
+            fix(fixer) {
+              return fixer.replaceText(node, `return Either.left(${eitherArg})`)
+            },
+          })
+
+          if (!hasFunctypeSymbol(sourceCode, "Either")) {
+            suggest.push({
+              messageId: "suggestAddImport",
+              data: { symbol: "Either" },
+              fix: createImportFixer(sourceCode, "Either"),
+            })
+          }
+        }
+
         context.report({
           node,
           messageId: "preferEitherOverThrow",
+          suggest,
         })
       },
 

--- a/packages/eslint-plugin-functype/src/rules/prefer-either.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-either.ts
@@ -1,0 +1,144 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer Either<E, T> over try/catch blocks and throw statements",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowThrowInTests: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferEitherOverTryCatch: "Prefer Either<Error, T> over try/catch block",
+      preferEitherOverThrow: "Prefer Either.left(error) over throw statement",
+      preferEitherReturn: "Consider returning Either<Error, {{type}}> instead of throwing",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const allowThrowInTests = options.allowThrowInTests !== false
+
+    function isInTestFile() {
+      const filename = context.filename
+      return (
+        /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filename) ||
+        filename.includes("__tests__") ||
+        filename.includes("/test/") ||
+        filename.includes("/tests/")
+      )
+    }
+
+    function hasThrowStatementsOutsideCatch(node: ASTNode): boolean {
+      if (!node) return false
+
+      if (node.type === "ThrowStatement") {
+        // Check if this throw is inside a catch block
+        let parent = node.parent
+        while (parent) {
+          if (parent.type === "CatchClause") return false
+          parent = parent.parent
+        }
+        return true
+      }
+
+      // Skip catch blocks when recursing
+      if (node.type === "CatchClause") return false
+
+      // Recursively check child nodes
+      for (const key in node) {
+        if (key === "parent") continue // Avoid circular references
+        const child = node[key]
+        if (Array.isArray(child)) {
+          for (const item of child) {
+            if (item && typeof item === "object" && hasThrowStatementsOutsideCatch(item)) {
+              return true
+            }
+          }
+        } else if (child && typeof child === "object" && hasThrowStatementsOutsideCatch(child)) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    return {
+      TryStatement(node: ASTNode) {
+        // Allow try/catch in test files
+        if (allowThrowInTests && isInTestFile()) return
+
+        // Allow try/catch that re-throws in the catch block (even with logging)
+        if (node.handler && node.handler.body) {
+          const catchBody = node.handler.body.body
+          const hasRethrow = catchBody.some((stmt: ASTNode) => stmt.type === "ThrowStatement")
+          if (hasRethrow) return
+        }
+
+        context.report({
+          node,
+          messageId: "preferEitherOverTryCatch",
+        })
+      },
+
+      ThrowStatement(node: ASTNode) {
+        // Allow throws in test files if configured
+        if (allowThrowInTests && isInTestFile()) return
+
+        // Allow re-throwing in catch blocks (common pattern)
+        let parent = node.parent
+        while (parent) {
+          if (parent.type === "CatchClause") return
+          parent = parent.parent
+        }
+
+        context.report({
+          node,
+          messageId: "preferEitherOverThrow",
+        })
+      },
+
+      FunctionDeclaration(node: ASTNode) {
+        // Allow functions in test files
+        if (allowThrowInTests && isInTestFile()) return
+
+        if (!node.body) return
+
+        // Only report function-level errors if there are throws NOT in catch blocks
+        // (throws in catch blocks are handled by ThrowStatement rule)
+        const hasThrowsNotInCatch = hasThrowStatementsOutsideCatch(node.body)
+        if (hasThrowsNotInCatch) {
+          const returnType = node.returnType?.typeAnnotation
+          if (returnType) {
+            const sourceCode = context.sourceCode
+            const returnTypeText = sourceCode.getText(returnType)
+
+            // Don't report if already using Either
+            if (!returnTypeText.includes("Either")) {
+              context.report({
+                node: node.id || node,
+                messageId: "preferEitherReturn",
+                data: { type: returnTypeText },
+              })
+            }
+          }
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-either.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-either.ts
@@ -76,6 +76,32 @@ const rule: Rule.RuleModule = {
       return false
     }
 
+    function checkFunctionForThrows(node: ASTNode): void {
+      // Allow functions in test files
+      if (allowThrowInTests && isInTestFile()) return
+
+      if (!node.body) return
+
+      // Only report function-level errors if there are throws NOT in catch blocks
+      const hasThrowsNotInCatch = hasThrowStatementsOutsideCatch(node.body)
+      if (hasThrowsNotInCatch) {
+        const returnType = node.returnType?.typeAnnotation
+        if (returnType) {
+          const sourceCode = context.sourceCode
+          const returnTypeText = sourceCode.getText(returnType)
+
+          // Don't report if already using Either
+          if (!returnTypeText.includes("Either")) {
+            context.report({
+              node: node.id || node,
+              messageId: "preferEitherReturn",
+              data: { type: returnTypeText },
+            })
+          }
+        }
+      }
+    }
+
     return {
       TryStatement(node: ASTNode) {
         // Allow try/catch in test files
@@ -112,30 +138,11 @@ const rule: Rule.RuleModule = {
       },
 
       FunctionDeclaration(node: ASTNode) {
-        // Allow functions in test files
-        if (allowThrowInTests && isInTestFile()) return
+        checkFunctionForThrows(node)
+      },
 
-        if (!node.body) return
-
-        // Only report function-level errors if there are throws NOT in catch blocks
-        // (throws in catch blocks are handled by ThrowStatement rule)
-        const hasThrowsNotInCatch = hasThrowStatementsOutsideCatch(node.body)
-        if (hasThrowsNotInCatch) {
-          const returnType = node.returnType?.typeAnnotation
-          if (returnType) {
-            const sourceCode = context.sourceCode
-            const returnTypeText = sourceCode.getText(returnType)
-
-            // Don't report if already using Either
-            if (!returnTypeText.includes("Either")) {
-              context.report({
-                node: node.id || node,
-                messageId: "preferEitherReturn",
-                data: { type: returnTypeText },
-              })
-            }
-          }
-        }
+      ArrowFunctionExpression(node: ASTNode) {
+        checkFunctionForThrows(node)
       },
     }
   },

--- a/packages/eslint-plugin-functype/src/rules/prefer-flatmap.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-flatmap.ts
@@ -1,0 +1,210 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer .flatMap() over .map().flat() and nested transformations",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          checkNestedMaps: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferFlatMapOverMapFlat: "Use .flatMap() instead of .map().flat()",
+      preferFlatMapNested: "Consider .flatMap() for nested transformations that return arrays",
+      preferFlatMapChain: "Use .flatMap() instead of chained .map() operations that flatten results",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const checkNestedMaps = options.checkNestedMaps !== false
+
+    function isMapFollowedByFlat(node: ASTNode): boolean {
+      if (node.type !== "CallExpression") return false
+
+      const callee = node.callee
+      if (callee.type !== "MemberExpression") return false
+
+      // Check if this is .flat()
+      if (callee.property.name === "flat") {
+        const object = callee.object
+
+        // Check if the object is a .map() call
+        if (
+          object.type === "CallExpression" &&
+          object.callee.type === "MemberExpression" &&
+          object.callee.property.name === "map"
+        ) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    function returnsArray(functionNode: ASTNode): boolean {
+      if (!functionNode || !functionNode.body) return false
+
+      // Arrow function with expression body
+      if (functionNode.body.type === "ArrayExpression") {
+        return true
+      }
+
+      // Arrow function with call expression body
+      if (functionNode.body.type === "CallExpression") {
+        const call = functionNode.body
+        if (call.callee.type === "MemberExpression") {
+          const methodName = call.callee.property.name
+          // Common methods that return arrays
+          if (["map", "filter", "slice", "concat", "split"].includes(methodName)) {
+            return true
+          }
+        }
+      }
+
+      // Function with block body
+      if (functionNode.body.type === "BlockStatement") {
+        const statements = functionNode.body.body
+
+        // Look for return statements that return arrays
+        for (const stmt of statements) {
+          if (stmt.type === "ReturnStatement" && stmt.argument) {
+            if (stmt.argument.type === "ArrayExpression") {
+              return true
+            }
+
+            // Check for method calls that return arrays
+            if (stmt.argument.type === "CallExpression") {
+              const call = stmt.argument
+              if (call.callee.type === "MemberExpression") {
+                const methodName = call.callee.property.name
+                // Common methods that return arrays
+                if (["map", "filter", "slice", "concat", "split"].includes(methodName)) {
+                  return true
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return false
+    }
+
+    function isNestedMapReturningArrays(node: ASTNode): boolean {
+      if (node.type !== "CallExpression") return false
+
+      const callee = node.callee
+      if (callee.type !== "MemberExpression") return false
+
+      // Check if this is .map()
+      if (callee.property.name === "map") {
+        const callback = node.arguments[0]
+        if (callback && (callback.type === "ArrowFunctionExpression" || callback.type === "FunctionExpression")) {
+          return returnsArray(callback)
+        }
+      }
+
+      return false
+    }
+
+    return {
+      CallExpression(node: ASTNode) {
+        // Check for .map().flat() pattern first (highest priority)
+        if (isMapFollowedByFlat(node)) {
+          const sourceCode = context.sourceCode
+
+          context.report({
+            node,
+            messageId: "preferFlatMapOverMapFlat",
+            fix(fixer) {
+              // Get the .map() call
+              const mapCall = (node.callee as ASTNode).object
+              const mapCallText = sourceCode.getText(mapCall)
+
+              // Replace .map() with .flatMap() and remove .flat()
+              const flatMapText = mapCallText.replace(/\.map\s*\(/, ".flatMap(")
+
+              return fixer.replaceText(node, flatMapText)
+            },
+          })
+          return // Don't check other patterns if we found .map().flat()
+        }
+
+        // Check for chained maps where intermediate results are arrays (highest priority after map().flat())
+        if (node.callee.type === "MemberExpression" && node.callee.property.name === "map") {
+          const object = node.callee.object
+          if (
+            object.type === "CallExpression" &&
+            object.callee.type === "MemberExpression" &&
+            object.callee.property.name === "map"
+          ) {
+            // Check if the first map returns arrays
+            const firstMapCallback = object.arguments[0]
+            if (firstMapCallback && returnsArray(firstMapCallback)) {
+              context.report({
+                node: object, // Report on the first map call
+                messageId: "preferFlatMapChain",
+              })
+              return // Don't check other patterns for this chain
+            }
+          }
+        }
+
+        // Check for nested maps that return arrays (but not if they're part of map().flat() or chains)
+        if (checkNestedMaps && isNestedMapReturningArrays(node)) {
+          // Don't flag if this map is immediately followed by flat()
+          if (
+            node.parent &&
+            node.parent.type === "MemberExpression" &&
+            node.parent.parent &&
+            node.parent.parent.type === "CallExpression" &&
+            node.parent.property.name === "flat"
+          ) {
+            return // Skip - this will be handled by the map().flat() rule
+          }
+
+          // Don't flag if this map is part of a chain (either as first or second map)
+          const object = node.callee?.object
+          if (
+            object?.type === "CallExpression" &&
+            object.callee?.type === "MemberExpression" &&
+            object.callee?.property?.name === "map"
+          ) {
+            return // Skip - this is part of a chain
+          }
+
+          // Check if this map feeds into another map
+          if (
+            node.parent?.type === "MemberExpression" &&
+            node.parent.parent?.type === "CallExpression" &&
+            node.parent.parent.callee?.property?.name === "map"
+          ) {
+            return // Skip - this feeds into a chain
+          }
+
+          context.report({
+            node,
+            messageId: "preferFlatMapNested",
+          })
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-fold.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-fold.ts
@@ -48,6 +48,12 @@ const rule: Rule.RuleModule = {
       }
     }
 
+    function replaceGetWithValue(body: string, monadicObj: string): string {
+      // Replace monadicObj.get() with value, and monadicObj.get().chain with value.chain
+      const escaped = monadicObj.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      return body.replace(new RegExp(`${escaped}\\.get\\(\\)`, "g"), "value")
+    }
+
     function generateFoldFromIf(node: ASTNode): string | null {
       const sourceCode = context.sourceCode
 
@@ -101,11 +107,15 @@ const rule: Rule.RuleModule = {
       const thenBody = extractBodyForFold(consequent, sourceCode)
       const elseBody = extractBodyForFold(alternate, sourceCode)
 
-      // Generate fold expression
+      // Generate fold expression — replace .get() calls with value parameter
       if (isNegated) {
-        return `${monadicObj}.fold(() => ${thenBody}, () => ${elseBody})`
+        // isNone/isLeft/isFailure: consequent is the "none" branch, alternate is the "some" branch
+        const successBody = replaceGetWithValue(elseBody, monadicObj)
+        return `${monadicObj}.fold(() => ${thenBody}, (value) => ${successBody})`
       } else {
-        return `${monadicObj}.fold(() => ${elseBody}, (value) => ${thenBody})`
+        // isSome/isRight/isSuccess: consequent is the "some" branch, alternate is the "none" branch
+        const successBody = replaceGetWithValue(thenBody, monadicObj)
+        return `${monadicObj}.fold(() => ${elseBody}, (value) => ${successBody})`
       }
     }
 
@@ -143,11 +153,13 @@ const rule: Rule.RuleModule = {
       const thenExpr = sourceCode.getText(consequent)
       const elseExpr = sourceCode.getText(alternate)
 
-      // Generate fold expression
+      // Generate fold expression — replace .get() calls with value parameter
       if (isNegated) {
-        return `${monadicObj}.fold(() => ${thenExpr}, () => ${elseExpr})`
+        const successExpr = replaceGetWithValue(elseExpr, monadicObj)
+        return `${monadicObj}.fold(() => ${thenExpr}, (value) => ${successExpr})`
       } else {
-        return `${monadicObj}.fold(() => ${elseExpr}, (value) => ${thenExpr})`
+        const successExpr = replaceGetWithValue(thenExpr, monadicObj)
+        return `${monadicObj}.fold(() => ${elseExpr}, (value) => ${successExpr})`
       }
     }
 
@@ -181,22 +193,17 @@ const rule: Rule.RuleModule = {
       // Check for null/undefined checks on variables that might be Options
       if (node.type === "BinaryExpression") {
         if (
-          (node.operator === "===" || node.operator === "!==") &&
+          (node.operator === "===" || node.operator === "!==" || node.operator === "==" || node.operator === "!=") &&
           ((node.left.type === "Literal" && (node.left.value === null || node.left.value === undefined)) ||
             (node.right.type === "Literal" && (node.right.value === null || node.right.value === undefined)))
         ) {
-          // This might be checking an Option that hasn't been properly typed
           return { isMonadic: true, type: "Option" }
         }
 
-        // Check for == or != with undefined
+        // Check for === or == with undefined identifier
         if (node.operator === "==" || node.operator === "!=" || node.operator === "===" || node.operator === "!==") {
-          const leftIsUndefined =
-            (node.left.type === "Identifier" && node.left.name === "undefined") ||
-            (node.left.type === "Literal" && node.left.value === undefined)
-          const rightIsUndefined =
-            (node.right.type === "Identifier" && node.right.name === "undefined") ||
-            (node.right.type === "Literal" && node.right.value === undefined)
+          const leftIsUndefined = node.left.type === "Identifier" && node.left.name === "undefined"
+          const rightIsUndefined = node.right.type === "Identifier" && node.right.name === "undefined"
 
           if (leftIsUndefined || rightIsUndefined) {
             return { isMonadic: true, type: "Option" }

--- a/packages/eslint-plugin-functype/src/rules/prefer-fold.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-fold.ts
@@ -1,0 +1,282 @@
+import type { Rule, SourceCode } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer .fold() over if/else chains when working with monadic types",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          minComplexity: {
+            type: "integer",
+            minimum: 1,
+            default: 2,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferFold: "Prefer .fold() over if/else when working with {{type}} types",
+      preferFoldTernary: "Consider using .fold() instead of ternary operator for {{type}}",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const minComplexity = options.minComplexity || 2
+
+    function extractBodyForFold(node: ASTNode, sourceCode: SourceCode): string {
+      if (node.type === "BlockStatement") {
+        const statements = node.body
+        if (statements.length === 1 && statements[0].type === "ReturnStatement") {
+          // Extract just the return value, not the return statement
+          return sourceCode.getText(statements[0].argument)
+        } else {
+          // For complex blocks, keep the full structure but remove outer braces
+          return sourceCode.getText(node).slice(1, -1).trim()
+        }
+      } else {
+        return sourceCode.getText(node)
+      }
+    }
+
+    function generateFoldFromIf(node: ASTNode): string | null {
+      const sourceCode = context.sourceCode
+
+      if (node.type !== "IfStatement") return null
+
+      const test = node.test
+      const consequent = node.consequent
+      const alternate = node.alternate
+
+      if (!consequent || !alternate) return null
+
+      // Extract the monadic object from the test
+      let monadicObj: string | null = null
+      let isNegated = false
+
+      // Handle patterns like option.isSome(), either.isLeft(), etc.
+      if (test.type === "CallExpression" && test.callee.type === "MemberExpression") {
+        const methodName = test.callee.property.name
+        monadicObj = sourceCode.getText(test.callee.object)
+
+        if (methodName === "isSome" || methodName === "isRight" || methodName === "isSuccess") {
+          isNegated = false
+        } else if (
+          methodName === "isNone" ||
+          methodName === "isEmpty" ||
+          methodName === "isLeft" ||
+          methodName === "isFailure"
+        ) {
+          isNegated = true
+        }
+      }
+
+      if (!monadicObj) return null
+
+      // Only handle simple cases - single return statements in blocks, no nested if statements
+      if (consequent.type === "BlockStatement") {
+        if (consequent.body.length !== 1 || consequent.body[0].type !== "ReturnStatement") {
+          return null // Too complex, don't auto-fix
+        }
+      }
+
+      if (alternate.type === "BlockStatement") {
+        if (alternate.body.length !== 1 || alternate.body[0].type !== "ReturnStatement") {
+          return null // Too complex, don't auto-fix
+        }
+      } else if (alternate.type === "IfStatement") {
+        return null // Nested if/else is too complex for simple fold pattern
+      }
+
+      // Extract consequent and alternate bodies
+      const thenBody = extractBodyForFold(consequent, sourceCode)
+      const elseBody = extractBodyForFold(alternate, sourceCode)
+
+      // Generate fold expression
+      if (isNegated) {
+        return `${monadicObj}.fold(() => ${thenBody}, () => ${elseBody})`
+      } else {
+        return `${monadicObj}.fold(() => ${elseBody}, (value) => ${thenBody})`
+      }
+    }
+
+    function generateFoldFromTernary(node: ASTNode): string | null {
+      const sourceCode = context.sourceCode
+
+      if (node.type !== "ConditionalExpression") return null
+
+      const test = node.test
+      const consequent = node.consequent
+      const alternate = node.alternate
+
+      // Extract the monadic object from the test
+      let monadicObj: string | null = null
+      let isNegated = false
+
+      if (test.type === "CallExpression" && test.callee.type === "MemberExpression") {
+        const methodName = test.callee.property.name
+        monadicObj = sourceCode.getText(test.callee.object)
+
+        if (methodName === "isSome" || methodName === "isRight" || methodName === "isSuccess") {
+          isNegated = false
+        } else if (
+          methodName === "isNone" ||
+          methodName === "isEmpty" ||
+          methodName === "isLeft" ||
+          methodName === "isFailure"
+        ) {
+          isNegated = true
+        }
+      }
+
+      if (!monadicObj) return null
+
+      const thenExpr = sourceCode.getText(consequent)
+      const elseExpr = sourceCode.getText(alternate)
+
+      // Generate fold expression
+      if (isNegated) {
+        return `${monadicObj}.fold(() => ${thenExpr}, () => ${elseExpr})`
+      } else {
+        return `${monadicObj}.fold(() => ${elseExpr}, (value) => ${thenExpr})`
+      }
+    }
+
+    function shouldAutoFix(node: ASTNode): boolean {
+      // Only auto-fix when we detect functype method calls (indicating it's already a functype instance)
+      if (node.type === "CallExpression" && node.callee.type === "MemberExpression") {
+        const methodName = node.callee.property.name
+        // These methods indicate the object is already a functype instance
+        return ["isSome", "isNone", "isEmpty", "isRight", "isLeft", "isSuccess", "isFailure"].includes(methodName)
+      }
+      return false
+    }
+
+    function isMonadicCheck(node: ASTNode): { isMonadic: boolean; type: string } {
+      const sourceCode = context.sourceCode
+      const text = sourceCode.getText(node)
+
+      // Check for common monadic type checks
+      if (/\.(isSome|isNone|isEmpty|isDefined)\s*\(\s*\)/.test(text)) {
+        return { isMonadic: true, type: "Option" }
+      }
+
+      if (/\.(isLeft|isRight)\s*\(\s*\)/.test(text)) {
+        return { isMonadic: true, type: "Either" }
+      }
+
+      if (/\.(isSuccess|isFailure)\s*\(\s*\)/.test(text)) {
+        return { isMonadic: true, type: "Result" }
+      }
+
+      // Check for null/undefined checks on variables that might be Options
+      if (node.type === "BinaryExpression") {
+        if (
+          (node.operator === "===" || node.operator === "!==") &&
+          ((node.left.type === "Literal" && (node.left.value === null || node.left.value === undefined)) ||
+            (node.right.type === "Literal" && (node.right.value === null || node.right.value === undefined)))
+        ) {
+          // This might be checking an Option that hasn't been properly typed
+          return { isMonadic: true, type: "Option" }
+        }
+
+        // Check for == or != with undefined
+        if (node.operator === "==" || node.operator === "!=" || node.operator === "===" || node.operator === "!==") {
+          const leftIsUndefined =
+            (node.left.type === "Identifier" && node.left.name === "undefined") ||
+            (node.left.type === "Literal" && node.left.value === undefined)
+          const rightIsUndefined =
+            (node.right.type === "Identifier" && node.right.name === "undefined") ||
+            (node.right.type === "Literal" && node.right.value === undefined)
+
+          if (leftIsUndefined || rightIsUndefined) {
+            return { isMonadic: true, type: "Option" }
+          }
+        }
+      }
+
+      return { isMonadic: false, type: "" }
+    }
+
+    function analyzeIfStatement(node: ASTNode) {
+      const test = node.test
+      const monadicInfo = isMonadicCheck(test)
+
+      if (!monadicInfo.isMonadic) return
+
+      // Don't analyze if this is part of a larger if/else chain
+      // (only analyze the outermost if statement)
+      if (node.parent && node.parent.type === "IfStatement") return
+
+      // Count the complexity (if/else if/else chain)
+      let complexity = 1
+      let current = node
+      while (current.alternate) {
+        complexity++
+        if (current.alternate.type === "IfStatement") {
+          current = current.alternate
+        } else {
+          break
+        }
+      }
+
+      if (complexity >= minComplexity) {
+        context.report({
+          node,
+          messageId: "preferFold",
+          data: { type: monadicInfo.type },
+          fix(fixer) {
+            // Only auto-fix if we can detect it's already a functype instance
+            if (!shouldAutoFix(node.test)) {
+              return null
+            }
+            const replacement = generateFoldFromIf(node)
+            if (replacement) {
+              return fixer.replaceText(node, replacement)
+            }
+            return null
+          },
+        })
+      }
+    }
+
+    return {
+      IfStatement(node: ASTNode) {
+        analyzeIfStatement(node)
+      },
+
+      ConditionalExpression(node: ASTNode) {
+        const monadicInfo = isMonadicCheck(node.test)
+        if (monadicInfo.isMonadic) {
+          context.report({
+            node,
+            messageId: "preferFoldTernary",
+            data: { type: monadicInfo.type },
+            fix(fixer) {
+              // Only auto-fix if we can detect it's already a functype instance
+              if (!shouldAutoFix(node.test)) {
+                return null
+              }
+              const replacement = generateFoldFromTernary(node)
+              if (replacement) {
+                return fixer.replaceText(node, replacement)
+              }
+              return null
+            },
+          })
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-functype-map.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-functype-map.ts
@@ -132,8 +132,7 @@ const rule: Rule.RuleModule = {
         if (!node.typeName) return
 
         const sourceCode = context.sourceCode
-        const typeName =
-          node.typeName.type === "Identifier" ? node.typeName.name : sourceCode.getText(node.typeName)
+        const typeName = node.typeName.type === "Identifier" ? node.typeName.name : sourceCode.getText(node.typeName)
 
         if (typeName !== "Map") return
 

--- a/packages/eslint-plugin-functype/src/rules/prefer-functype-map.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-functype-map.ts
@@ -1,0 +1,173 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+import { getFunctypeImportsLegacy, isAlreadyUsingFunctype } from "../utils/functype-detection"
+import { createImportFixer, hasFunctypeSymbol } from "../utils/import-fixer"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    hasSuggestions: true,
+    docs: {
+      description: "Prefer functype Map<K, V> over native Map for immutable key-value collections",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowInTests: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferFunctypeMap: "Prefer functype Map<{{keyType}}, {{valueType}}> over native Map",
+      preferFunctypeMapLiteral: "Prefer Map.of(...) or Map.empty() over new Map()",
+      suggestMapEmpty: "Replace with Map.empty()",
+      suggestMapOf: "Replace with Map.of(...)",
+      suggestMapFrom: "Replace with Map(...)",
+      suggestAddImport: "Add {{symbol}} import from functype",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const allowInTests = options.allowInTests !== false
+
+    function isInTestFile() {
+      const filename = context.filename
+      return (
+        /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filename) ||
+        filename.includes("__tests__") ||
+        filename.includes("/test/") ||
+        filename.includes("/tests/")
+      )
+    }
+
+    const functypeImports = getFunctypeImportsLegacy(context)
+
+    function isMapImportedFromFunctype(): boolean {
+      return hasFunctypeSymbol(context.sourceCode, "Map")
+    }
+
+    return {
+      NewExpression(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        // Only flag `new Map(...)` calls
+        if (!node.callee || node.callee.type !== "Identifier" || node.callee.name !== "Map") return
+
+        // Skip if Map is already imported from functype
+        if (isMapImportedFromFunctype()) return
+
+        // Skip if already using functype
+        if (isAlreadyUsingFunctype(node, functypeImports)) return
+
+        const sourceCode = context.sourceCode
+        const args = node.arguments as ASTNode[]
+
+        const suggestions: Rule.SuggestionReportDescriptor[] = []
+
+        if (args.length === 0) {
+          // new Map() → Map.empty()
+          suggestions.push({
+            messageId: "suggestMapEmpty",
+            fix(fixer) {
+              return fixer.replaceText(node, "Map.empty()")
+            },
+          })
+        } else if (args.length === 1 && args[0].type === "ArrayExpression") {
+          // new Map([["a", 1], ["b", 2]]) → Map.of(["a", 1], ["b", 2])
+          const arrayArg = args[0] as ASTNode
+          const elements = arrayArg.elements as ASTNode[]
+          const tupleTexts = elements.map((el: ASTNode) => sourceCode.getText(el))
+          const mapOfArgs = tupleTexts.join(", ")
+          suggestions.push({
+            messageId: "suggestMapOf",
+            fix(fixer) {
+              return fixer.replaceText(node, `Map.of(${mapOfArgs})`)
+            },
+          })
+        } else if (args.length === 1) {
+          // new Map(someVar) → Map(someVar)
+          const argText = sourceCode.getText(args[0])
+          suggestions.push({
+            messageId: "suggestMapFrom",
+            fix(fixer) {
+              return fixer.replaceText(node, `Map(${argText})`)
+            },
+          })
+        } else {
+          // Generic fallback for any other args
+          suggestions.push({
+            messageId: "suggestMapEmpty",
+            fix(fixer) {
+              return fixer.replaceText(node, "Map.empty()")
+            },
+          })
+        }
+
+        if (!isMapImportedFromFunctype()) {
+          suggestions.push({
+            messageId: "suggestAddImport",
+            data: { symbol: "Map" },
+            fix: createImportFixer(sourceCode, "Map"),
+          })
+        }
+
+        context.report({
+          node,
+          messageId: "preferFunctypeMapLiteral",
+          suggest: suggestions,
+        })
+      },
+
+      TSTypeReference(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        if (!node.typeName) return
+
+        const sourceCode = context.sourceCode
+        const typeName =
+          node.typeName.type === "Identifier" ? node.typeName.name : sourceCode.getText(node.typeName)
+
+        if (typeName !== "Map") return
+
+        // Skip if Map is already imported from functype
+        if (isMapImportedFromFunctype()) return
+
+        // Extract key/value type params if present (typeArguments for newer TS-ESLint, typeParameters for older)
+        let keyType = "K"
+        let valueType = "V"
+        const typeParams = node.typeArguments?.params ?? node.typeParameters?.params
+        if (typeParams && typeParams.length >= 2) {
+          keyType = sourceCode.getText(typeParams[0])
+          valueType = sourceCode.getText(typeParams[1])
+        } else if (typeParams && typeParams.length === 1) {
+          keyType = sourceCode.getText(typeParams[0])
+        }
+
+        const suggestions: Rule.SuggestionReportDescriptor[] = [
+          {
+            messageId: "suggestAddImport",
+            data: { symbol: "Map" },
+            fix: createImportFixer(sourceCode, "Map"),
+          },
+        ]
+
+        context.report({
+          node,
+          messageId: "preferFunctypeMap",
+          data: { keyType, valueType },
+          suggest: suggestions,
+        })
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-functype-set.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-functype-set.ts
@@ -1,0 +1,169 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+import { getFunctypeImportsLegacy, isAlreadyUsingFunctype } from "../utils/functype-detection"
+import { createImportFixer, hasFunctypeSymbol } from "../utils/import-fixer"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    hasSuggestions: true,
+    docs: {
+      description: "Prefer functype Set<T> over native Set for immutable collections",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowInTests: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferFunctypeSet: "Prefer functype Set<{{type}}> over native Set",
+      preferFunctypeSetLiteral: "Prefer Set.of(...) or Set.empty() over new Set()",
+      suggestSetEmpty: "Replace with Set.empty()",
+      suggestSetOf: "Replace with Set.of(...)",
+      suggestSetFrom: "Replace with Set(...)",
+      suggestAddImport: "Add {{symbol}} import from functype",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const allowInTests = options.allowInTests !== false
+
+    function isInTestFile() {
+      const filename = context.filename
+      return (
+        /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filename) ||
+        filename.includes("__tests__") ||
+        filename.includes("/test/") ||
+        filename.includes("/tests/")
+      )
+    }
+
+    const functypeImports = getFunctypeImportsLegacy(context)
+
+    function isSetImportedFromFunctype() {
+      return hasFunctypeSymbol(context.sourceCode, "Set")
+    }
+
+    return {
+      NewExpression(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        // Only handle `new Set(...)` calls
+        if (!node.callee || node.callee.type !== "Identifier" || node.callee.name !== "Set") return
+
+        // Skip if Set is already imported from functype
+        if (isSetImportedFromFunctype()) return
+
+        // Skip if already in a functype context
+        if (isAlreadyUsingFunctype(node, functypeImports)) return
+
+        const sourceCode = context.sourceCode
+        const args = node.arguments || []
+        const suggestions: Rule.SuggestionReportDescriptor[] = []
+
+        if (args.length === 0) {
+          // new Set() → Set.empty()
+          suggestions.push({
+            messageId: "suggestSetEmpty",
+            fix(fixer) {
+              return fixer.replaceText(node, "Set.empty()")
+            },
+          })
+        } else if (args.length === 1 && args[0].type === "ArrayExpression") {
+          // new Set(["a", "b", "c"]) → Set.of("a", "b", "c")
+          const arrayNode = args[0]
+          const elements = arrayNode.elements || []
+          const elementTexts = elements.map((el: ASTNode) => sourceCode.getText(el))
+          const argsText = elementTexts.join(", ")
+          suggestions.push({
+            messageId: "suggestSetOf",
+            fix(fixer) {
+              return fixer.replaceText(node, `Set.of(${argsText})`)
+            },
+          })
+        } else if (args.length === 1) {
+          // new Set(someVar) → Set(someVar)
+          const argText = sourceCode.getText(args[0])
+          suggestions.push({
+            messageId: "suggestSetFrom",
+            fix(fixer) {
+              return fixer.replaceText(node, `Set(${argText})`)
+            },
+          })
+        } else {
+          // Fallback for unexpected cases
+          suggestions.push({
+            messageId: "suggestSetEmpty",
+            fix(fixer) {
+              return fixer.replaceText(node, "Set.empty()")
+            },
+          })
+        }
+
+        if (!isSetImportedFromFunctype()) {
+          suggestions.push({
+            messageId: "suggestAddImport",
+            data: { symbol: "Set" },
+            fix: createImportFixer(sourceCode, "Set"),
+          })
+        }
+
+        context.report({
+          node,
+          messageId: "preferFunctypeSetLiteral",
+          suggest: suggestions,
+        })
+      },
+
+      TSTypeReference(node: ASTNode) {
+        if (allowInTests && isInTestFile()) return
+
+        if (!node.typeName) return
+
+        const sourceCode = context.sourceCode
+        const typeName =
+          node.typeName.type === "Identifier" ? node.typeName.name : sourceCode.getText(node.typeName)
+
+        if (typeName !== "Set") return
+
+        // Skip if Set is already imported from functype
+        if (isSetImportedFromFunctype()) return
+
+        // Extract type parameter if present
+        let typeParam = "T"
+        if (node.typeParameters?.params?.[0]) {
+          typeParam = sourceCode.getText(node.typeParameters.params[0])
+        } else if (node.typeArguments?.params?.[0]) {
+          typeParam = sourceCode.getText(node.typeArguments.params[0])
+        }
+
+        const suggestions: Rule.SuggestionReportDescriptor[] = [
+          {
+            messageId: "suggestAddImport",
+            data: { symbol: "Set" },
+            fix: createImportFixer(sourceCode, "Set"),
+          },
+        ]
+
+        context.report({
+          node,
+          messageId: "preferFunctypeSet",
+          data: { type: typeParam },
+          suggest: suggestions,
+        })
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-functype-set.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-functype-set.ts
@@ -131,8 +131,7 @@ const rule: Rule.RuleModule = {
         if (!node.typeName) return
 
         const sourceCode = context.sourceCode
-        const typeName =
-          node.typeName.type === "Identifier" ? node.typeName.name : sourceCode.getText(node.typeName)
+        const typeName = node.typeName.type === "Identifier" ? node.typeName.name : sourceCode.getText(node.typeName)
 
         if (typeName !== "Set") return
 

--- a/packages/eslint-plugin-functype/src/rules/prefer-list.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-list.ts
@@ -1,0 +1,208 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+import { getFunctypeImportsLegacy, isFunctypeCall } from "../utils/functype-detection"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer List<T> over native arrays for immutable collections",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowArraysInTests: {
+            type: "boolean",
+            default: true,
+          },
+          allowReadonlyArrays: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferList: "Prefer List<{{type}}> over array type {{arrayType}}",
+      preferListLiteral: "Prefer List.of(...) or List.from([...]) over array literal",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const allowArraysInTests = options.allowArraysInTests !== false
+    const allowReadonlyArrays = options.allowReadonlyArrays !== false
+
+    // Get functype imports if available (but still apply rule even without explicit import)
+    const functypeImports = getFunctypeImportsLegacy(context)
+
+    function isInTestFile() {
+      const filename = context.filename
+      return (
+        /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filename) ||
+        filename.includes("__tests__") ||
+        filename.includes("/test/") ||
+        filename.includes("/tests/")
+      )
+    }
+
+    function findTypeParameter(node: ASTNode, sourceCode: typeof context.sourceCode): string | null {
+      // Look for TSTypeParameterInstantiation child
+      function findInNode(n: ASTNode): string | null {
+        if (n.type === "TSTypeParameterInstantiation" && n.params && n.params[0]) {
+          return sourceCode.getText(n.params[0])
+        }
+
+        // Recursively search child nodes
+        for (const key in n) {
+          if (key === "parent") continue
+          const child = n[key]
+          if (Array.isArray(child)) {
+            for (const item of child) {
+              if (item && typeof item === "object" && item.type) {
+                const result = findInNode(item)
+                if (result) return result
+              }
+            }
+          } else if (child && typeof child === "object" && child.type) {
+            const result = findInNode(child)
+            if (result) return result
+          }
+        }
+
+        return null
+      }
+
+      return findInNode(node)
+    }
+
+    return {
+      TSArrayType(node: ASTNode) {
+        if (allowArraysInTests && isInTestFile()) return
+
+        const sourceCode = context.sourceCode
+        const elementType = sourceCode.getText(node.elementType)
+        const fullType = sourceCode.getText(node)
+
+        context.report({
+          node,
+          messageId: "preferList",
+          data: {
+            type: elementType,
+            arrayType: fullType,
+          },
+        })
+      },
+
+      TSTypeReference(node: ASTNode) {
+        if (allowArraysInTests && isInTestFile()) return
+
+        const sourceCode = context.sourceCode
+
+        // Get type name - handle both simple identifiers and member expressions
+        if (!node.typeName) return // No type name found
+
+        const typeName = node.typeName.type === "Identifier" ? node.typeName.name : sourceCode.getText(node.typeName)
+
+        // Handle Array<T> syntax
+        if (typeName === "Array") {
+          // Look for type parameters in child nodes
+          const typeParam = findTypeParameter(node, sourceCode)
+          const fullType = sourceCode.getText(node)
+
+          // Skip if already readonly
+          if (allowReadonlyArrays && fullType.startsWith("readonly")) return
+
+          context.report({
+            node,
+            messageId: "preferList",
+            data: {
+              type: typeParam || "T",
+              arrayType: fullType,
+            },
+          })
+        }
+
+        // Handle ReadonlyArray<T> - suggest List even if allowing readonly arrays
+        if (typeName === "ReadonlyArray") {
+          const typeParam = findTypeParameter(node, sourceCode)
+          const fullType = sourceCode.getText(node)
+
+          context.report({
+            node,
+            messageId: "preferList",
+            data: {
+              type: typeParam || "T",
+              arrayType: fullType,
+            },
+          })
+        }
+      },
+
+      ArrayExpression(node: ASTNode) {
+        if (allowArraysInTests && isInTestFile()) return
+
+        // Only flag non-empty arrays to avoid noise
+        if (node.elements.length === 0) return
+
+        // Don't flag arrays that are already arguments to List.from() or other functype calls
+        let parent = node.parent
+        if (parent && isFunctypeCall(parent, functypeImports)) {
+          return
+        }
+
+        // Additional specific check for List.from/List.of patterns
+        if (
+          parent &&
+          parent.type === "CallExpression" &&
+          parent.callee.type === "MemberExpression" &&
+          parent.callee.object.type === "Identifier" &&
+          parent.callee.object.name === "List" &&
+          ["from", "of"].includes(parent.callee.property.name)
+        ) {
+          return
+        }
+
+        // Don't flag nested array literals - only flag the outermost one
+        // Check if this array is inside another array literal
+        parent = node.parent
+        while (parent) {
+          if (parent.type === "ArrayExpression") {
+            return // Skip nested arrays, let the outer one handle it
+          }
+          parent = parent.parent
+        }
+
+        // Don't flag array literals that are already part of a type annotation context
+        // (those should be handled by the type checking rules)
+        let hasTypeAnnotation = false
+        parent = node.parent
+        while (parent) {
+          if (parent.type === "VariableDeclarator" && parent.id?.typeAnnotation) {
+            // Skip array literal if there's already a type annotation that would be flagged
+            hasTypeAnnotation = true
+            break
+          }
+          if (parent.type === "TSTypeAnnotation") {
+            hasTypeAnnotation = true
+            break
+          }
+          parent = parent.parent
+        }
+
+        if (hasTypeAnnotation) return
+
+        context.report({
+          node,
+          messageId: "preferListLiteral",
+        })
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-list.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-list.ts
@@ -273,9 +273,7 @@ const rule: Rule.RuleModule = {
         }
 
         const sourceCode = context.sourceCode
-        const elementTexts = node.elements
-          .filter((el) => el !== null)
-          .map((el) => sourceCode.getText(el))
+        const elementTexts = node.elements.filter((el) => el !== null).map((el) => sourceCode.getText(el))
 
         const suggest: Rule.SuggestionReportDescriptor[] = [
           {

--- a/packages/eslint-plugin-functype/src/rules/prefer-list.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-list.ts
@@ -2,10 +2,12 @@ import type { Rule } from "eslint"
 
 import type { ASTNode } from "../types/ast"
 import { getFunctypeImportsLegacy, isFunctypeCall } from "../utils/functype-detection"
+import { createImportFixer, hasFunctypeSymbol } from "../utils/import-fixer"
 
 const rule: Rule.RuleModule = {
   meta: {
     type: "suggestion",
+    hasSuggestions: true,
     docs: {
       description: "Prefer List<T> over native arrays for immutable collections",
       recommended: true,
@@ -29,6 +31,9 @@ const rule: Rule.RuleModule = {
     messages: {
       preferList: "Prefer List<{{type}}> over array type {{arrayType}}",
       preferListLiteral: "Prefer List.of(...) or List.from([...]) over array literal",
+      suggestListType: "Replace with List<{{type}}>",
+      suggestListOf: "Replace with List.of(...)",
+      suggestAddImport: "Add {{symbol}} import from functype",
     },
   },
 
@@ -88,6 +93,24 @@ const rule: Rule.RuleModule = {
         const elementType = sourceCode.getText(node.elementType)
         const fullType = sourceCode.getText(node)
 
+        const suggest: Rule.SuggestionReportDescriptor[] = [
+          {
+            messageId: "suggestListType",
+            data: { type: elementType },
+            fix(fixer: Rule.RuleFixer) {
+              return fixer.replaceText(node, `List<${elementType}>`)
+            },
+          },
+        ]
+
+        if (!hasFunctypeSymbol(sourceCode, "List")) {
+          suggest.push({
+            messageId: "suggestAddImport",
+            data: { symbol: "List" },
+            fix: createImportFixer(sourceCode, "List"),
+          })
+        }
+
         context.report({
           node,
           messageId: "preferList",
@@ -95,6 +118,7 @@ const rule: Rule.RuleModule = {
             type: elementType,
             arrayType: fullType,
           },
+          suggest,
         })
       },
 
@@ -117,13 +141,34 @@ const rule: Rule.RuleModule = {
           // Skip if already readonly
           if (allowReadonlyArrays && fullType.startsWith("readonly")) return
 
+          const resolvedType = typeParam || "T"
+
+          const suggest: Rule.SuggestionReportDescriptor[] = [
+            {
+              messageId: "suggestListType",
+              data: { type: resolvedType },
+              fix(fixer: Rule.RuleFixer) {
+                return fixer.replaceText(node, `List<${resolvedType}>`)
+              },
+            },
+          ]
+
+          if (!hasFunctypeSymbol(sourceCode, "List")) {
+            suggest.push({
+              messageId: "suggestAddImport",
+              data: { symbol: "List" },
+              fix: createImportFixer(sourceCode, "List"),
+            })
+          }
+
           context.report({
             node,
             messageId: "preferList",
             data: {
-              type: typeParam || "T",
+              type: resolvedType,
               arrayType: fullType,
             },
+            suggest,
           })
         }
 
@@ -131,14 +176,34 @@ const rule: Rule.RuleModule = {
         if (typeName === "ReadonlyArray") {
           const typeParam = findTypeParameter(node, sourceCode)
           const fullType = sourceCode.getText(node)
+          const resolvedType = typeParam || "T"
+
+          const suggest: Rule.SuggestionReportDescriptor[] = [
+            {
+              messageId: "suggestListType",
+              data: { type: resolvedType },
+              fix(fixer: Rule.RuleFixer) {
+                return fixer.replaceText(node, `List<${resolvedType}>`)
+              },
+            },
+          ]
+
+          if (!hasFunctypeSymbol(sourceCode, "List")) {
+            suggest.push({
+              messageId: "suggestAddImport",
+              data: { symbol: "List" },
+              fix: createImportFixer(sourceCode, "List"),
+            })
+          }
 
           context.report({
             node,
             messageId: "preferList",
             data: {
-              type: typeParam || "T",
+              type: resolvedType,
               arrayType: fullType,
             },
+            suggest,
           })
         }
       },
@@ -196,9 +261,43 @@ const rule: Rule.RuleModule = {
 
         if (hasTypeAnnotation) return
 
+        // Check if any element is a SpreadElement — ambiguous semantics, skip suggestions
+        const hasSpread = node.elements.some((el) => el !== null && el.type === "SpreadElement")
+
+        if (hasSpread) {
+          context.report({
+            node,
+            messageId: "preferListLiteral",
+          })
+          return
+        }
+
+        const sourceCode = context.sourceCode
+        const elementTexts = node.elements
+          .filter((el) => el !== null)
+          .map((el) => sourceCode.getText(el))
+
+        const suggest: Rule.SuggestionReportDescriptor[] = [
+          {
+            messageId: "suggestListOf",
+            fix(fixer: Rule.RuleFixer) {
+              return fixer.replaceText(node, `List.of(${elementTexts.join(", ")})`)
+            },
+          },
+        ]
+
+        if (!hasFunctypeSymbol(sourceCode, "List")) {
+          suggest.push({
+            messageId: "suggestAddImport",
+            data: { symbol: "List" },
+            fix: createImportFixer(sourceCode, "List"),
+          })
+        }
+
         context.report({
           node,
           messageId: "preferListLiteral",
+          suggest,
         })
       },
     }

--- a/packages/eslint-plugin-functype/src/rules/prefer-map.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-map.ts
@@ -1,0 +1,185 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer .map() over manual transformations and imperative patterns",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          checkArrayMethods: {
+            type: "boolean",
+            default: true,
+          },
+          checkForLoops: {
+            type: "boolean",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferMapOverLoop: "Prefer .map() over for loop for transforming {{collection}}",
+      preferMapOverPush: "Prefer .map() over manual .push() in loop",
+      preferMapChain: "Consider using .map() for transformation instead of manual property access",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const checkArrayMethods = options.checkArrayMethods !== false
+    const checkForLoops = options.checkForLoops !== false
+
+    function isForEachToMapSafe(node: ASTNode): boolean {
+      // Only auto-fix simple forEach → map transformations on expressions that return values
+      // This is safe because both native arrays and functype Lists have these methods
+      if (
+        node.type !== "CallExpression" ||
+        node.callee.type !== "MemberExpression" ||
+        node.callee.property.name !== "forEach"
+      ) {
+        return false
+      }
+
+      // Check if the callback returns a value (simple property access pattern)
+      const callback = node.arguments[0]
+      if (callback && (callback.type === "ArrowFunctionExpression" || callback.type === "FunctionExpression")) {
+        const body = callback.body
+        // Simple property access in arrow function (e.g., item => item.name)
+        return body.type === "MemberExpression"
+      }
+      return false
+    }
+
+    function isTransformationLoop(node: ASTNode): boolean {
+      if (!node.body || node.body.type !== "BlockStatement") return false
+
+      const statements = node.body.body
+      if (statements.length === 0) return false
+
+      // Look for patterns like: newArray.push(transform(item))
+      return statements.some((stmt: ASTNode) => {
+        if (stmt.type === "ExpressionStatement" && stmt.expression.type === "CallExpression") {
+          const call = stmt.expression
+          return call.callee.type === "MemberExpression" && call.callee.property.name === "push"
+        }
+        return false
+      })
+    }
+
+    function isSimplePropertyAccess(node: ASTNode): boolean {
+      // Check for patterns like: items.forEach(item => console.log(item.name))
+      // These could often be: items.map(item => item.name)
+      if (
+        node.type === "CallExpression" &&
+        node.callee.type === "MemberExpression" &&
+        node.callee.property.name === "forEach"
+      ) {
+        const callback = node.arguments[0]
+        if (callback && (callback.type === "ArrowFunctionExpression" || callback.type === "FunctionExpression")) {
+          const body = callback.body
+          // Simple property access in arrow function
+          if (body.type === "MemberExpression") {
+            return true
+          }
+        }
+      }
+      return false
+    }
+
+    return {
+      ForStatement(node: ASTNode) {
+        if (!checkForLoops) return
+
+        if (isTransformationLoop(node)) {
+          context.report({
+            node,
+            messageId: "preferMapOverLoop",
+            data: { collection: "array" },
+          })
+        }
+      },
+
+      ForInStatement(node: ASTNode) {
+        if (!checkForLoops) return
+
+        if (isTransformationLoop(node)) {
+          context.report({
+            node,
+            messageId: "preferMapOverLoop",
+            data: { collection: "object" },
+          })
+        }
+      },
+
+      ForOfStatement(node: ASTNode) {
+        if (!checkForLoops) return
+
+        if (isTransformationLoop(node)) {
+          context.report({
+            node,
+            messageId: "preferMapOverLoop",
+            data: { collection: "iterable" },
+          })
+        }
+      },
+
+      CallExpression(node: ASTNode) {
+        if (!checkArrayMethods) return
+
+        // Check for forEach that could be map
+        if (node.callee.type === "MemberExpression" && node.callee.property.name === "forEach") {
+          if (isSimplePropertyAccess(node)) {
+            context.report({
+              node,
+              messageId: "preferMapChain",
+              fix(fixer) {
+                // Only auto-fix safe forEach → map transformations
+                if (!isForEachToMapSafe(node)) {
+                  return null
+                }
+
+                const sourceCode = context.sourceCode
+                const text = sourceCode.getText(node)
+
+                // Simple replacement: forEach -> map
+                const fixedText = text.replace(/\.forEach\s*\(/g, ".map(")
+                return fixer.replaceText(node, fixedText)
+              },
+            })
+          }
+        }
+
+        // Check for manual push patterns in callbacks
+        if (node.callee.type === "MemberExpression" && node.callee.property.name === "push") {
+          // Check if we're inside a forEach or similar iteration
+          let parent = node.parent
+          while (parent) {
+            if (
+              parent.type === "CallExpression" &&
+              parent.callee.type === "MemberExpression" &&
+              (parent.callee.property.name === "forEach" || parent.callee.property.name === "for")
+            ) {
+              context.report({
+                node,
+                messageId: "preferMapOverPush",
+              })
+              break
+            }
+            parent = parent.parent
+          }
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-option.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-option.ts
@@ -1,0 +1,83 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+import { getFunctypeImportsLegacy, isAlreadyUsingFunctype, isFunctypeType } from "../utils/functype-detection"
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer Option<T> over nullable types (T | null | undefined)",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowNullableIntersections: {
+            type: "boolean",
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferOption: "Prefer Option<{{type}}> over nullable type '{{nullable}}'",
+      preferOptionReturn: "Prefer Option<{{type}}> as return type over nullable '{{nullable}}'",
+    },
+  },
+
+  create(context) {
+    // const options = context.options[0] || {}
+    // Remove unused variable
+    // const _allowNullableIntersections = options.allowNullableIntersections || false
+
+    // Get functype imports if available (but still apply rule even without explicit import)
+    const functypeImports = getFunctypeImportsLegacy(context)
+
+    return {
+      TSUnionType(node: ASTNode) {
+        if (!node.types || node.types.length < 2) return
+
+        const hasNull = node.types.some(
+          (type: ASTNode) => type.type === "TSNullKeyword" || type.type === "TSUndefinedKeyword",
+        )
+
+        if (!hasNull) return
+
+        const nonNullTypes = node.types.filter(
+          (type: ASTNode) => type.type !== "TSNullKeyword" && type.type !== "TSUndefinedKeyword",
+        )
+
+        if (nonNullTypes.length === 1) {
+          const nonNullType = nonNullTypes[0]
+
+          // Skip if it's already an Option type or other functype type
+          if (isFunctypeType(nonNullType, functypeImports)) return
+
+          // Skip if we're already in a functype context
+          if (isAlreadyUsingFunctype(node, functypeImports)) return
+
+          const sourceCode = context.sourceCode
+          const nonNullTypeText = sourceCode.getText(nonNullType)
+          const fullType = sourceCode.getText(node)
+
+          // Skip if it's already an Option type (fallback check)
+          if (nonNullTypeText.startsWith("Option<")) return
+
+          context.report({
+            node,
+            messageId: "preferOption",
+            data: {
+              type: nonNullTypeText,
+              nullable: fullType,
+            },
+          })
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-functype/src/rules/prefer-option.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-option.ts
@@ -2,10 +2,12 @@ import type { Rule } from "eslint"
 
 import type { ASTNode } from "../types/ast"
 import { getFunctypeImportsLegacy, isAlreadyUsingFunctype, isFunctypeType } from "../utils/functype-detection"
+import { createImportFixer, hasFunctypeSymbol } from "../utils/import-fixer"
 
 const rule: Rule.RuleModule = {
   meta: {
     type: "suggestion",
+    hasSuggestions: true,
     docs: {
       description: "Prefer Option<T> over nullable types (T | null | undefined)",
       recommended: true,
@@ -25,6 +27,8 @@ const rule: Rule.RuleModule = {
     messages: {
       preferOption: "Prefer Option<{{type}}> over nullable type '{{nullable}}'",
       preferOptionReturn: "Prefer Option<{{type}}> as return type over nullable '{{nullable}}'",
+      suggestOptionType: "Replace with Option<{{type}}>",
+      suggestAddImport: "Add {{symbol}} import from functype",
     },
   },
 
@@ -66,6 +70,24 @@ const rule: Rule.RuleModule = {
           // Skip if it's already an Option type (fallback check)
           if (nonNullTypeText.startsWith("Option<")) return
 
+          const suggestions: Rule.SuggestionReportDescriptor[] = [
+            {
+              messageId: "suggestOptionType",
+              data: { type: nonNullTypeText },
+              fix(fixer) {
+                return fixer.replaceText(node, `Option<${nonNullTypeText}>`)
+              },
+            },
+          ]
+
+          if (!hasFunctypeSymbol(sourceCode, "Option")) {
+            suggestions.push({
+              messageId: "suggestAddImport",
+              data: { symbol: "Option" },
+              fix: createImportFixer(sourceCode, "Option"),
+            })
+          }
+
           context.report({
             node,
             messageId: "preferOption",
@@ -73,6 +95,7 @@ const rule: Rule.RuleModule = {
               type: nonNullTypeText,
               nullable: fullType,
             },
+            suggest: suggestions,
           })
         }
       },

--- a/packages/eslint-plugin-functype/src/types/ast.ts
+++ b/packages/eslint-plugin-functype/src/types/ast.ts
@@ -1,0 +1,9 @@
+/**
+ * ESLint AST Node type alias
+ *
+ * ESLint's AST node types are complex and not fully typed in the public API.
+ * Using `any` is the standard practice for ESLint rule development when working
+ * with AST nodes that need dynamic property access.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ASTNode = any

--- a/packages/eslint-plugin-functype/src/utils/dependency-validator.ts
+++ b/packages/eslint-plugin-functype/src/utils/dependency-validator.ts
@@ -1,0 +1,127 @@
+// Utility to validate peer dependencies and provide helpful error messages
+
+interface PeerDependency {
+  name: string
+  packageName: string
+  description: string
+  required: boolean
+}
+
+const PEER_DEPENDENCIES: PeerDependency[] = [
+  {
+    name: "@typescript-eslint/eslint-plugin",
+    packageName: "@typescript-eslint/eslint-plugin",
+    description: "TypeScript-aware ESLint rules",
+    required: true,
+  },
+  {
+    name: "@typescript-eslint/parser",
+    packageName: "@typescript-eslint/parser",
+    description: "TypeScript parser for ESLint",
+    required: true,
+  },
+  {
+    name: "eslint-plugin-functional",
+    packageName: "eslint-plugin-functional",
+    description: "Functional programming ESLint rules",
+    required: true,
+  },
+  {
+    name: "eslint-plugin-prettier",
+    packageName: "eslint-plugin-prettier",
+    description: "Code formatting rules",
+    required: false,
+  },
+  {
+    name: "eslint-plugin-simple-import-sort",
+    packageName: "eslint-plugin-simple-import-sort",
+    description: "Import sorting rules",
+    required: false,
+  },
+  {
+    name: "prettier",
+    packageName: "prettier",
+    description: "Code formatter",
+    required: false,
+  },
+]
+
+export interface ValidationResult {
+  isValid: boolean
+  missing: PeerDependency[]
+  available: PeerDependency[]
+  installCommand: string
+  warnings: string[]
+}
+
+function tryRequire(packageName: string): boolean {
+  try {
+    require.resolve(packageName)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function validatePeerDependencies(): ValidationResult {
+  const missing: PeerDependency[] = []
+  const available: PeerDependency[] = []
+  const warnings: string[] = []
+
+  for (const dep of PEER_DEPENDENCIES) {
+    if (tryRequire(dep.packageName)) {
+      available.push(dep)
+    } else {
+      missing.push(dep)
+      if (dep.required) {
+        // Required dependency is missing - this will cause errors
+      } else {
+        // Optional dependency is missing - add warning
+        warnings.push(`Optional plugin '${dep.name}' not found. Some rules will be skipped.`)
+      }
+    }
+  }
+
+  const requiredMissing = missing.filter((dep) => dep.required)
+  const isValid = requiredMissing.length === 0
+
+  // Generate install command for missing dependencies
+  const missingPackageNames = missing.map((dep) => dep.packageName)
+  const installCommand = missingPackageNames.length > 0 ? `pnpm add -D ${missingPackageNames.join(" ")}` : ""
+
+  return {
+    isValid,
+    missing,
+    available,
+    installCommand,
+    warnings,
+  }
+}
+
+export function createValidationError(result: ValidationResult): Error {
+  const requiredMissing = result.missing.filter((dep) => dep.required)
+
+  if (requiredMissing.length === 0) {
+    return new Error("No validation errors")
+  }
+
+  const missingList = requiredMissing.map((dep) => `  • ${dep.name} - ${dep.description}`).join("\n")
+
+  const message = [
+    "❌ Missing required peer dependencies for eslint-plugin-functype:",
+    "",
+    missingList,
+    "",
+    "📦 Install missing dependencies:",
+    `   ${result.installCommand}`,
+    "",
+    "📖 See installation guide: https://github.com/jordanburke/eslint-plugin-functype#installation",
+  ].join("\n")
+
+  return new Error(message)
+}
+
+export function shouldValidateDependencies(): boolean {
+  // Skip validation in test environments or when explicitly disabled
+  return process.env.NODE_ENV !== "test" && process.env.FUNCTYPE_SKIP_VALIDATION !== "true"
+}

--- a/packages/eslint-plugin-functype/src/utils/functype-detection.ts
+++ b/packages/eslint-plugin-functype/src/utils/functype-detection.ts
@@ -1,0 +1,304 @@
+import type { Rule } from "eslint"
+
+import type { ASTNode } from "../types/ast"
+
+/**
+ * Utility functions for detecting functype library usage in ESLint rules
+ */
+
+/**
+ * Check if functype library is imported in the current file
+ */
+export function hasFunctypeImport(context: Rule.RuleContext): boolean {
+  const sourceCode = context.sourceCode
+  const program = sourceCode.ast
+
+  // Look for import statements that import from 'functype'
+  for (const node of program.body) {
+    if (node.type === "ImportDeclaration" && node.source.type === "Literal" && node.source.value === "functype") {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Enhanced functype imports tracking
+ */
+export interface FunctypeImports {
+  types: Set<string> // Option, Either, List, etc.
+  functions: Set<string> // Do, DoAsync, $, etc.
+  all: Set<string> // Combined for compatibility
+}
+
+/**
+ * Get imported functype symbols from the current file
+ */
+export function getFunctypeImports(context: Rule.RuleContext): FunctypeImports {
+  const types = new Set<string>()
+  const functions = new Set<string>()
+  const all = new Set<string>()
+
+  const sourceCode = context.sourceCode
+  const program = sourceCode.ast
+
+  for (const node of program.body) {
+    if (node.type === "ImportDeclaration" && node.source.type === "Literal" && node.source.value === "functype") {
+      // Handle named imports: import { Option, Either, Do, $ } from 'functype'
+      if (node.specifiers) {
+        for (const spec of node.specifiers) {
+          if (spec.type === "ImportSpecifier" && spec.imported.type === "Identifier") {
+            const name = spec.imported.name
+            all.add(name)
+
+            // Categorize imports
+            if (["Option", "Either", "List", "LazyList", "Task", "Try"].includes(name)) {
+              types.add(name)
+            } else if (["Do", "DoAsync", "$"].includes(name)) {
+              functions.add(name)
+            } else {
+              // Other imports (constructors, utilities, etc.)
+              functions.add(name)
+            }
+          } else if (spec.type === "ImportDefaultSpecifier") {
+            all.add("default")
+            functions.add("default")
+          } else if (spec.type === "ImportNamespaceSpecifier") {
+            all.add("*")
+            types.add("*")
+            functions.add("*")
+          }
+        }
+      }
+    }
+  }
+
+  return { types, functions, all }
+}
+
+/**
+ * Legacy compatibility - returns the 'all' set
+ */
+export function getFunctypeImportsLegacy(context: Rule.RuleContext): Set<string> {
+  return getFunctypeImports(context).all
+}
+
+/**
+ * Check if a type reference is using functype types
+ */
+export function isFunctypeType(node: ASTNode, functypeImports: FunctypeImports | Set<string>): boolean {
+  if (!node) return false
+
+  // Handle both new and legacy API
+  const types = functypeImports instanceof Set ? functypeImports : functypeImports.types || functypeImports.all
+
+  // Check direct type names
+  if (node.type === "TSTypeReference" && node.typeName?.type === "Identifier") {
+    const typeName = node.typeName.name
+    return types.has(typeName) || ["Option", "Either", "List", "LazyList", "Task", "Try"].includes(typeName)
+  }
+
+  return false
+}
+
+/**
+ * Check if a call expression is using functype methods
+ */
+export function isFunctypeCall(node: ASTNode, functypeImports: Set<string>): boolean {
+  if (!node || node.type !== "CallExpression") return false
+
+  const callee = node.callee
+
+  // Check for static method calls like Option.some(), Either.left(), List.of()
+  if (callee.type === "MemberExpression" && callee.object.type === "Identifier") {
+    const objectName = callee.object.name
+    const methodName = callee.property?.name
+
+    // Check if calling methods on imported functype types
+    if (functypeImports.has(objectName)) return true
+
+    // Check for common functype patterns
+    if (
+      (objectName === "Option" && ["some", "none", "of"].includes(methodName)) ||
+      (objectName === "Either" && ["left", "right", "of"].includes(methodName)) ||
+      (objectName === "List" && ["of", "from", "empty"].includes(methodName))
+    ) {
+      return true
+    }
+  }
+
+  // Check for method calls on functype instances like someOption.map()
+  if (callee.type === "MemberExpression") {
+    const methodName = callee.property?.name
+
+    // Common functype methods
+    if (
+      [
+        "map",
+        "flatMap",
+        "filter",
+        "fold",
+        "foldLeft",
+        "foldRight",
+        "getOrElse",
+        "orElse",
+        "isEmpty",
+        "nonEmpty",
+        "isDefined",
+        "isSome",
+        "isNone",
+        "isLeft",
+        "isRight",
+        "toArray",
+      ].includes(methodName)
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Check if current context is already using functype patterns appropriately
+ */
+export function isAlreadyUsingFunctype(node: ASTNode, functypeImports: Set<string>): boolean {
+  let parent = node.parent
+
+  // Walk up the AST to find functype usage
+  while (parent) {
+    if (isFunctypeCall(parent as ASTNode, functypeImports) || isFunctypeType(parent as ASTNode, functypeImports)) {
+      return true
+    }
+    parent = parent.parent
+  }
+
+  return false
+}
+
+/**
+ * Check if a variable or parameter is typed with functype types
+ */
+export function hasFunctypeTypeAnnotation(node: ASTNode, functypeImports: FunctypeImports | Set<string>): boolean {
+  // Check for type annotation
+  if (node.typeAnnotation?.typeAnnotation) {
+    return isFunctypeType(node.typeAnnotation.typeAnnotation, functypeImports)
+  }
+
+  return false
+}
+
+/**
+ * Check if a call expression is a Do notation call
+ */
+export function isDoNotationCall(node: ASTNode, functypeImports: FunctypeImports): boolean {
+  if (!node || node.type !== "CallExpression") return false
+
+  const callee = node.callee
+
+  // Check for Do() or DoAsync() calls
+  if (callee.type === "Identifier") {
+    const name = callee.name
+    return functypeImports.functions.has(name) && ["Do", "DoAsync"].includes(name)
+  }
+
+  return false
+}
+
+/**
+ * Check if a call expression uses the $ helper function
+ */
+export function isDollarHelper(node: ASTNode, functypeImports: FunctypeImports): boolean {
+  if (!node || node.type !== "CallExpression") return false
+
+  const callee = node.callee
+
+  // Check for $() calls
+  if (callee.type === "Identifier" && callee.name === "$") {
+    return functypeImports.functions.has("$")
+  }
+
+  return false
+}
+
+/**
+ * Check if current expression is inside a Do notation block
+ */
+export function isInsideDoNotation(node: ASTNode, functypeImports: FunctypeImports): boolean {
+  let current = node.parent
+
+  while (current) {
+    if (current.type === "CallExpression" && isDoNotationCall(current as ASTNode, functypeImports)) {
+      return true
+    }
+    current = current.parent
+  }
+
+  return false
+}
+
+/**
+ * Check if a method call is a chained method call on functype types
+ */
+export function isChainedMethodCall(node: ASTNode, methodName: string): boolean {
+  if (!node || node.type !== "CallExpression") return false
+
+  const callee = node.callee
+
+  if (
+    callee.type === "MemberExpression" &&
+    callee.property.type === "Identifier" &&
+    callee.property.name === methodName
+  ) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Detect if code could benefit from Do notation
+ */
+export function shouldUseDoNotation(
+  node: ASTNode,
+  functypeImports: FunctypeImports,
+): {
+  shouldUse: boolean
+  reason: "nested-checks" | "chained-flatmaps" | "mixed-monads" | "async-chains" | null
+} {
+  // Already using Do notation
+  if (isInsideDoNotation(node, functypeImports)) {
+    return { shouldUse: false, reason: null }
+  }
+
+  // Check for nested null checks (a && a.b && a.b.c pattern)
+  if (node.type === "LogicalExpression" && node.operator === "&&") {
+    const text = node.toString ? node.toString() : ""
+    if (text.includes("&&") && text.match(/\w+(\.\w+){2,}/)) {
+      return { shouldUse: true, reason: "nested-checks" }
+    }
+  }
+
+  // Check for chained flatMap calls
+  if (isChainedMethodCall(node, "flatMap")) {
+    // Count chain depth
+    let depth = 0
+    let current = node
+
+    while (current && current.type === "CallExpression" && isChainedMethodCall(current, "flatMap")) {
+      depth++
+      if (current.callee.type === "MemberExpression") {
+        current = current.callee.object as ASTNode
+      } else {
+        break
+      }
+    }
+
+    if (depth >= 3) {
+      return { shouldUse: true, reason: "chained-flatmaps" }
+    }
+  }
+
+  return { shouldUse: false, reason: null }
+}

--- a/packages/eslint-plugin-functype/src/utils/functype-detection.ts
+++ b/packages/eslint-plugin-functype/src/utils/functype-detection.ts
@@ -53,7 +53,7 @@ export function getFunctypeImports(context: Rule.RuleContext): FunctypeImports {
             all.add(name)
 
             // Categorize imports
-            if (["Option", "Either", "List", "LazyList", "Task", "Try"].includes(name)) {
+            if (["Option", "Either", "List", "LazyList", "Task", "Try", "Map", "Set", "Stack"].includes(name)) {
               types.add(name)
             } else if (["Do", "DoAsync", "$"].includes(name)) {
               functions.add(name)
@@ -96,7 +96,7 @@ export function isFunctypeType(node: ASTNode, functypeImports: FunctypeImports |
   // Check direct type names
   if (node.type === "TSTypeReference" && node.typeName?.type === "Identifier") {
     const typeName = node.typeName.name
-    return types.has(typeName) || ["Option", "Either", "List", "LazyList", "Task", "Try"].includes(typeName)
+    return types.has(typeName) || ["Option", "Either", "List", "LazyList", "Task", "Try", "Map", "Set", "Stack"].includes(typeName)
   }
 
   return false
@@ -122,7 +122,9 @@ export function isFunctypeCall(node: ASTNode, functypeImports: Set<string>): boo
     if (
       (objectName === "Option" && ["some", "none", "of"].includes(methodName)) ||
       (objectName === "Either" && ["left", "right", "of"].includes(methodName)) ||
-      (objectName === "List" && ["of", "from", "empty"].includes(methodName))
+      (objectName === "List" && ["of", "from", "empty"].includes(methodName)) ||
+      (objectName === "Map" && ["of", "empty"].includes(methodName)) ||
+      (objectName === "Set" && ["of", "empty"].includes(methodName))
     ) {
       return true
     }

--- a/packages/eslint-plugin-functype/src/utils/functype-detection.ts
+++ b/packages/eslint-plugin-functype/src/utils/functype-detection.ts
@@ -96,7 +96,10 @@ export function isFunctypeType(node: ASTNode, functypeImports: FunctypeImports |
   // Check direct type names
   if (node.type === "TSTypeReference" && node.typeName?.type === "Identifier") {
     const typeName = node.typeName.name
-    return types.has(typeName) || ["Option", "Either", "List", "LazyList", "Task", "Try", "Map", "Set", "Stack"].includes(typeName)
+    return (
+      types.has(typeName) ||
+      ["Option", "Either", "List", "LazyList", "Task", "Try", "Map", "Set", "Stack"].includes(typeName)
+    )
   }
 
   return false

--- a/packages/eslint-plugin-functype/src/utils/import-fixer.ts
+++ b/packages/eslint-plugin-functype/src/utils/import-fixer.ts
@@ -14,7 +14,11 @@ export function hasFunctypeSymbol(sourceCode: SourceCode, symbolName: string): b
           if (spec.type === "ImportNamespaceSpecifier") {
             return true
           }
-          if (spec.type === "ImportSpecifier" && spec.imported.type === "Identifier" && spec.imported.name === symbolName) {
+          if (
+            spec.type === "ImportSpecifier" &&
+            spec.imported.type === "Identifier" &&
+            spec.imported.name === symbolName
+          ) {
             return true
           }
         }

--- a/packages/eslint-plugin-functype/src/utils/import-fixer.ts
+++ b/packages/eslint-plugin-functype/src/utils/import-fixer.ts
@@ -1,0 +1,97 @@
+import type { Rule } from "eslint"
+import type { SourceCode } from "eslint"
+
+/**
+ * Check if a given symbol is already imported from functype
+ */
+export function hasFunctypeSymbol(sourceCode: SourceCode, symbolName: string): boolean {
+  const program = sourceCode.ast
+
+  for (const node of program.body) {
+    if (node.type === "ImportDeclaration" && node.source.type === "Literal" && node.source.value === "functype") {
+      if (node.specifiers) {
+        for (const spec of node.specifiers) {
+          if (spec.type === "ImportNamespaceSpecifier") {
+            return true
+          }
+          if (spec.type === "ImportSpecifier" && spec.imported.type === "Identifier" && spec.imported.name === symbolName) {
+            return true
+          }
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * Create a fixer function that adds a symbol to the functype import.
+ * Returns a factory compatible with ESLint suggest[].fix signature.
+ */
+export function createImportFixer(
+  sourceCode: SourceCode,
+  symbolName: string,
+): (fixer: Rule.RuleFixer) => Rule.Fix | null {
+  return (fixer: Rule.RuleFixer): Rule.Fix | null => {
+    const program = sourceCode.ast
+
+    let existingFunctypeImport: (typeof program.body)[number] | null = null
+    let lastImportNode: (typeof program.body)[number] | null = null
+
+    for (const node of program.body) {
+      if (node.type === "ImportDeclaration") {
+        lastImportNode = node
+        if (node.source.type === "Literal" && node.source.value === "functype") {
+          existingFunctypeImport = node
+        }
+      }
+    }
+
+    // If already imported, nothing to do
+    if (hasFunctypeSymbol(sourceCode, symbolName)) {
+      return null
+    }
+
+    if (existingFunctypeImport && existingFunctypeImport.type === "ImportDeclaration") {
+      const importDecl = existingFunctypeImport
+
+      // Check for namespace import — can't add named imports alongside it
+      const hasNamespace = importDecl.specifiers?.some((s) => s.type === "ImportNamespaceSpecifier") ?? false
+      if (hasNamespace) {
+        return null
+      }
+
+      // Find the last named specifier and append after it
+      const specifiers = importDecl.specifiers ?? []
+      const namedSpecifiers = specifiers.filter((s) => s.type === "ImportSpecifier")
+
+      if (namedSpecifiers.length > 0) {
+        const lastSpecifier = namedSpecifiers[namedSpecifiers.length - 1]
+        if (lastSpecifier) {
+          return fixer.insertTextAfter(lastSpecifier, `, ${symbolName}`)
+        }
+      }
+
+      // No named specifiers yet — insert before closing brace
+      const importText = sourceCode.getText(importDecl)
+      const newText = importText.replace(/\{(\s*)\}/, `{ ${symbolName} }`)
+      return fixer.replaceText(importDecl, newText)
+    }
+
+    // No existing functype import — add a new one
+    const newImport = `import { ${symbolName} } from "functype"`
+
+    if (lastImportNode) {
+      return fixer.insertTextAfter(lastImportNode, `\n${newImport}`)
+    }
+
+    // No imports at all — insert at top of file
+    const firstNode = program.body[0]
+    if (firstNode) {
+      return fixer.insertTextBefore(firstNode, `${newImport}\n`)
+    }
+
+    return fixer.insertTextBeforeRange([0, 0], `${newImport}\n`)
+  }
+}

--- a/packages/eslint-plugin-functype/tests/rules/functype-integration.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/functype-integration.test.ts
@@ -1,0 +1,85 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import preferOption from "../../src/rules/prefer-option"
+import preferList from "../../src/rules/prefer-list"
+
+describe("functype-integration", () => {
+  describe("prefer-option with functype imports", () => {
+    ruleTester.run("prefer-option", preferOption, {
+      valid: [
+        // Should not flag when functype is imported and used properly
+        {
+          name: "Functype Option usage is not flagged",
+          code: `
+            import { Option, Some, None } from 'functype'
+            const maybeValue: Option<string> = Some("test")
+            const noValue: Option<string> = None
+          `,
+        },
+        // Already using Option types should not be flagged again
+        {
+          name: "Existing Option types are not flagged",
+          code: `
+            import { Option } from 'functype'
+            const value: Option<string> = Option.some("test")
+          `,
+        },
+      ],
+      invalid: [
+        // Should still flag nullable types when functype is imported but not used
+        {
+          name: "Still flags nullable types with functype import",
+          code: `
+            import { Option } from 'functype'
+            const value: string | null = null
+          `,
+          errors: [
+            {
+              messageId: "preferOption",
+              data: { type: "string", nullable: "string | null" },
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  describe("prefer-list with functype imports", () => {
+    ruleTester.run("prefer-list", preferList, {
+      valid: [
+        // Should not flag when List.from is used
+        {
+          name: "List.from usage is not flagged",
+          code: `
+            import { List } from 'functype'
+            const items = List.from([1, 2, 3])
+            const empty = List.empty<string>()
+          `,
+        },
+        // Should not flag arrays within List.of calls
+        {
+          name: "Arrays in List.of calls are not flagged",
+          code: `
+            import { List } from 'functype'
+            const matrix = List.from([[1, 2], [3, 4]])
+          `,
+        },
+      ],
+      invalid: [
+        // Should still flag array literals when functype is imported but List not used
+        {
+          name: "Still flags array literals with functype import",
+          code: `
+            import { Option } from 'functype'
+            const items = [1, 2, 3]
+          `,
+          errors: [
+            {
+              messageId: "preferListLiteral",
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/functype-integration.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/functype-integration.test.ts
@@ -37,6 +37,15 @@ describe("functype-integration", () => {
             {
               messageId: "preferOption",
               data: { type: "string", nullable: "string | null" },
+              suggestions: [
+                {
+                  messageId: "suggestOptionType",
+                  output: `
+            import { Option } from 'functype'
+            const value: Option<string> = null
+          `,
+                },
+              ],
             },
           ],
         },
@@ -76,6 +85,22 @@ describe("functype-integration", () => {
           errors: [
             {
               messageId: "preferListLiteral",
+              suggestions: [
+                {
+                  messageId: "suggestListOf",
+                  output: `
+            import { Option } from 'functype'
+            const items = List.of(1, 2, 3)
+          `,
+                },
+                {
+                  messageId: "suggestAddImport",
+                  output: `
+            import { Option, List } from 'functype'
+            const items = [1, 2, 3]
+          `,
+                },
+              ],
             },
           ],
         },

--- a/packages/eslint-plugin-functype/tests/rules/no-get-unsafe.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/no-get-unsafe.test.ts
@@ -1,0 +1,152 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/no-get-unsafe"
+
+describe("no-get-unsafe", () => {
+  ruleTester.run("no-get-unsafe", rule, {
+    valid: [
+      // Using safe methods
+      {
+        name: "Using fold() is allowed",
+        code: `
+          const result = option.fold(
+            () => "default",
+            (value) => value
+          )
+        `,
+      },
+      // Using getOrElse
+      {
+        name: "Using getOrElse() is allowed",
+        code: 'const value = option.getOrElse("default")',
+      },
+      // Using map
+      {
+        name: "Using map() is allowed",
+        code: "const mapped = option.map(x => x.toUpperCase())",
+      },
+      // Regular method calls
+      {
+        name: "Regular method calls are allowed",
+        code: "const result = obj.getData()",
+      },
+      // Non-monadic get calls
+      {
+        name: "Non-monadic get() calls are allowed",
+        code: 'const item = map.get("key")',
+      },
+    ],
+    invalid: [
+      // Unsafe get() call on Option
+      {
+        name: "get() call on Option should be avoided",
+        code: "const value = someOption.get()",
+        errors: [
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "get" },
+          },
+        ],
+        output: "const value = someOption.getOrElse(/* TODO: provide default value */)",
+      },
+      // Unsafe getOrThrow() call
+      {
+        name: "getOrThrow() call should be avoided",
+        code: "const value = either.getOrThrow()",
+        errors: [
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "getOrThrow" },
+          },
+        ],
+        output: "const value = either.getOrElse(/* TODO: provide default value */)",
+      },
+      // Unsafe unwrap() call
+      {
+        name: "unwrap() call should be avoided",
+        code: "const value = result.unwrap()",
+        errors: [
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "unwrap" },
+          },
+        ],
+        output: "const value = result.getOrElse(/* TODO: provide default value */)",
+      },
+      // Unsafe expect() call
+      {
+        name: "expect() call should be avoided",
+        code: 'const value = option.expect("Should have value")',
+        errors: [
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "expect" },
+          },
+        ],
+        output: "const value = option.getOrElse(/* TODO: provide default value */)",
+      },
+      // Chained method calls
+      {
+        name: "Chained unsafe calls should be detected",
+        code: 'const value = Some("test").map(x => x.toUpperCase()).get()',
+        errors: [
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "get" },
+          },
+        ],
+        output: 'const value = Some("test").map(x => x.toUpperCase()).getOrElse(/* TODO: provide default value */)',
+      },
+      // Method call in assignment
+      {
+        name: "Unsafe get in variable assignment",
+        code: `
+          function processOption(opt: Option<string>) {
+            const result = opt.get()
+            return result.toUpperCase()
+          }
+        `,
+        errors: [
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "get" },
+          },
+        ],
+        output: `
+          function processOption(opt: Option<string>) {
+            const result = opt.getOrElse(/* TODO: provide default value */)
+            return result.toUpperCase()
+          }
+        `,
+      },
+      // Multiple unsafe calls
+      {
+        name: "Multiple unsafe calls should all be flagged",
+        code: `
+          const value1 = option1.get()
+          const value2 = option2.getOrThrow()
+          const value3 = result.unwrap()
+        `,
+        errors: [
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "get" },
+          },
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "getOrThrow" },
+          },
+          {
+            messageId: "noUnsafeGet",
+            data: { method: "unwrap" },
+          },
+        ],
+        output: `
+          const value1 = option1.getOrElse(/* TODO: provide default value */)
+          const value2 = option2.getOrElse(/* TODO: provide default value */)
+          const value3 = result.getOrElse(/* TODO: provide default value */)
+        `,
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/no-imperative-loops.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/no-imperative-loops.test.ts
@@ -58,6 +58,17 @@ describe("no-imperative-loops", () => {
         errors: [
           {
             messageId: "noForInLoop",
+            suggestions: [
+              {
+                messageId: "suggestObjectKeys",
+                data: { object: "obj" },
+                output: `
+          Object.keys(obj).forEach((key) => {
+  console.log(obj[key])
+})
+        `,
+              },
+            ],
           },
         ],
       },
@@ -72,6 +83,17 @@ describe("no-imperative-loops", () => {
         errors: [
           {
             messageId: "noForOfLoop",
+            suggestions: [
+              {
+                messageId: "suggestForEach",
+                data: { iterable: "items" },
+                output: `
+          items.forEach((item) => {
+  console.log(item)
+})
+        `,
+              },
+            ],
           },
         ],
       },
@@ -129,11 +151,11 @@ describe("no-imperative-loops", () => {
           for (let i = 0; i < items.length; i++) {
             console.log(items[i])
           }
-          
+
           for (const item of otherItems) {
             process(item)
           }
-          
+
           while (condition) {
             doSomething()
           }
@@ -144,6 +166,25 @@ describe("no-imperative-loops", () => {
           },
           {
             messageId: "noForOfLoop",
+            suggestions: [
+              {
+                messageId: "suggestForEach",
+                data: { iterable: "otherItems" },
+                output: `
+          for (let i = 0; i < items.length; i++) {
+            console.log(items[i])
+          }
+
+          otherItems.forEach((item) => {
+  process(item)
+})
+
+          while (condition) {
+            doSomething()
+          }
+        `,
+              },
+            ],
           },
           {
             messageId: "noWhileLoop",
@@ -168,6 +209,66 @@ describe("no-imperative-loops", () => {
             messageId: "noForLoop",
           },
         ],
+      },
+      // Suggestion: simple for..of -> forEach
+      {
+        name: "Simple for..of should suggest forEach",
+        code: `for (const item of items) {
+  console.log(item)
+}`,
+        errors: [
+          {
+            messageId: "noForOfLoop",
+            suggestions: [
+              {
+                messageId: "suggestForEach",
+                data: { iterable: "items" },
+                output: `items.forEach((item) => {
+  console.log(item)
+})`,
+              },
+            ],
+          },
+        ],
+      },
+      // Suggestion: for..in -> Object.keys().forEach()
+      {
+        name: "for..in should suggest Object.keys().forEach()",
+        code: `for (const key in obj) {
+  console.log(key)
+}`,
+        errors: [
+          {
+            messageId: "noForInLoop",
+            suggestions: [
+              {
+                messageId: "suggestObjectKeys",
+                data: { object: "obj" },
+                output: `Object.keys(obj).forEach((key) => {
+  console.log(key)
+})`,
+              },
+            ],
+          },
+        ],
+      },
+      // No suggestion: for..of with push
+      {
+        name: "for..of with push should have no suggestion",
+        code: `for (const item of items) {\n  results.push(item)\n}`,
+        errors: [{ messageId: "noForOfLoop" }],
+      },
+      // No suggestion: for..of with destructuring
+      {
+        name: "for..of with destructuring should have no suggestion",
+        code: `for (const { x, y } of points) {\n  console.log(x, y)\n}`,
+        errors: [{ messageId: "noForOfLoop" }],
+      },
+      // No suggestion: for..of with multi-statement body
+      {
+        name: "Complex for..of body should have no suggestion",
+        code: `for (const item of items) {\n  if (item > 0) console.log(item)\n  doMore()\n}`,
+        errors: [{ messageId: "noForOfLoop" }],
       },
     ],
   })

--- a/packages/eslint-plugin-functype/tests/rules/no-imperative-loops.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/no-imperative-loops.test.ts
@@ -1,0 +1,174 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/no-imperative-loops"
+
+describe("no-imperative-loops", () => {
+  ruleTester.run("no-imperative-loops", rule, {
+    valid: [
+      // Using functional methods
+      {
+        name: "Using forEach is preferred",
+        code: "items.forEach(item => console.log(item))",
+      },
+      {
+        name: "Using map is preferred",
+        code: "const doubled = numbers.map(n => n * 2)",
+      },
+      {
+        name: "Using filter is preferred",
+        code: "const evens = numbers.filter(n => n % 2 === 0)",
+      },
+      {
+        name: "Using reduce is preferred",
+        code: "const sum = numbers.reduce((acc, n) => acc + n, 0)",
+      },
+      // Non-loop statements
+      {
+        name: "Non-loop statements are allowed",
+        code: `
+          function processData(data: string) {
+            return data.toUpperCase()
+          }
+        `,
+      },
+    ],
+    invalid: [
+      // Basic for loop
+      {
+        name: "For loop should use functional methods",
+        code: `
+          for (let i = 0; i < items.length; i++) {
+            console.log(items[i])
+          }
+        `,
+        errors: [
+          {
+            messageId: "noForLoop",
+          },
+        ],
+      },
+      // For...in loop
+      {
+        name: "For...in loop should use functional methods",
+        code: `
+          for (const key in obj) {
+            console.log(obj[key])
+          }
+        `,
+        errors: [
+          {
+            messageId: "noForInLoop",
+          },
+        ],
+      },
+      // For...of loop
+      {
+        name: "For...of loop should use functional methods",
+        code: `
+          for (const item of items) {
+            console.log(item)
+          }
+        `,
+        errors: [
+          {
+            messageId: "noForOfLoop",
+          },
+        ],
+      },
+      // While loop
+      {
+        name: "While loop should use functional methods",
+        code: `
+          let i = 0
+          while (i < items.length) {
+            console.log(items[i])
+            i++
+          }
+        `,
+        errors: [
+          {
+            messageId: "noWhileLoop",
+          },
+        ],
+      },
+      // Do...while loop
+      {
+        name: "Do...while loop should use functional methods",
+        code: `
+          let i = 0
+          do {
+            console.log(items[i])
+            i++
+          } while (i < items.length)
+        `,
+        errors: [
+          {
+            messageId: "noDoWhileLoop",
+          },
+        ],
+      },
+      // For loop with array.push (transformation pattern)
+      {
+        name: "For loop with push should use map",
+        code: `
+          const results = []
+          for (let i = 0; i < items.length; i++) {
+            results.push(items[i].toUpperCase())
+          }
+        `,
+        errors: [
+          {
+            messageId: "noForLoop",
+          },
+        ],
+      },
+      // Multiple loops
+      {
+        name: "Multiple loops should all be flagged",
+        code: `
+          for (let i = 0; i < items.length; i++) {
+            console.log(items[i])
+          }
+          
+          for (const item of otherItems) {
+            process(item)
+          }
+          
+          while (condition) {
+            doSomething()
+          }
+        `,
+        errors: [
+          {
+            messageId: "noForLoop",
+          },
+          {
+            messageId: "noForOfLoop",
+          },
+          {
+            messageId: "noWhileLoop",
+          },
+        ],
+      },
+      // Nested loops
+      {
+        name: "Nested loops should be flagged",
+        code: `
+          for (let i = 0; i < matrix.length; i++) {
+            for (let j = 0; j < matrix[i].length; j++) {
+              console.log(matrix[i][j])
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: "noForLoop",
+          },
+          {
+            messageId: "noForLoop",
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/no-let.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/no-let.test.ts
@@ -1,0 +1,56 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/no-let"
+
+describe("no-let", () => {
+  ruleTester.run("no-let", rule, {
+    valid: [
+      {
+        name: "const is allowed",
+        code: "const x = 1",
+      },
+      {
+        name: "const destructuring is allowed",
+        code: "const { a, b } = obj",
+      },
+      {
+        name: "for-of with const is allowed",
+        code: "for (const item of items) { console.log(item) }",
+      },
+    ],
+    invalid: [
+      {
+        name: "let without reassignment should autofix to const",
+        code: "let x = 1",
+        errors: [{ messageId: "noLet" }],
+        output: "const x = 1",
+      },
+      {
+        name: "let with reassignment should warn without autofix",
+        code: "let x = 1; x = 2",
+        errors: [{ messageId: "noLet", suggestions: [{ messageId: "suggestConst", output: "const x = 1; x = 2" }] }],
+        output: null,
+      },
+      {
+        name: "let declared then assigned should warn without autofix",
+        code: "let x; x = getValue()",
+        errors: [{ messageId: "noLet", suggestions: [{ messageId: "suggestConst", output: "const x; x = getValue()" }] }],
+        output: null,
+      },
+      {
+        name: "let with multiple declarators without reassignment should autofix",
+        code: "let x = 1, y = 2",
+        errors: [{ messageId: "noLet" }],
+        output: "const x = 1, y = 2",
+      },
+      {
+        name: "for loop with increment should warn without autofix",
+        code: "for (let i = 0; i < 10; i++) { console.log(i) }",
+        errors: [
+          { messageId: "noLet", suggestions: [{ messageId: "suggestConst", output: "for (const i = 0; i < 10; i++) { console.log(i) }" }] },
+        ],
+        output: null,
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/no-let.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/no-let.test.ts
@@ -34,7 +34,9 @@ describe("no-let", () => {
       {
         name: "let declared then assigned should warn without autofix",
         code: "let x; x = getValue()",
-        errors: [{ messageId: "noLet", suggestions: [{ messageId: "suggestConst", output: "const x; x = getValue()" }] }],
+        errors: [
+          { messageId: "noLet", suggestions: [{ messageId: "suggestConst", output: "const x; x = getValue()" }] },
+        ],
         output: null,
       },
       {
@@ -47,7 +49,10 @@ describe("no-let", () => {
         name: "for loop with increment should warn without autofix",
         code: "for (let i = 0; i < 10; i++) { console.log(i) }",
         errors: [
-          { messageId: "noLet", suggestions: [{ messageId: "suggestConst", output: "for (const i = 0; i < 10; i++) { console.log(i) }" }] },
+          {
+            messageId: "noLet",
+            suggestions: [{ messageId: "suggestConst", output: "for (const i = 0; i < 10; i++) { console.log(i) }" }],
+          },
         ],
         output: null,
       },

--- a/packages/eslint-plugin-functype/tests/rules/prefer-do-notation.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-do-notation.test.ts
@@ -1,0 +1,104 @@
+import { describe } from "vitest"
+import { VisualRuleTester, showTransformations } from "../utils/visual-rule-tester"
+import rule from "../../src/rules/prefer-do-notation"
+
+describe("prefer-do-notation", () => {
+  VisualRuleTester.run(
+    "prefer-do-notation",
+    rule,
+    {
+      valid: [
+        // Already using Do notation
+        {
+          name: "Do notation is allowed",
+          code: `
+          import { Do, Option, $ } from 'functype'
+          const result = Do(function* () {
+            const x = yield* $(Option(user))
+            const y = yield* $(Option(x.address))
+            return y.city
+          })
+        `,
+        },
+        // Simple property access without nesting
+        {
+          name: "Simple property access is allowed",
+          code: "const city = user.address.city",
+        },
+        // Single flatMap calls
+        {
+          name: "Single flatMap is allowed",
+          code: "const result = option.flatMap(x => processValue(x))",
+        },
+      ],
+      invalid: showTransformations([
+        // Nested null checks
+        {
+          name: "Nested null checks should use Do notation",
+          code: "const city = user && user.address && user.address.city && user.address.city.name",
+          errors: [
+            {
+              messageId: "preferDoForNestedChecks",
+            },
+            {
+              messageId: "preferDoForNestedChecks",
+            },
+          ],
+        },
+        // Multiple chained flatMaps
+        {
+          name: "Chained flatMap calls should use Do notation",
+          code: `
+          const result = option1
+            .flatMap(x => getOption2(x))
+            .flatMap(y => getOption3(y))
+            .flatMap(z => getOption4(z))
+            .flatMap(w => getOption5(w))
+        `,
+          errors: [
+            {
+              messageId: "preferDoForChainedMethods",
+              data: { count: "4" },
+            },
+            {
+              messageId: "preferDoForChainedMethods",
+              data: { count: "3" },
+            },
+          ],
+        },
+        // Real-world user data access example
+        {
+          name: "Real-world nested user data access",
+          code: `
+          function getUserCity(user) {
+            return user && user.profile && user.profile.address && user.profile.address.city
+          }
+        `,
+          errors: [
+            {
+              messageId: "preferDoForNestedChecks",
+            },
+            {
+              messageId: "preferDoForNestedChecks",
+            },
+          ],
+        },
+        // Mixed monad types
+        {
+          name: "Mixed Option and Either operations",
+          code: `
+          const result = option
+            .flatMap(x => Either.right(x))
+            .flatMap(y => Try(() => process(y)))
+        `,
+          errors: [
+            {
+              messageId: "preferDoForMixedMonads",
+            },
+          ],
+        },
+      ]),
+    },
+    { showAll: true },
+  )
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-do-notation.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-do-notation.test.ts
@@ -30,6 +30,30 @@ describe("prefer-do-notation", () => {
           name: "Single flatMap is allowed",
           code: "const result = option.flatMap(x => processValue(x))",
         },
+        // Two flatMap chain (below default minChainDepth: 3)
+        {
+          name: "Two flatMap chain is below threshold",
+          code: `
+          const result = option
+            .flatMap(x => getOption2(x))
+            .flatMap(y => getOption3(y))
+        `,
+        },
+        // Single && with property access (below depth 2)
+        {
+          name: "Single && with property access is allowed",
+          code: "const city = user && user.address",
+        },
+        // Mixed monads allowed when detectMixedMonads is false
+        {
+          name: "Mixed monads allowed when detection is disabled",
+          code: `
+          const result = option
+            .flatMap(x => Either.right(x))
+            .flatMap(y => Try(() => process(y)))
+        `,
+          options: [{ detectMixedMonads: false }],
+        },
       ],
       invalid: showTransformations([
         // Nested null checks
@@ -94,6 +118,52 @@ describe("prefer-do-notation", () => {
           errors: [
             {
               messageId: "preferDoForMixedMonads",
+            },
+          ],
+        },
+        // Custom minChainDepth: 2 triggers on shorter chains
+        {
+          name: "Custom minChainDepth triggers on shorter chains",
+          code: `
+          const result = option
+            .flatMap(x => getOption2(x))
+            .flatMap(y => getOption3(y))
+            .flatMap(z => getOption4(z))
+        `,
+          options: [{ minChainDepth: 2 }],
+          errors: [
+            {
+              messageId: "preferDoForChainedMethods",
+              data: { count: "3" },
+            },
+          ],
+        },
+        // Mixed monads with Option + Try
+        {
+          name: "Mixed Option and Try operations",
+          code: `
+          const result = Option.of(value)
+            .flatMap(x => Try(() => riskyOp(x)))
+        `,
+          errors: [
+            {
+              messageId: "preferDoForMixedMonads",
+            },
+          ],
+        },
+        // Deeply nested && chain (4+ levels)
+        {
+          name: "Deeply nested && chain with property access",
+          code: "const x = a && a.b && a.b.c && a.b.c.d && a.b.c.d.e",
+          errors: [
+            {
+              messageId: "preferDoForNestedChecks",
+            },
+            {
+              messageId: "preferDoForNestedChecks",
+            },
+            {
+              messageId: "preferDoForNestedChecks",
             },
           ],
         },

--- a/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
@@ -37,6 +37,35 @@ describe("prefer-either", () => {
           }
         `,
       },
+      // Rethrowing after multiple statements in catch
+      {
+        name: "Rethrowing after logging and cleanup is allowed",
+        code: `
+          function handleWithCleanup() {
+            try {
+              riskyOperation()
+            } catch (error) {
+              cleanup()
+              logError(error)
+              notifyAdmin(error)
+              throw error
+            }
+          }
+        `,
+      },
+      // Function already returning Either should not trigger preferEitherReturn
+      {
+        name: "Function returning Either with internal throw is allowed",
+        code: `
+          function safeParse(json: string): Either<Error, object> {
+            try {
+              return Either.right(JSON.parse(json))
+            } catch (error) {
+              throw error
+            }
+          }
+        `,
+      },
     ],
     invalid: [
       // Try/catch block
@@ -105,7 +134,7 @@ describe("prefer-either", () => {
             } catch (e1) {
               console.error(e1)
             }
-            
+
             try {
               secondOperation()
             } catch (e2) {
@@ -119,6 +148,117 @@ describe("prefer-either", () => {
           },
           {
             messageId: "preferEitherOverTryCatch",
+          },
+        ],
+      },
+      // try/catch with empty catch block
+      {
+        name: "Empty catch block should use Either",
+        code: `
+          function silentParse(json: string) {
+            try {
+              return JSON.parse(json)
+            } catch (e) {
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherOverTryCatch",
+          },
+        ],
+      },
+      // Nested try/catch
+      {
+        name: "Nested try/catch should use Either",
+        code: `
+          function nestedOps() {
+            try {
+              try {
+                riskyOperation()
+              } catch (inner) {
+                fallback()
+              }
+            } catch (outer) {
+              console.error(outer)
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherOverTryCatch",
+          },
+          {
+            messageId: "preferEitherOverTryCatch",
+          },
+        ],
+      },
+      // Function with throw and complex return type
+      {
+        name: "Function with throw and complex return type should return Either",
+        code: `
+          function fetchData(url: string): Promise<Array<Record<string, unknown>>> {
+            if (!url) {
+              throw new Error('URL required')
+            }
+            return fetch(url).then(r => r.json())
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherReturn",
+            data: { type: "Promise<Array<Record<string, unknown>>>" },
+          },
+          {
+            messageId: "preferEitherOverThrow",
+          },
+        ],
+      },
+      // Arrow function with throw and return type
+      {
+        name: "Arrow function with throw should suggest Either return",
+        code: `
+          const divide = (a: number, b: number): number => {
+            if (b === 0) {
+              throw new Error('Division by zero')
+            }
+            return a / b
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherReturn",
+            data: { type: "number" },
+          },
+          {
+            messageId: "preferEitherOverThrow",
+          },
+        ],
+      },
+      // Multiple throws in same function
+      {
+        name: "Multiple throw statements should each report",
+        code: `
+          function validate(input: string): string {
+            if (!input) {
+              throw new Error('Input required')
+            }
+            if (input.length > 100) {
+              throw new Error('Input too long')
+            }
+            return input.trim()
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherReturn",
+            data: { type: "string" },
+          },
+          {
+            messageId: "preferEitherOverThrow",
+          },
+          {
+            messageId: "preferEitherOverThrow",
           },
         ],
       },

--- a/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
@@ -1,0 +1,127 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-either"
+
+describe("prefer-either", () => {
+  ruleTester.run("prefer-either", rule, {
+    valid: [
+      // Using Either instead of try/catch
+      {
+        name: "Using Either is allowed",
+        code: `
+          function safeParse(json: string): Either<Error, object> {
+            return Either.right(JSON.parse(json))
+          }
+        `,
+      },
+      // No error handling
+      {
+        name: "Functions without error handling are allowed",
+        code: `
+          function add(a: number, b: number): number {
+            return a + b
+          }
+        `,
+      },
+      // Rethrowing in catch blocks (common pattern)
+      {
+        name: "Rethrowing in catch blocks is allowed",
+        code: `
+          function handleError() {
+            try {
+              riskyOperation()
+            } catch (error) {
+              console.error('Error occurred:', error)
+              throw error  // Re-throwing is allowed
+            }
+          }
+        `,
+      },
+    ],
+    invalid: [
+      // Try/catch block
+      {
+        name: "Try/catch should use Either",
+        code: `
+          function parseJson(json: string) {
+            try {
+              return JSON.parse(json)
+            } catch (error) {
+              return null
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherOverTryCatch",
+          },
+        ],
+      },
+      // Throw statement
+      {
+        name: "Throw statement should use Either.left",
+        code: `
+          function validateAge(age: number) {
+            if (age < 0) {
+              throw new Error('Age cannot be negative')
+            }
+            return age
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherOverThrow",
+          },
+        ],
+      },
+      // Function with throw and no Either return type
+      {
+        name: "Function with throw should return Either",
+        code: `
+          function divide(a: number, b: number): number {
+            if (b === 0) {
+              throw new Error('Division by zero')
+            }
+            return a / b
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherReturn",
+            data: { type: "number" },
+          },
+          {
+            messageId: "preferEitherOverThrow",
+          },
+        ],
+      },
+      // Multiple try/catch blocks
+      {
+        name: "Multiple try/catch blocks should use Either",
+        code: `
+          function complexOperation() {
+            try {
+              firstOperation()
+            } catch (e1) {
+              console.error(e1)
+            }
+            
+            try {
+              secondOperation()
+            } catch (e2) {
+              console.error(e2)
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferEitherOverTryCatch",
+          },
+          {
+            messageId: "preferEitherOverTryCatch",
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
@@ -151,7 +151,7 @@ describe("prefer-either", () => {
           },
         ],
       },
-      // try/catch with empty catch block
+      // try/catch with empty catch block — simple try + empty catch triggers suggestions
       {
         name: "Empty catch block should use Either",
         code: `
@@ -165,6 +165,29 @@ describe("prefer-either", () => {
         errors: [
           {
             messageId: "preferEitherOverTryCatch",
+            suggestions: [
+              {
+                messageId: "suggestTry",
+                output: `
+          function silentParse(json: string) {
+            return Try(() => JSON.parse(json))
+          }
+        `,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Try" },
+                output: `
+          import { Try } from "functype"
+function silentParse(json: string) {
+            try {
+              return JSON.parse(json)
+            } catch (e) {
+            }
+          }
+        `,
+              },
+            ],
           },
         ],
       },
@@ -211,6 +234,32 @@ describe("prefer-either", () => {
           },
           {
             messageId: "preferEitherOverThrow",
+            suggestions: [
+              {
+                messageId: "suggestEitherLeft",
+                output: `
+          function fetchData(url: string): Promise<Array<Record<string, unknown>>> {
+            if (!url) {
+              return Either.left(new Error('URL required'))
+            }
+            return fetch(url).then(r => r.json())
+          }
+        `,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Either" },
+                output: `
+          import { Either } from "functype"
+function fetchData(url: string): Promise<Array<Record<string, unknown>>> {
+            if (!url) {
+              throw new Error('URL required')
+            }
+            return fetch(url).then(r => r.json())
+          }
+        `,
+              },
+            ],
           },
         ],
       },
@@ -232,6 +281,32 @@ describe("prefer-either", () => {
           },
           {
             messageId: "preferEitherOverThrow",
+            suggestions: [
+              {
+                messageId: "suggestEitherLeft",
+                output: `
+          const divide = (a: number, b: number): number => {
+            if (b === 0) {
+              return Either.left(new Error('Division by zero'))
+            }
+            return a / b
+          }
+        `,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Either" },
+                output: `
+          import { Either } from "functype"
+const divide = (a: number, b: number): number => {
+            if (b === 0) {
+              throw new Error('Division by zero')
+            }
+            return a / b
+          }
+        `,
+              },
+            ],
           },
         ],
       },
@@ -256,9 +331,73 @@ describe("prefer-either", () => {
           },
           {
             messageId: "preferEitherOverThrow",
+            suggestions: [
+              {
+                messageId: "suggestEitherLeft",
+                output: `
+          function validate(input: string): string {
+            if (!input) {
+              return Either.left(new Error('Input required'))
+            }
+            if (input.length > 100) {
+              throw new Error('Input too long')
+            }
+            return input.trim()
+          }
+        `,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Either" },
+                output: `
+          import { Either } from "functype"
+function validate(input: string): string {
+            if (!input) {
+              throw new Error('Input required')
+            }
+            if (input.length > 100) {
+              throw new Error('Input too long')
+            }
+            return input.trim()
+          }
+        `,
+              },
+            ],
           },
           {
             messageId: "preferEitherOverThrow",
+            suggestions: [
+              {
+                messageId: "suggestEitherLeft",
+                output: `
+          function validate(input: string): string {
+            if (!input) {
+              throw new Error('Input required')
+            }
+            if (input.length > 100) {
+              return Either.left(new Error('Input too long'))
+            }
+            return input.trim()
+          }
+        `,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Either" },
+                output: `
+          import { Either } from "functype"
+function validate(input: string): string {
+            if (!input) {
+              throw new Error('Input required')
+            }
+            if (input.length > 100) {
+              throw new Error('Input too long')
+            }
+            return input.trim()
+          }
+        `,
+              },
+            ],
           },
         ],
       },

--- a/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-either.test.ts
@@ -68,18 +68,10 @@ describe("prefer-either", () => {
       },
     ],
     invalid: [
-      // Try/catch block
+      // Try/catch block with multi-stmt catch — no suggestion (catch has 2 stmts, isSimpleCatch=false)
       {
         name: "Try/catch should use Either",
-        code: `
-          function parseJson(json: string) {
-            try {
-              return JSON.parse(json)
-            } catch (error) {
-              return null
-            }
-          }
-        `,
+        code: `function parseJson(json: string) { try { return JSON.parse(json) } catch (error) { console.error(error); return null } }`,
         errors: [
           {
             messageId: "preferEitherOverTryCatch",
@@ -89,31 +81,28 @@ describe("prefer-either", () => {
       // Throw statement
       {
         name: "Throw statement should use Either.left",
-        code: `
-          function validateAge(age: number) {
-            if (age < 0) {
-              throw new Error('Age cannot be negative')
-            }
-            return age
-          }
-        `,
+        code: `function validateAge(age: number) { if (age < 0) { throw new Error('Age cannot be negative') } return age }`,
         errors: [
           {
             messageId: "preferEitherOverThrow",
+            suggestions: [
+              {
+                messageId: "suggestEitherLeft",
+                output: `function validateAge(age: number) { if (age < 0) { return Either.left(new Error('Age cannot be negative')) } return age }`,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Either" },
+                output: `import { Either } from "functype"\nfunction validateAge(age: number) { if (age < 0) { throw new Error('Age cannot be negative') } return age }`,
+              },
+            ],
           },
         ],
       },
       // Function with throw and no Either return type
       {
         name: "Function with throw should return Either",
-        code: `
-          function divide(a: number, b: number): number {
-            if (b === 0) {
-              throw new Error('Division by zero')
-            }
-            return a / b
-          }
-        `,
+        code: `function divide(a: number, b: number): number { if (b === 0) { throw new Error('Division by zero') } return a / b }`,
         errors: [
           {
             messageId: "preferEitherReturn",
@@ -121,10 +110,21 @@ describe("prefer-either", () => {
           },
           {
             messageId: "preferEitherOverThrow",
+            suggestions: [
+              {
+                messageId: "suggestEitherLeft",
+                output: `function divide(a: number, b: number): number { if (b === 0) { return Either.left(new Error('Division by zero')) } return a / b }`,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Either" },
+                output: `import { Either } from "functype"\nfunction divide(a: number, b: number): number { if (b === 0) { throw new Error('Division by zero') } return a / b }`,
+              },
+            ],
           },
         ],
       },
-      // Multiple try/catch blocks
+      // Multiple try/catch blocks — each has single-stmt expression body (non-return), so no suggestion
       {
         name: "Multiple try/catch blocks should use Either",
         code: `
@@ -261,6 +261,81 @@ describe("prefer-either", () => {
             messageId: "preferEitherOverThrow",
           },
         ],
+      },
+      // Simple try/catch with empty catch -> Try() suggestion
+      {
+        name: "Simple try/catch with empty catch should suggest Try()",
+        code: `function parse(json: string) {
+  try {
+    return JSON.parse(json)
+  } catch (e) {}
+}`,
+        errors: [
+          {
+            messageId: "preferEitherOverTryCatch",
+            suggestions: [
+              {
+                messageId: "suggestTry",
+                output: `function parse(json: string) {
+  return Try(() => JSON.parse(json))
+}`,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Try" },
+                output: `import { Try } from "functype"
+function parse(json: string) {
+  try {
+    return JSON.parse(json)
+  } catch (e) {}
+}`,
+              },
+            ],
+          },
+        ],
+      },
+      // throw in function body -> Either.left()
+      {
+        name: "throw in function body should suggest Either.left()",
+        code: `function validate(x: number) {
+  if (x < 0) {
+    throw new Error("negative")
+  }
+  return x
+}`,
+        errors: [
+          {
+            messageId: "preferEitherOverThrow",
+            suggestions: [
+              {
+                messageId: "suggestEitherLeft",
+                output: `function validate(x: number) {
+  if (x < 0) {
+    return Either.left(new Error("negative"))
+  }
+  return x
+}`,
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Either" },
+                output: `import { Either } from "functype"
+function validate(x: number) {
+  if (x < 0) {
+    throw new Error("negative")
+  }
+  return x
+}`,
+              },
+            ],
+          },
+        ],
+      },
+      // Multi-statement try body -> no suggestion
+      {
+        name: "Multi-statement try body should have no suggestion",
+        code: `function f() { try { const a = 1; return a } catch (e) { return null } }`,
+        errors: [{ messageId: "preferEitherOverTryCatch" }],
       },
     ],
   })

--- a/packages/eslint-plugin-functype/tests/rules/prefer-flatmap.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-flatmap.test.ts
@@ -1,0 +1,149 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-flatmap"
+
+describe("prefer-flatmap", () => {
+  ruleTester.run("prefer-flatmap", rule, {
+    valid: [
+      // Using flatMap
+      {
+        name: "Using flatMap is preferred",
+        code: "const result = items.flatMap(item => item.tags)",
+      },
+      // Using map without flat
+      {
+        name: "Using map without flat is allowed",
+        code: "const doubled = numbers.map(n => n * 2)",
+      },
+      // Using flat without preceding map
+      {
+        name: "Using flat alone is allowed",
+        code: "const flattened = nestedArrays.flat()",
+      },
+      // Other functional methods
+      {
+        name: "Other functional methods are allowed",
+        code: "const filtered = items.filter(item => item.active)",
+      },
+    ],
+    invalid: [
+      // map().flat() pattern
+      {
+        name: "map().flat() should use flatMap",
+        code: "const result = items.map(item => item.children).flat()",
+        errors: [
+          {
+            messageId: "preferFlatMapOverMapFlat",
+          },
+        ],
+        output: "const result = items.flatMap(item => item.children)",
+      },
+      // map().flat() with more complex transformation
+      {
+        name: "Complex map().flat() should use flatMap",
+        code: `
+          const tags = posts
+            .map(post => post.tags.filter(tag => tag.active))
+            .flat()
+        `,
+        errors: [
+          {
+            messageId: "preferFlatMapOverMapFlat",
+          },
+        ],
+        output: `
+          const tags = posts
+            .flatMap(post => post.tags.filter(tag => tag.active))
+        `,
+      },
+      // Nested map returning arrays
+      {
+        name: "Map returning arrays should consider flatMap",
+        code: `
+          const result = items.map(item => {
+            return item.values.map(v => v * 2)
+          })
+        `,
+        errors: [
+          {
+            messageId: "preferFlatMapNested",
+          },
+        ],
+      },
+      // Map with array return in arrow function
+      {
+        name: "Map with array literal return should consider flatMap",
+        code: "const pairs = items.map(item => [item.id, item.name])",
+        errors: [
+          {
+            messageId: "preferFlatMapNested",
+          },
+        ],
+      },
+      // Chained maps where first returns arrays
+      {
+        name: "Chained maps with array-returning first map",
+        code: `
+          const result = data
+            .map(item => item.split(','))
+            .map(parts => parts.map(p => p.trim()))
+        `,
+        errors: [
+          {
+            messageId: "preferFlatMapChain",
+          },
+        ],
+      },
+      // Multiple map().flat() patterns
+      {
+        name: "Multiple map().flat() patterns should all be flagged",
+        code: `
+          const result1 = items.map(i => i.children).flat()
+          const result2 = data.map(d => d.tags).flat()
+        `,
+        errors: [
+          {
+            messageId: "preferFlatMapOverMapFlat",
+          },
+          {
+            messageId: "preferFlatMapOverMapFlat",
+          },
+        ],
+        output: `
+          const result1 = items.flatMap(i => i.children)
+          const result2 = data.flatMap(d => d.tags)
+        `,
+      },
+      // Map returning method calls that return arrays
+      {
+        name: "Map returning array-returning method calls",
+        code: `
+          const words = sentences.map(sentence => sentence.split(' '))
+        `,
+        errors: [
+          {
+            messageId: "preferFlatMapNested",
+          },
+        ],
+      },
+      // Complex nested transformation
+      {
+        name: "Complex nested array transformation",
+        code: `
+          const result = users.map(user => {
+            return user.posts.map(post => ({
+              userId: user.id,
+              postTitle: post.title,
+              tags: post.tags
+            }))
+          })
+        `,
+        errors: [
+          {
+            messageId: "preferFlatMapNested",
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-fold.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-fold.test.ts
@@ -1,0 +1,137 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-fold"
+
+describe("prefer-fold", () => {
+  ruleTester.run("prefer-fold", rule, {
+    valid: [
+      // Using fold
+      {
+        name: "Using fold() is preferred",
+        code: `
+          const result = option.fold(
+            () => "empty",
+            (value) => value.toUpperCase()
+          )
+        `,
+      },
+      // Simple if without monadic checks
+      {
+        name: "Simple if statements are allowed",
+        code: `
+          if (x > 5) {
+            console.log("greater")
+          }
+        `,
+      },
+      // Single if statement with monadic check (below complexity threshold)
+      {
+        name: "Single if with monadic check is allowed with low complexity",
+        code: `
+          if (option.isSome()) {
+            console.log(option.get())
+          }
+        `,
+        options: [{ minComplexity: 3 }],
+      },
+    ],
+    invalid: [
+      // If/else chain with isSome check
+      {
+        name: "If/else with isSome should use fold",
+        code: `
+          if (option.isSome()) {
+            return option.get()
+          } else {
+            return "default"
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Option" },
+          },
+        ],
+        output: `
+          option.fold(() => "default", (value) => option.get())
+        `,
+      },
+      // Ternary operator with isRight check
+      {
+        name: "Ternary with Either check should use fold",
+        code: 'const result = either.isRight() ? either.get() : "error"',
+        errors: [
+          {
+            messageId: "preferFoldTernary",
+            data: { type: "Either" },
+          },
+        ],
+        output: 'const result = either.fold(() => "error", (value) => either.get())',
+      },
+      // Complex if/else if/else chain
+      {
+        name: "Complex if/else chain with monadic checks",
+        code: `
+          if (result.isSuccess()) {
+            return result.get()
+          } else if (result.isFailure()) {
+            return "failed"
+          } else {
+            return "unknown"
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Result" },
+          },
+        ],
+      },
+      // Null check that could be Option
+      {
+        name: "Null check should potentially use Option.fold",
+        code: `
+          if (value !== null) {
+            return value.toUpperCase()
+          } else {
+            return "empty"
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Option" },
+          },
+        ],
+      },
+      // Undefined check
+      {
+        name: "Undefined check should potentially use Option.fold",
+        code: `
+          if (value !== undefined) {
+            return process(value)
+          } else {
+            return defaultValue
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Option" },
+          },
+        ],
+      },
+      // Ternary with null check
+      {
+        name: "Ternary with null check should use fold",
+        code: 'const result = value === null ? "empty" : value.toString()',
+        errors: [
+          {
+            messageId: "preferFoldTernary",
+            data: { type: "Option" },
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-fold.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-fold.test.ts
@@ -34,6 +34,22 @@ describe("prefer-fold", () => {
         `,
         options: [{ minComplexity: 3 }],
       },
+      // Using getOrElse (already using proper pattern)
+      {
+        name: "getOrElse is a valid alternative to fold",
+        code: `const result = option.getOrElse("default")`,
+      },
+      // If/else with regular boolean condition (not monadic)
+      {
+        name: "Non-monadic if/else is allowed",
+        code: `
+          if (count > 0) {
+            return "positive"
+          } else {
+            return "non-positive"
+          }
+        `,
+      },
     ],
     invalid: [
       // If/else chain with isSome check
@@ -53,7 +69,7 @@ describe("prefer-fold", () => {
           },
         ],
         output: `
-          option.fold(() => "default", (value) => option.get())
+          option.fold(() => "default", (value) => value)
         `,
       },
       // Ternary operator with isRight check
@@ -66,7 +82,7 @@ describe("prefer-fold", () => {
             data: { type: "Either" },
           },
         ],
-        output: 'const result = either.fold(() => "error", (value) => either.get())',
+        output: 'const result = either.fold(() => "error", (value) => value)',
       },
       // Complex if/else if/else chain
       {
@@ -131,6 +147,136 @@ describe("prefer-fold", () => {
             data: { type: "Option" },
           },
         ],
+      },
+      // isNone() check in if/else (negated path)
+      {
+        name: "If/else with isNone should use fold",
+        code: `
+          if (option.isNone()) {
+            return "empty"
+          } else {
+            return option.get()
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Option" },
+          },
+        ],
+        output: `
+          option.fold(() => "empty", (value) => value)
+        `,
+      },
+      // isLeft() check in if/else (Either negated path)
+      {
+        name: "If/else with isLeft should use fold",
+        code: `
+          if (either.isLeft()) {
+            return "error"
+          } else {
+            return either.get()
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Either" },
+          },
+        ],
+        output: `
+          either.fold(() => "error", (value) => value)
+        `,
+      },
+      // Ternary with isNone() (negated ternary)
+      {
+        name: "Ternary with isNone should use fold",
+        code: 'const result = option.isNone() ? "empty" : option.get()',
+        errors: [
+          {
+            messageId: "preferFoldTernary",
+            data: { type: "Option" },
+          },
+        ],
+        output: 'const result = option.fold(() => "empty", (value) => value)',
+      },
+      // minComplexity: 1 triggers on single if/else
+      {
+        name: "Single if/else triggers with minComplexity 1",
+        code: `
+          if (option.isSome()) {
+            return option.get()
+          } else {
+            return "default"
+          }
+        `,
+        options: [{ minComplexity: 1 }],
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Option" },
+          },
+        ],
+        output: `
+          option.fold(() => "default", (value) => value)
+        `,
+      },
+      // Loose equality null check (== null)
+      {
+        name: "Loose null equality check should use fold",
+        code: `
+          if (value == null) {
+            return "missing"
+          } else {
+            return value.toString()
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Option" },
+          },
+        ],
+      },
+      // .get() followed by method call should be replaced with value
+      {
+        name: "Auto-fix replaces .get().method() with value.method()",
+        code: `
+          if (option.isSome()) {
+            return option.get().toUpperCase()
+          } else {
+            return "default"
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Option" },
+          },
+        ],
+        output: `
+          option.fold(() => "default", (value) => value.toUpperCase())
+        `,
+      },
+      // isFailure() check (Result type negated path)
+      {
+        name: "If/else with isFailure should use fold",
+        code: `
+          if (result.isFailure()) {
+            return "failed"
+          } else {
+            return result.get()
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferFold",
+            data: { type: "Result" },
+          },
+        ],
+        output: `
+          result.fold(() => "failed", (value) => value)
+        `,
       },
     ],
   })

--- a/packages/eslint-plugin-functype/tests/rules/prefer-functype-map.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-functype-map.test.ts
@@ -1,0 +1,127 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-functype-map"
+
+describe("prefer-functype-map", () => {
+  ruleTester.run("prefer-functype-map", rule, {
+    valid: [
+      // Already using functype Map
+      {
+        name: "functype Map.empty() is allowed",
+        code: 'import { Map } from "functype"\nconst m = Map.empty()',
+      },
+      // functype Map.of() is allowed
+      {
+        name: "functype Map.of() is allowed",
+        code: 'import { Map } from "functype"\nconst m = Map.of(["a", 1], ["b", 2])',
+      },
+      // Non-Map code is fine
+      {
+        name: "Non-Map code is allowed",
+        code: 'const x: string = "hello"',
+      },
+      // functype Map type annotation is allowed
+      {
+        name: "functype Map type annotation is allowed",
+        code: 'import { Map } from "functype"\nconst m: Map<string, number> = Map.empty()',
+      },
+    ],
+    invalid: [
+      // new Map() with no args → Map.empty()
+      {
+        name: "new Map() should use Map.empty()",
+        code: "const m = new Map()",
+        errors: [
+          {
+            messageId: "preferFunctypeMapLiteral",
+            suggestions: [
+              {
+                messageId: "suggestMapEmpty",
+                output: "const m = Map.empty()",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Map" },
+                output: 'import { Map } from "functype"\nconst m = new Map()',
+              },
+            ],
+          },
+        ],
+      },
+      // new Map with array of tuples → Map.of(...)
+      {
+        name: "new Map([...]) should use Map.of(...)",
+        code: 'const m = new Map([["a", 1], ["b", 2]])',
+        errors: [
+          {
+            messageId: "preferFunctypeMapLiteral",
+            suggestions: [
+              {
+                messageId: "suggestMapOf",
+                output: 'const m = Map.of(["a", 1], ["b", 2])',
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Map" },
+                output: 'import { Map } from "functype"\nconst m = new Map([["a", 1], ["b", 2]])',
+              },
+            ],
+          },
+        ],
+      },
+      // new Map(entries) → Map(entries)
+      {
+        name: "new Map(entries) should use Map(entries)",
+        code: "const m = new Map(entries)",
+        errors: [
+          {
+            messageId: "preferFunctypeMapLiteral",
+            suggestions: [
+              {
+                messageId: "suggestMapFrom",
+                output: "const m = Map(entries)",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Map" },
+                output: 'import { Map } from "functype"\nconst m = new Map(entries)',
+              },
+            ],
+          },
+        ],
+      },
+      // Map<K, V> type annotation → two errors (type + new expression)
+      {
+        name: "Map<K, V> type annotation and new Map() both flagged",
+        code: "const m: Map<string, number> = new Map()",
+        errors: [
+          {
+            messageId: "preferFunctypeMap",
+            data: { keyType: "string", valueType: "number" },
+            suggestions: [
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Map" },
+                output: 'import { Map } from "functype"\nconst m: Map<string, number> = new Map()',
+              },
+            ],
+          },
+          {
+            messageId: "preferFunctypeMapLiteral",
+            suggestions: [
+              {
+                messageId: "suggestMapEmpty",
+                output: "const m: Map<string, number> = Map.empty()",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Map" },
+                output: 'import { Map } from "functype"\nconst m: Map<string, number> = new Map()',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-functype-set.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-functype-set.test.ts
@@ -1,0 +1,115 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-functype-set"
+
+describe("prefer-functype-set", () => {
+  ruleTester.run("prefer-functype-set", rule, {
+    valid: [
+      {
+        name: "functype Set is fine",
+        code: 'import { Set } from "functype"\nconst s = Set.empty()',
+      },
+      {
+        name: "non-Set code is fine",
+        code: 'const x: string = "hello"',
+      },
+    ],
+    invalid: [
+      {
+        name: "new Set() should use Set.empty()",
+        code: "const s = new Set()",
+        errors: [
+          {
+            messageId: "preferFunctypeSetLiteral",
+            suggestions: [
+              {
+                messageId: "suggestSetEmpty",
+                output: "const s = Set.empty()",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Set" },
+                output: 'import { Set } from "functype"\nconst s = new Set()',
+              },
+            ],
+          },
+        ],
+        output: null,
+      },
+      {
+        name: "new Set([...]) should use Set.of(...) with unwrapped elements",
+        code: 'const s = new Set(["a", "b", "c"])',
+        errors: [
+          {
+            messageId: "preferFunctypeSetLiteral",
+            suggestions: [
+              {
+                messageId: "suggestSetOf",
+                output: 'const s = Set.of("a", "b", "c")',
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Set" },
+                output: 'import { Set } from "functype"\nconst s = new Set(["a", "b", "c"])',
+              },
+            ],
+          },
+        ],
+        output: null,
+      },
+      {
+        name: "new Set(variable) should use Set(variable)",
+        code: "const s = new Set(items)",
+        errors: [
+          {
+            messageId: "preferFunctypeSetLiteral",
+            suggestions: [
+              {
+                messageId: "suggestSetFrom",
+                output: "const s = Set(items)",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Set" },
+                output: 'import { Set } from "functype"\nconst s = new Set(items)',
+              },
+            ],
+          },
+        ],
+        output: null,
+      },
+      {
+        name: "Set<string> type annotation with new Set() should report two errors",
+        code: "const s: Set<string> = new Set()",
+        errors: [
+          {
+            messageId: "preferFunctypeSet",
+            data: { type: "string" },
+            suggestions: [
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Set" },
+                output: 'import { Set } from "functype"\nconst s: Set<string> = new Set()',
+              },
+            ],
+          },
+          {
+            messageId: "preferFunctypeSetLiteral",
+            suggestions: [
+              {
+                messageId: "suggestSetEmpty",
+                output: "const s: Set<string> = Set.empty()",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Set" },
+                output: 'import { Set } from "functype"\nconst s: Set<string> = new Set()',
+              },
+            ],
+          },
+        ],
+        output: null,
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-list.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-list.test.ts
@@ -1,0 +1,116 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-list"
+
+describe("prefer-list", () => {
+  ruleTester.run("prefer-list", rule, {
+    valid: [
+      // Already using List
+      {
+        name: "List type is allowed",
+        code: 'const items: List<string> = List.of("a", "b", "c")',
+      },
+      // Non-array types
+      {
+        name: "Non-array types are allowed",
+        code: 'const value: string = "test"',
+      },
+      // Object types
+      {
+        name: "Object types are allowed",
+        code: 'const user: { name: string } = { name: "test" }',
+      },
+    ],
+    invalid: [
+      // Array type syntax
+      {
+        name: "Array type should use List",
+        code: 'const items: string[] = ["a", "b", "c"]',
+        errors: [
+          {
+            messageId: "preferList",
+            data: { type: "string", arrayType: "string[]" },
+          },
+        ],
+      },
+      // Array<T> syntax
+      {
+        name: "Array<T> type should use List",
+        code: 'const items: Array<string> = ["a", "b", "c"]',
+        errors: [
+          {
+            messageId: "preferList",
+            data: { type: "string", arrayType: "Array<string>" },
+          },
+        ],
+      },
+      // ReadonlyArray<T> should still suggest List
+      {
+        name: "ReadonlyArray<T> should use List",
+        code: 'const items: ReadonlyArray<string> = ["a", "b", "c"]',
+        errors: [
+          {
+            messageId: "preferList",
+            data: { type: "string", arrayType: "ReadonlyArray<string>" },
+          },
+        ],
+      },
+      // Array literal
+      {
+        name: "Array literal should use List.from",
+        code: 'const items = ["a", "b", "c"]',
+        errors: [
+          {
+            messageId: "preferListLiteral",
+          },
+        ],
+      },
+      // Complex type array
+      {
+        name: "Complex type array should use List",
+        code: "const users: { name: string; age: number }[] = []",
+        errors: [
+          {
+            messageId: "preferList",
+            data: {
+              type: "{ name: string; age: number }",
+              arrayType: "{ name: string; age: number }[]",
+            },
+          },
+        ],
+      },
+      // Function parameter
+      {
+        name: "Function parameter array should use List",
+        code: "function processItems(items: string[]): void {}",
+        errors: [
+          {
+            messageId: "preferList",
+            data: { type: "string", arrayType: "string[]" },
+          },
+        ],
+      },
+      // Function return type
+      {
+        name: "Function return array should use List",
+        code: "function getItems(): string[] { return [] }",
+        errors: [
+          {
+            messageId: "preferList",
+            data: { type: "string", arrayType: "string[]" },
+          },
+        ],
+      },
+      // Nested array literal in assignment
+      {
+        name: "Nested array literals should use List.from",
+        code: "const matrix = [[1, 2], [3, 4]]",
+        errors: [
+          {
+            messageId: "preferListLiteral",
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-list.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-list.test.ts
@@ -30,6 +30,18 @@ describe("prefer-list", () => {
           {
             messageId: "preferList",
             data: { type: "string", arrayType: "string[]" },
+            suggestions: [
+              {
+                messageId: "suggestListType",
+                data: { type: "string" },
+                output: 'const items: List<string> = ["a", "b", "c"]',
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nconst items: string[] = ["a", "b", "c"]',
+              },
+            ],
           },
         ],
       },
@@ -41,6 +53,18 @@ describe("prefer-list", () => {
           {
             messageId: "preferList",
             data: { type: "string", arrayType: "Array<string>" },
+            suggestions: [
+              {
+                messageId: "suggestListType",
+                data: { type: "string" },
+                output: 'const items: List<string> = ["a", "b", "c"]',
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nconst items: Array<string> = ["a", "b", "c"]',
+              },
+            ],
           },
         ],
       },
@@ -52,6 +76,18 @@ describe("prefer-list", () => {
           {
             messageId: "preferList",
             data: { type: "string", arrayType: "ReadonlyArray<string>" },
+            suggestions: [
+              {
+                messageId: "suggestListType",
+                data: { type: "string" },
+                output: 'const items: List<string> = ["a", "b", "c"]',
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nconst items: ReadonlyArray<string> = ["a", "b", "c"]',
+              },
+            ],
           },
         ],
       },
@@ -62,6 +98,17 @@ describe("prefer-list", () => {
         errors: [
           {
             messageId: "preferListLiteral",
+            suggestions: [
+              {
+                messageId: "suggestListOf",
+                output: 'const items = List.of("a", "b", "c")',
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nconst items = ["a", "b", "c"]',
+              },
+            ],
           },
         ],
       },
@@ -76,6 +123,18 @@ describe("prefer-list", () => {
               type: "{ name: string; age: number }",
               arrayType: "{ name: string; age: number }[]",
             },
+            suggestions: [
+              {
+                messageId: "suggestListType",
+                data: { type: "{ name: string; age: number }" },
+                output: "const users: List<{ name: string; age: number }> = []",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nconst users: { name: string; age: number }[] = []',
+              },
+            ],
           },
         ],
       },
@@ -87,6 +146,18 @@ describe("prefer-list", () => {
           {
             messageId: "preferList",
             data: { type: "string", arrayType: "string[]" },
+            suggestions: [
+              {
+                messageId: "suggestListType",
+                data: { type: "string" },
+                output: "function processItems(items: List<string>): void {}",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nfunction processItems(items: string[]): void {}',
+              },
+            ],
           },
         ],
       },
@@ -98,6 +169,18 @@ describe("prefer-list", () => {
           {
             messageId: "preferList",
             data: { type: "string", arrayType: "string[]" },
+            suggestions: [
+              {
+                messageId: "suggestListType",
+                data: { type: "string" },
+                output: "function getItems(): List<string> { return [] }",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nfunction getItems(): string[] { return [] }',
+              },
+            ],
           },
         ],
       },
@@ -108,6 +191,28 @@ describe("prefer-list", () => {
         errors: [
           {
             messageId: "preferListLiteral",
+            suggestions: [
+              {
+                messageId: "suggestListOf",
+                output: "const matrix = List.of([1, 2], [3, 4])",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "List" },
+                output: 'import { List } from "functype"\nconst matrix = [[1, 2], [3, 4]]',
+              },
+            ],
+          },
+        ],
+      },
+      // Array with spread elements — no suggestions (ambiguous semantics)
+      {
+        name: "Array literal with spread should warn but have no suggestions",
+        code: "const items = [...other, 1, 2]",
+        errors: [
+          {
+            messageId: "preferListLiteral",
+            suggestions: [],
           },
         ],
       },

--- a/packages/eslint-plugin-functype/tests/rules/prefer-map.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-map.test.ts
@@ -1,0 +1,151 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-map"
+
+describe("prefer-map", () => {
+  ruleTester.run("prefer-map", rule, {
+    valid: [
+      // Using map
+      {
+        name: "Using map is preferred",
+        code: "const doubled = numbers.map(n => n * 2)",
+      },
+      // Using other functional methods
+      {
+        name: "Using filter is allowed",
+        code: "const evens = numbers.filter(n => n % 2 === 0)",
+      },
+      // Simple forEach without transformation
+      {
+        name: "Simple forEach for side effects is allowed",
+        code: "numbers.forEach(n => console.log(n))",
+      },
+      // Non-array operations
+      {
+        name: "Non-array operations are allowed",
+        code: "const result = calculateValue(input)",
+      },
+    ],
+    invalid: [
+      // For loop with transformation
+      {
+        name: "For loop with transformation should use map",
+        code: `
+          const results = []
+          for (let i = 0; i < items.length; i++) {
+            results.push(transform(items[i]))
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferMapOverLoop",
+            data: { collection: "array" },
+          },
+        ],
+      },
+      // For...of loop with push
+      {
+        name: "For...of loop with push should use map",
+        code: `
+          const results = []
+          for (const item of items) {
+            results.push(item.toUpperCase())
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferMapOverLoop",
+            data: { collection: "iterable" },
+          },
+        ],
+      },
+      // For...in loop with transformation
+      {
+        name: "For...in loop with transformation should use map",
+        code: `
+          const results = []
+          for (const key in obj) {
+            results.push(obj[key].toString())
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferMapOverLoop",
+            data: { collection: "object" },
+          },
+        ],
+      },
+      // forEach with simple property access (could be map)
+      {
+        name: "forEach with property access should consider map",
+        code: "items.forEach(item => item.name)",
+        errors: [
+          {
+            messageId: "preferMapChain",
+          },
+        ],
+        output: "items.map(item => item.name)",
+      },
+      // Manual push inside forEach
+      {
+        name: "Manual push inside forEach should use map",
+        code: `
+          const names = []
+          items.forEach(item => {
+            names.push(item.name)
+          })
+        `,
+        errors: [
+          {
+            messageId: "preferMapOverPush",
+          },
+        ],
+      },
+      // Complex transformation in for loop
+      {
+        name: "Complex transformation in for loop",
+        code: `
+          const processed = []
+          for (let i = 0; i < users.length; i++) {
+            processed.push({
+              id: users[i].id,
+              name: users[i].name.toUpperCase(),
+              active: true
+            })
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferMapOverLoop",
+            data: { collection: "array" },
+          },
+        ],
+      },
+      // Multiple push operations suggesting map
+      {
+        name: "Multiple loops with push should all use map",
+        code: `
+          const results1 = []
+          for (const item of list1) {
+            results1.push(process(item))
+          }
+          
+          const results2 = []
+          for (let i = 0; i < list2.length; i++) {
+            results2.push(list2[i].value)
+          }
+        `,
+        errors: [
+          {
+            messageId: "preferMapOverLoop",
+            data: { collection: "iterable" },
+          },
+          {
+            messageId: "preferMapOverLoop",
+            data: { collection: "array" },
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-option.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-option.test.ts
@@ -144,8 +144,7 @@ describe("prefer-option", () => {
               {
                 messageId: "suggestAddImport",
                 data: { symbol: "Option" },
-                output:
-                  'import { Option } from "functype"\nconst user: { name: string; age: number } | null = null',
+                output: 'import { Option } from "functype"\nconst user: { name: string; age: number } | null = null',
               },
             ],
           },

--- a/packages/eslint-plugin-functype/tests/rules/prefer-option.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-option.test.ts
@@ -1,0 +1,101 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import rule from "../../src/rules/prefer-option"
+
+describe("prefer-option", () => {
+  ruleTester.run("prefer-option", rule, {
+    valid: [
+      // Already using Option
+      {
+        name: "Option type is allowed",
+        code: 'const value: Option<string> = Some("test")',
+      },
+      // Non-nullable types
+      {
+        name: "Non-nullable types are allowed",
+        code: 'const value: string = "test"',
+      },
+      // Function parameters with non-nullable types
+      {
+        name: "Function with non-nullable parameters",
+        code: "function test(value: string): string { return value }",
+      },
+      // Complex types without null/undefined
+      {
+        name: "Complex types without nullability",
+        code: 'const value: { name: string; age: number } = { name: "test", age: 25 }',
+      },
+    ],
+    invalid: [
+      // Basic nullable type
+      {
+        name: "String or null should use Option",
+        code: "const value: string | null = null",
+        errors: [
+          {
+            messageId: "preferOption",
+            data: { type: "string", nullable: "string | null" },
+          },
+        ],
+      },
+      // String or undefined
+      {
+        name: "String or undefined should use Option",
+        code: "const value: string | undefined = undefined",
+        errors: [
+          {
+            messageId: "preferOption",
+            data: { type: "string", nullable: "string | undefined" },
+          },
+        ],
+      },
+      // String with both null and undefined
+      {
+        name: "String with null and undefined should use Option",
+        code: "const value: string | null | undefined = null",
+        errors: [
+          {
+            messageId: "preferOption",
+            data: { type: "string", nullable: "string | null | undefined" },
+          },
+        ],
+      },
+      // Function return type
+      {
+        name: "Function return type should use Option",
+        code: "function getValue(): string | null { return null }",
+        errors: [
+          {
+            messageId: "preferOption",
+            data: { type: "string", nullable: "string | null" },
+          },
+        ],
+      },
+      // Complex type with null
+      {
+        name: "Complex type with null should use Option",
+        code: "const user: { name: string; age: number } | null = null",
+        errors: [
+          {
+            messageId: "preferOption",
+            data: {
+              type: "{ name: string; age: number }",
+              nullable: "{ name: string; age: number } | null",
+            },
+          },
+        ],
+      },
+      // Array type with null
+      {
+        name: "Array type with null should use Option",
+        code: "const items: string[] | null = null",
+        errors: [
+          {
+            messageId: "preferOption",
+            data: { type: "string[]", nullable: "string[] | null" },
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/prefer-option.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-option.test.ts
@@ -25,6 +25,11 @@ describe("prefer-option", () => {
         name: "Complex types without nullability",
         code: 'const value: { name: string; age: number } = { name: "test", age: 25 }',
       },
+      // Multi-member union should not flag
+      {
+        name: "Multi-type union with null is not flagged",
+        code: "const value: string | number | null = null",
+      },
     ],
     invalid: [
       // Basic nullable type
@@ -35,6 +40,18 @@ describe("prefer-option", () => {
           {
             messageId: "preferOption",
             data: { type: "string", nullable: "string | null" },
+            suggestions: [
+              {
+                messageId: "suggestOptionType",
+                data: { type: "string" },
+                output: "const value: Option<string> = null",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Option" },
+                output: 'import { Option } from "functype"\nconst value: string | null = null',
+              },
+            ],
           },
         ],
       },
@@ -46,6 +63,18 @@ describe("prefer-option", () => {
           {
             messageId: "preferOption",
             data: { type: "string", nullable: "string | undefined" },
+            suggestions: [
+              {
+                messageId: "suggestOptionType",
+                data: { type: "string" },
+                output: "const value: Option<string> = undefined",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Option" },
+                output: 'import { Option } from "functype"\nconst value: string | undefined = undefined',
+              },
+            ],
           },
         ],
       },
@@ -57,6 +86,18 @@ describe("prefer-option", () => {
           {
             messageId: "preferOption",
             data: { type: "string", nullable: "string | null | undefined" },
+            suggestions: [
+              {
+                messageId: "suggestOptionType",
+                data: { type: "string" },
+                output: "const value: Option<string> = null",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Option" },
+                output: 'import { Option } from "functype"\nconst value: string | null | undefined = null',
+              },
+            ],
           },
         ],
       },
@@ -68,6 +109,18 @@ describe("prefer-option", () => {
           {
             messageId: "preferOption",
             data: { type: "string", nullable: "string | null" },
+            suggestions: [
+              {
+                messageId: "suggestOptionType",
+                data: { type: "string" },
+                output: "function getValue(): Option<string> { return null }",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Option" },
+                output: 'import { Option } from "functype"\nfunction getValue(): string | null { return null }',
+              },
+            ],
           },
         ],
       },
@@ -82,6 +135,19 @@ describe("prefer-option", () => {
               type: "{ name: string; age: number }",
               nullable: "{ name: string; age: number } | null",
             },
+            suggestions: [
+              {
+                messageId: "suggestOptionType",
+                data: { type: "{ name: string; age: number }" },
+                output: "const user: Option<{ name: string; age: number }> = null",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Option" },
+                output:
+                  'import { Option } from "functype"\nconst user: { name: string; age: number } | null = null',
+              },
+            ],
           },
         ],
       },
@@ -93,6 +159,18 @@ describe("prefer-option", () => {
           {
             messageId: "preferOption",
             data: { type: "string[]", nullable: "string[] | null" },
+            suggestions: [
+              {
+                messageId: "suggestOptionType",
+                data: { type: "string[]" },
+                output: "const items: Option<string[]> = null",
+              },
+              {
+                messageId: "suggestAddImport",
+                data: { symbol: "Option" },
+                output: 'import { Option } from "functype"\nconst items: string[] | null = null',
+              },
+            ],
           },
         ],
       },

--- a/packages/eslint-plugin-functype/tests/rules/real-functype-integration.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/real-functype-integration.test.ts
@@ -57,6 +57,16 @@ describe("real-functype-integration", () => {
             {
               messageId: "preferOption",
               data: { type: "string", nullable: "string | null" },
+              suggestions: [
+                {
+                  messageId: "suggestOptionType",
+                  output: `
+            import { Option } from 'functype'
+            const value: Option<string> = null
+            const unused = Option.some("test") // functype is available but not used for value
+          `,
+                },
+              ],
             },
           ],
         },
@@ -110,6 +120,16 @@ describe("real-functype-integration", () => {
           errors: [
             {
               messageId: "preferListLiteral",
+              suggestions: [
+                {
+                  messageId: "suggestListOf",
+                  output: `
+            import { List } from 'functype'
+            const items = List.of(1, 2, 3)
+            const unused = List.from([4, 5, 6]) // functype is available but not used for items
+          `,
+                },
+              ],
             },
           ],
         },

--- a/packages/eslint-plugin-functype/tests/rules/real-functype-integration.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/real-functype-integration.test.ts
@@ -1,0 +1,119 @@
+import { describe } from "vitest"
+import { ruleTester } from "../utils/rule-tester"
+import preferOption from "../../src/rules/prefer-option"
+import preferList from "../../src/rules/prefer-list"
+
+/**
+ * Integration tests using actual functype library patterns
+ * This verifies our rules work correctly with real functype usage
+ */
+describe("real-functype-integration", () => {
+  describe("prefer-option with real functype patterns", () => {
+    ruleTester.run("prefer-option", preferOption, {
+      valid: [
+        // Real functype Option usage should not be flagged
+        {
+          name: "Real Option.some() usage",
+          code: `
+            import { Option } from 'functype'
+            const maybeValue = Option.some("test")
+            const result: Option<string> = maybeValue.map(x => x.toUpperCase())
+          `,
+        },
+        // Real functype None usage
+        {
+          name: "Real Option.none() usage",
+          code: `
+            import { Option } from 'functype'
+            const noValue = Option.none<string>()
+            const result = noValue.getOrElse("default")
+          `,
+        },
+        // Real functype chaining patterns
+        {
+          name: "Real Option chaining",
+          code: `
+            import { Option } from 'functype'
+            function findUser(id: string): Option<{ name: string }> {
+              return Option.some({ name: "test" })
+            }
+            const userName = findUser("123")
+              .map(user => user.name)
+              .filter(name => name.length > 0)
+              .getOrElse("Unknown")
+          `,
+        },
+      ],
+      invalid: [
+        // Should still flag when functype is available but not used
+        {
+          name: "Still flags nullable types with functype available",
+          code: `
+            import { Option } from 'functype'
+            const value: string | null = null
+            const unused = Option.some("test") // functype is available but not used for value
+          `,
+          errors: [
+            {
+              messageId: "preferOption",
+              data: { type: "string", nullable: "string | null" },
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  describe("prefer-list with real functype patterns", () => {
+    ruleTester.run("prefer-list", preferList, {
+      valid: [
+        // Real functype List.from usage should not be flagged
+        {
+          name: "Real List.from() usage",
+          code: `
+            import { List } from 'functype'
+            const items = List.from([1, 2, 3])
+            const result = items.map(x => x * 2).filter(x => x > 2)
+          `,
+        },
+        // Real functype List.of usage
+        {
+          name: "Real List.of() usage",
+          code: `
+            import { List } from 'functype'
+            const items = List.of(1, 2, 3)
+            const doubled = items.map(x => x * 2)
+          `,
+        },
+        // Real functype List chaining
+        {
+          name: "Real List chaining patterns",
+          code: `
+            import { List } from 'functype'
+            const numbers = List.from([1, 2, 3, 4, 5])
+            const result = numbers
+              .filter(x => x % 2 === 0)
+              .map(x => x.toString())
+              .fold("", (acc, x) => acc + x)
+          `,
+        },
+      ],
+      invalid: [
+        // Should still flag when functype is available but array literals used
+        {
+          name: "Still flags array literals with functype available",
+          code: `
+            import { List } from 'functype'
+            const items = [1, 2, 3]
+            const unused = List.from([4, 5, 6]) // functype is available but not used for items
+          `,
+          errors: [
+            {
+              messageId: "preferListLiteral",
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/packages/eslint-plugin-functype/tests/rules/visual-transformation-demo.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/visual-transformation-demo.test.ts
@@ -1,0 +1,140 @@
+import { describe } from "vitest"
+import { VisualRuleTester, showTransformations } from "../utils/visual-rule-tester"
+import preferOption from "../../src/rules/prefer-option"
+import preferList from "../../src/rules/prefer-list"
+import noImperativeLoops from "../../src/rules/no-imperative-loops"
+
+describe("Visual Transformation Demo", () => {
+  describe("prefer-option transformations", () => {
+    VisualRuleTester.run(
+      "prefer-option",
+      preferOption,
+      {
+        valid: [],
+        invalid: showTransformations([
+          {
+            name: "🚫 Nullable User Function → Option<User> (Manual Fix Required)",
+            code: "function findUser(id: string): User | null { return getUser(id) }",
+            errors: [{ messageId: "preferOption" }],
+          },
+          {
+            name: "🚫 Complex Nullable Type → Option<T> (Manual Fix Required)",
+            code: "const userProfile: { name: string; email: string } | null = getUserProfile()",
+            errors: [{ messageId: "preferOption" }],
+          },
+          {
+            name: "🚫 Optional Configuration → Option<Config> (Manual Fix Required)",
+            code: "const config: AppConfig | undefined = loadConfig()",
+            errors: [{ messageId: "preferOption" }],
+          },
+        ]),
+      },
+      { showAll: true },
+    )
+  })
+
+  describe("prefer-list transformations", () => {
+    VisualRuleTester.run(
+      "prefer-list",
+      preferList,
+      {
+        valid: [],
+        invalid: showTransformations([
+          {
+            name: "🚫 Array Type → List<T> (Manual Fix Required)",
+            code: 'const userIds: string[] = ["user1", "user2", "user3"]',
+            errors: [{ messageId: "preferList" }],
+          },
+          {
+            name: "🚫 Array<T> → List<T> (Manual Fix Required)",
+            code: "const scores: Array<number> = [85, 92, 78, 96]",
+            errors: [{ messageId: "preferList" }],
+          },
+          {
+            name: "🚫 Array Literal → List.from() (Manual Fix Required)",
+            code: 'const colors = ["red", "green", "blue"]',
+            errors: [{ messageId: "preferListLiteral" }],
+          },
+          {
+            name: "🚫 Function Parameter Array → List<T> (Manual Fix Required)",
+            code: "function processItems(items: ProcessedItem[]): void { }",
+            errors: [{ messageId: "preferList" }],
+          },
+        ]),
+      },
+      { showAll: true },
+    )
+  })
+
+  describe("no-imperative-loops transformations", () => {
+    VisualRuleTester.run(
+      "no-imperative-loops",
+      noImperativeLoops,
+      {
+        valid: [],
+        invalid: [
+          // These aren't auto-fixable but show the violations detected
+          {
+            name: "🚫 For Loop → Functional Methods (Manual Fix Required)",
+            code: `
+            for (let i = 0; i < items.length; i++) {
+              console.log(items[i])
+            }
+          `,
+            errors: [{ messageId: "noForLoop" }],
+            showTransformation: true,
+          },
+          {
+            name: "🚫 While Loop → Functional Methods (Manual Fix Required)",
+            code: `
+            let sum = 0
+            let i = 0
+            while (i < numbers.length) {
+              sum += numbers[i]
+              i++
+            }
+          `,
+            errors: [{ messageId: "noWhileLoop" }],
+            showTransformation: true,
+          },
+          {
+            name: "🚫 For-of Loop → Functional Methods (Manual Fix Required)",
+            code: `
+            for (const user of users) {
+              processUser(user)
+            }
+          `,
+            errors: [{ messageId: "noForOfLoop" }],
+            showTransformation: true,
+          },
+        ],
+      },
+      { showAll: true },
+    )
+  })
+})
+
+// Mock types for compilation
+interface User {
+  id: string
+  name: string
+}
+
+interface AppConfig {
+  apiUrl: string
+  timeout: number
+}
+
+interface ProcessedItem {
+  id: string
+  value: number
+}
+
+// Mock functions
+declare function getUser(id: string): User | null
+declare function getUserProfile(): { name: string; email: string } | null
+declare function loadConfig(): AppConfig | undefined
+declare function processUser(user: User): void
+declare const items: any[]
+declare const numbers: number[]
+declare const users: User[]

--- a/packages/eslint-plugin-functype/tests/rules/visual-transformation-demo.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/visual-transformation-demo.test.ts
@@ -202,7 +202,22 @@ describe("Visual Transformation Demo", () => {
               processUser(user)
             }
           `,
-            errors: [{ messageId: "noForOfLoop" }],
+            errors: [
+              {
+                messageId: "noForOfLoop",
+                suggestions: [
+                  {
+                    messageId: "suggestForEach",
+                    data: { iterable: "users" },
+                    output: `
+            users.forEach((user) => {
+  processUser(user)
+})
+          `,
+                  },
+                ],
+              },
+            ],
             showTransformation: true,
           },
         ],

--- a/packages/eslint-plugin-functype/tests/rules/visual-transformation-demo.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/visual-transformation-demo.test.ts
@@ -15,17 +15,59 @@ describe("Visual Transformation Demo", () => {
           {
             name: "🚫 Nullable User Function → Option<User> (Manual Fix Required)",
             code: "function findUser(id: string): User | null { return getUser(id) }",
-            errors: [{ messageId: "preferOption" }],
+            errors: [
+              {
+                messageId: "preferOption",
+                suggestions: [
+                  {
+                    messageId: "suggestOptionType",
+                    output: "function findUser(id: string): Option<User> { return getUser(id) }",
+                  },
+                  {
+                    messageId: "suggestAddImport",
+                    output: `import { Option } from "functype"\nfunction findUser(id: string): User | null { return getUser(id) }`,
+                  },
+                ],
+              },
+            ],
           },
           {
             name: "🚫 Complex Nullable Type → Option<T> (Manual Fix Required)",
             code: "const userProfile: { name: string; email: string } | null = getUserProfile()",
-            errors: [{ messageId: "preferOption" }],
+            errors: [
+              {
+                messageId: "preferOption",
+                suggestions: [
+                  {
+                    messageId: "suggestOptionType",
+                    output: "const userProfile: Option<{ name: string; email: string }> = getUserProfile()",
+                  },
+                  {
+                    messageId: "suggestAddImport",
+                    output: `import { Option } from "functype"\nconst userProfile: { name: string; email: string } | null = getUserProfile()`,
+                  },
+                ],
+              },
+            ],
           },
           {
             name: "🚫 Optional Configuration → Option<Config> (Manual Fix Required)",
             code: "const config: AppConfig | undefined = loadConfig()",
-            errors: [{ messageId: "preferOption" }],
+            errors: [
+              {
+                messageId: "preferOption",
+                suggestions: [
+                  {
+                    messageId: "suggestOptionType",
+                    output: "const config: Option<AppConfig> = loadConfig()",
+                  },
+                  {
+                    messageId: "suggestAddImport",
+                    output: `import { Option } from "functype"\nconst config: AppConfig | undefined = loadConfig()`,
+                  },
+                ],
+              },
+            ],
           },
         ]),
       },
@@ -43,22 +85,78 @@ describe("Visual Transformation Demo", () => {
           {
             name: "🚫 Array Type → List<T> (Manual Fix Required)",
             code: 'const userIds: string[] = ["user1", "user2", "user3"]',
-            errors: [{ messageId: "preferList" }],
+            errors: [
+              {
+                messageId: "preferList",
+                suggestions: [
+                  {
+                    messageId: "suggestListType",
+                    output: 'const userIds: List<string> = ["user1", "user2", "user3"]',
+                  },
+                  {
+                    messageId: "suggestAddImport",
+                    output: `import { List } from "functype"\nconst userIds: string[] = ["user1", "user2", "user3"]`,
+                  },
+                ],
+              },
+            ],
           },
           {
             name: "🚫 Array<T> → List<T> (Manual Fix Required)",
             code: "const scores: Array<number> = [85, 92, 78, 96]",
-            errors: [{ messageId: "preferList" }],
+            errors: [
+              {
+                messageId: "preferList",
+                suggestions: [
+                  {
+                    messageId: "suggestListType",
+                    output: "const scores: List<number> = [85, 92, 78, 96]",
+                  },
+                  {
+                    messageId: "suggestAddImport",
+                    output: `import { List } from "functype"\nconst scores: Array<number> = [85, 92, 78, 96]`,
+                  },
+                ],
+              },
+            ],
           },
           {
             name: "🚫 Array Literal → List.from() (Manual Fix Required)",
             code: 'const colors = ["red", "green", "blue"]',
-            errors: [{ messageId: "preferListLiteral" }],
+            errors: [
+              {
+                messageId: "preferListLiteral",
+                suggestions: [
+                  {
+                    messageId: "suggestListOf",
+                    output: 'const colors = List.of("red", "green", "blue")',
+                  },
+                  {
+                    messageId: "suggestAddImport",
+                    output: `import { List } from "functype"\nconst colors = ["red", "green", "blue"]`,
+                  },
+                ],
+              },
+            ],
           },
           {
             name: "🚫 Function Parameter Array → List<T> (Manual Fix Required)",
             code: "function processItems(items: ProcessedItem[]): void { }",
-            errors: [{ messageId: "preferList" }],
+            errors: [
+              {
+                messageId: "preferList",
+                suggestions: [
+                  {
+                    messageId: "suggestListType",
+                    output: "function processItems(items: List<ProcessedItem>): void { }",
+                  },
+                  {
+                    messageId: "suggestAddImport",
+                    output: `import { List } from "functype"\nfunction processItems(items: ProcessedItem[]): void { }`,
+                  },
+                ],
+              },
+            ],
           },
         ]),
       },

--- a/packages/eslint-plugin-functype/tests/utils/rule-tester.ts
+++ b/packages/eslint-plugin-functype/tests/utils/rule-tester.ts
@@ -40,6 +40,11 @@ export type InvalidTestCase = ValidTestCase & {
     data?: Record<string, unknown>
     line?: number
     column?: number
+    suggestions?: Array<{
+      messageId: string
+      data?: Record<string, unknown>
+      output: string
+    }>
   }>
   output?: string
 }

--- a/packages/eslint-plugin-functype/tests/utils/rule-tester.ts
+++ b/packages/eslint-plugin-functype/tests/utils/rule-tester.ts
@@ -1,0 +1,50 @@
+import { RuleTester } from "@typescript-eslint/rule-tester"
+import tsParser from "@typescript-eslint/parser"
+import * as vitest from "vitest"
+
+// Configure RuleTester to use Vitest
+RuleTester.afterAll = vitest.afterAll
+RuleTester.it = vitest.it
+RuleTester.itOnly = vitest.it.only
+RuleTester.describe = vitest.describe
+
+// Create a rule tester instance configured for TypeScript using flat config
+export const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+// Helper types for test cases
+export type ValidTestCase = {
+  name?: string
+  code: string
+  options?: unknown[]
+  languageOptions?: {
+    ecmaVersion?: number
+    sourceType?: "script" | "module"
+    globals?: Record<string, boolean>
+  }
+}
+
+export type InvalidTestCase = ValidTestCase & {
+  errors: Array<{
+    messageId: string
+    data?: Record<string, unknown>
+    line?: number
+    column?: number
+  }>
+  output?: string
+}
+
+export type RuleTestCase = {
+  valid: ValidTestCase[]
+  invalid: InvalidTestCase[]
+}

--- a/packages/eslint-plugin-functype/tests/utils/visual-rule-tester.ts
+++ b/packages/eslint-plugin-functype/tests/utils/visual-rule-tester.ts
@@ -1,0 +1,126 @@
+import { RuleTester } from "@typescript-eslint/rule-tester"
+import type { Rule } from "eslint"
+import { ruleTester, type InvalidTestCase } from "./rule-tester"
+
+interface VisualTestCase extends InvalidTestCase {
+  showTransformation?: boolean
+}
+
+interface VisualRuleTestCase {
+  valid: Array<{ name?: string; code: string }>
+  invalid: VisualTestCase[]
+}
+
+/**
+ * Visual Rule Tester that displays before/after transformations
+ */
+export class VisualRuleTester {
+  private static colorize = {
+    red: (text: string) => `\x1b[31m${text}\x1b[0m`,
+    green: (text: string) => `\x1b[32m${text}\x1b[0m`,
+    blue: (text: string) => `\x1b[34m${text}\x1b[0m`,
+    yellow: (text: string) => `\x1b[33m${text}\x1b[0m`,
+    bold: (text: string) => `\x1b[1m${text}\x1b[0m`,
+    dim: (text: string) => `\x1b[2m${text}\x1b[0m`,
+  }
+
+  private static formatCode(code: string): string {
+    return code
+      .split("\n")
+      .map((line, index) => {
+        const lineNum = (index + 1).toString().padStart(3, " ")
+        return `${this.colorize.dim(lineNum)}│ ${line}`
+      })
+      .join("\n")
+  }
+
+  private static printTransformation(testCase: VisualTestCase, ruleName: string): void {
+    if (!testCase.output || testCase.showTransformation === false) {
+      return
+    }
+
+    const separator = "─".repeat(60)
+
+    console.log(`\n${this.colorize.blue("━".repeat(80))}`)
+    console.log(`${this.colorize.bold("🔧 TRANSFORMATION:")} ${this.colorize.yellow(testCase.name || "Unnamed test")}`)
+    console.log(`${this.colorize.bold("📋 RULE:")} ${this.colorize.blue(ruleName)}`)
+    console.log(`${this.colorize.blue(separator)}`)
+
+    console.log(`${this.colorize.red("❌ BEFORE:")}`)
+    console.log(this.formatCode(testCase.code.trim()))
+
+    console.log(`\n${this.colorize.green("✅ AFTER:")}`)
+    console.log(this.formatCode(testCase.output.trim()))
+
+    // Show violations
+    if (testCase.errors.length > 0) {
+      console.log(`\n${this.colorize.yellow("⚠️  VIOLATIONS:")}`)
+      testCase.errors.forEach((error, index) => {
+        const message = error.messageId
+        const data = error.data ? ` (${JSON.stringify(error.data)})` : ""
+        console.log(`${this.colorize.dim(`   ${index + 1}.`)} ${message}${data}`)
+      })
+    }
+
+    console.log(`${this.colorize.blue("━".repeat(80))}`)
+  }
+
+  /**
+   * Run tests with visual output for transformations
+   */
+  static run(
+    ruleName: string,
+    rule: Rule.RuleModule,
+    tests: VisualRuleTestCase,
+    options: { showAll?: boolean } = {},
+  ): void {
+    const { showAll = false } = options
+
+    // Convert to standard test format and add transformation logging
+    const standardTests = {
+      valid: tests.valid,
+      invalid: tests.invalid.map((testCase) => {
+        // Show transformation if explicitly enabled or if showAll is true
+        const shouldShow = showAll || testCase.showTransformation !== false
+
+        if (shouldShow && testCase.output) {
+          // Print transformation info before the test runs
+          setTimeout(() => {
+            this.printTransformation(testCase, ruleName)
+          }, 0)
+        }
+
+        // Return standard test case
+        return {
+          name: testCase.name,
+          code: testCase.code,
+          errors: testCase.errors,
+          output: testCase.output,
+        }
+      }),
+    }
+
+    // Run the actual tests
+    ruleTester.run(ruleName, rule, standardTests)
+  }
+
+  /**
+   * Helper to mark test cases for transformation display
+   */
+  static withTransformation(testCase: InvalidTestCase): VisualTestCase {
+    return {
+      ...testCase,
+      showTransformation: true,
+    }
+  }
+
+  /**
+   * Create a batch of test cases with transformation display
+   */
+  static showTransformations(testCases: InvalidTestCase[]): VisualTestCase[] {
+    return testCases.map((testCase) => VisualRuleTester.withTransformation(testCase))
+  }
+}
+
+// Export convenience functions
+export const { run: runVisualTest, withTransformation, showTransformations } = VisualRuleTester

--- a/packages/eslint-plugin-functype/ts-builds.config.json
+++ b/packages/eslint-plugin-functype/ts-builds.config.json
@@ -1,0 +1,8 @@
+{
+  "srcDir": "./src",
+  "testDir": "./tests",
+  "lint": {
+    "useProjectEslint": true
+  },
+  "validateChain": ["format", "lint", "typecheck", "test", "build"]
+}

--- a/packages/eslint-plugin-functype/tsconfig.json
+++ b/packages/eslint-plugin-functype/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "ts-builds/tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "lib", "tests"]
+}

--- a/packages/eslint-plugin-functype/tsconfig.json
+++ b/packages/eslint-plugin-functype/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "ts-builds/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "lib", "tests"]

--- a/packages/eslint-plugin-functype/tsdown.config.ts
+++ b/packages/eslint-plugin-functype/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { tsdown } from "ts-builds/tsdown"
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+  ...tsdown,
+  external: [
+    "eslint",
+    "@typescript-eslint/eslint-plugin",
+    "@typescript-eslint/parser",
+    "@typescript-eslint/rule-tester",
+    "prettier",
+  ],
+})

--- a/packages/eslint-plugin-functype/vitest.config.ts
+++ b/packages/eslint-plugin-functype/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from "vitest/config"
+import baseConfig from "ts-builds/vitest"
+
+export default mergeConfig(baseConfig, defineConfig({}))

--- a/packages/functype/package.json
+++ b/packages/functype/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@eslint/compat": "^2.1.0",
     "@types/node": "~24.10.15",
-    "eslint-config-functype": "2.3.0",
+    "eslint-config-functype": "workspace:^",
     "eslint-plugin-functional": "^9.0.4",
     "fast-check": "^4.8.0",
     "globals": "^17.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,77 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@24.12.4)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.0
       turbo:
         specifier: ^2.9.14
         version: 2.9.14
+
+  packages/eslint-config-functype:
+    dependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.5
+        version: 3.3.5
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      eslint:
+        specifier: ^10.0.3
+        version: 10.4.0(jiti@2.7.0)
+      prettier:
+        specifier: ^3.0.0
+        version: 3.8.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.4
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.59.1
+        version: 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.59.1
+        version: 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))(prettier@3.8.3)
+      eslint-plugin-simple-import-sort:
+        specifier: ^13.0.0
+        version: 13.0.0(eslint@10.4.0(jiti@2.7.0))
+      ts-builds:
+        specifier: ^2.8.0
+        version: 2.8.0(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(jiti@2.7.0)(jsdom@26.1.0)(tsdown@0.22.0(tsx@4.22.0)(typescript@6.0.3)(unrun@0.2.37(synckit@0.11.12)))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0))
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.22.0)(typescript@6.0.3)(unrun@0.2.37(synckit@0.11.12))
+
+  packages/eslint-plugin-functype:
+    dependencies:
+      eslint:
+        specifier: ^10.2.1
+        version: 10.4.0(jiti@2.7.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.4
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.59.1
+        version: 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.4.0(jiti@2.7.0))
+      functype:
+        specifier: workspace:^
+        version: link:../functype
+      ts-builds:
+        specifier: ^2.8.0
+        version: 2.8.0(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(jiti@2.7.0)(jsdom@26.1.0)(tsdown@0.22.0(tsx@4.22.0)(typescript@6.0.3)(unrun@0.2.37(synckit@0.11.12)))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0))
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.22.0)(typescript@6.0.3)(unrun@0.2.37(synckit@0.11.12))
 
   packages/functype:
     devDependencies:
@@ -30,8 +98,8 @@ importers:
         specifier: ~24.10.15
         version: 24.10.15
       eslint-config-functype:
-        specifier: 2.3.0
-        version: 2.3.0(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))(prettier@3.8.3))(eslint-plugin-simple-import-sort@13.0.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))(prettier@3.8.3)
+        specifier: workspace:^
+        version: link:../eslint-config-functype
       eslint-plugin-functional:
         specifier: ^9.0.4
         version: 9.0.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
@@ -1857,6 +1925,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/rule-tester@8.59.3':
+    resolution: {integrity: sha512-GH5g42Dt0IvM/G4ojD4JoOJaZCmogsQBGTSNExRa1ND+sDLI1SVppzYX66+xLIX/jFhcJRpYhiBOhHJEpLtgkA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.59.3':
     resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3383,6 +3458,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -6580,6 +6658,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/rule-tester@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      ajv: 6.15.0
+      eslint: 10.4.0(jiti@2.7.0)
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.8.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.59.3':
     dependencies:
       '@typescript-eslint/types': 8.59.3
@@ -8372,6 +8464,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.merge@4.6.2: {}
+
   lodash.startcase@4.4.0: {}
 
   loglayer@9.1.1:
@@ -9824,7 +9918,7 @@ snapshots:
       ts-node: 10.9.2(@types/node@24.10.15)(typescript@6.0.3)
       typescript: 6.0.3
       typescript-eslint: 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
-      vitest: 4.1.6(@types/node@24.10.15)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@26.1.0)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0))
+      vitest: 4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@26.1.0)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0))
     optionalDependencies:
       tsdown: 0.22.0(tsx@4.22.0)(typescript@6.0.3)(unrun@0.2.37(synckit@0.11.12))
       vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0)
@@ -10148,36 +10242,6 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@24.10.15)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.10.15
-      '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
-      '@vitest/ui': 4.1.6(vitest@4.1.6)
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.6(@types/node@24.10.15)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@26.1.0)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.15

--- a/scripts/check-eslint-mirror.ts
+++ b/scripts/check-eslint-mirror.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env tsx
+/**
+ * Verifies the eslint packages mirror functype's minor and patch.
+ *
+ * Rule: `eslint-config-functype` and `eslint-plugin-functype` versions
+ * must be exactly `2.<functype-minor>.<functype-patch>` (until functype
+ * 1.0, at which point the major catches up too and this script will
+ * need an update).
+ *
+ * Hooked into the root `version-packages` script so a release PR that
+ * misses an eslint bump (or uses a mismatched level) fails before
+ * `pnpm -r publish` runs. Also run on every PR via CI for early signal.
+ */
+
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
+
+const readVersion = (pkgPath: string): string => {
+  const json = JSON.parse(readFileSync(join(repoRoot, pkgPath, "package.json"), "utf8")) as { version: string }
+  return json.version
+}
+
+const functypeVersion = readVersion("packages/functype")
+const [functypeMajor, functypeMinor, functypePatch] = functypeVersion.split(".")
+
+if (!functypeMajor || functypeMinor === undefined || functypePatch === undefined) {
+  console.error(`✗ check-eslint-mirror: could not parse functype version ${functypeVersion}`)
+  process.exit(1)
+}
+
+if (functypeMajor !== "0") {
+  console.error(
+    `✗ check-eslint-mirror: functype is at ${functypeVersion} — the mirror rule assumes functype 0.x. Update this script for the 1.0 catch-up: eslint packages should move to 3.0.0 and from then on share the full version.`,
+  )
+  process.exit(1)
+}
+
+const expected = `2.${functypeMinor}.${functypePatch}`
+
+const targets = [
+  { pkg: "eslint-config-functype", path: "packages/eslint-config-functype" },
+  { pkg: "eslint-plugin-functype", path: "packages/eslint-plugin-functype" },
+]
+
+const drift = targets
+  .map(({ pkg, path }) => ({ pkg, actual: readVersion(path) }))
+  .filter(({ actual }) => actual !== expected)
+
+if (drift.length > 0) {
+  console.error(
+    `✗ check-eslint-mirror: eslint packages drifted from functype@${functypeVersion} (expected ${expected}):`,
+  )
+  for (const { pkg, actual } of drift) {
+    console.error(`    ${pkg}: ${actual} (expected ${expected})`)
+  }
+  console.error(
+    `\n  To fix: include all 7 publishable packages in the changeset at the same bump level as functype. Per-package or mismatched-level changesets break the mirror.`,
+  )
+  process.exit(1)
+}
+
+console.log(`✓ check-eslint-mirror: functype@${functypeVersion} mirrored by eslint-{config,plugin}-functype@${expected}`)

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -1,4 +1,4 @@
-# Functype v0.60.5
+# Functype v0.60.6
 
 > A functional programming library for TypeScript with immutable data structures, type-safe error handling, and Scala-inspired patterns.
 


### PR DESCRIPTION
## Summary

Brings \`eslint-config-functype\` and \`eslint-plugin-functype\` into the functype monorepo as two new packages under \`packages/\`. Same Phase 0–6 playbook used for the original \`functype-os\` and \`functype-log\` migrations; 33 commits of history preserved via \`git filter-repo\` with path remap.

| Before | After |
|---|---|
| \`jordanburke/eslint-functype/packages/config\` (eslint-config-functype@2.3.0) | \`jordanburke/functype/packages/eslint-config-functype\` (**2.60.6**) |
| \`jordanburke/eslint-functype/packages/plugin\` (eslint-plugin-functype@2.3.0) | \`jordanburke/functype/packages/eslint-plugin-functype\` (**2.60.6**) |

## Version line: mirror invariant

\`eslint-{config,plugin}-functype\` versions always mirror functype's minor and patch slots: \`2.<functype-minor>.<functype-patch>\`. The major stays at \`2\` until functype reaches \`1.0.0\`, at which point eslint catches up to \`3.0.0\` and the family converges on one version line.

Enforced by \`scripts/check-eslint-mirror.ts\`:
- Chained into the root \`version-packages\` script — a release that breaks the mirror fails before \`pnpm -r publish\` runs.
- Hooked into \`ci.yml\` — surfaces drift on every PR.

**Operating rule:** every release touching functype must include all 7 publishable packages in the same changeset at the same bump level. Per-package or mismatched-level changesets break the mirror.

## ⚠️ Before merging this PR

Configure the npm trusted publisher for **both** eslint packages on npmjs.com before merging, or the first CI publish from this monorepo E404s (same failure mode we hit with \`functype-react@0.60.6\`):

| Package | Repository | Workflow | Env |
|---|---|---|---|
| \`eslint-config-functype\` | \`jordanburke/functype\` | \`publish.yml\` | blank |
| \`eslint-plugin-functype\` | \`jordanburke/functype\` | \`publish.yml\` | blank |

URL: https://www.npmjs.com/package/eslint-config-functype/access → Trusted Publisher (and same for \`eslint-plugin-functype\`).

## After merge

\`publish.yml\` fires, sees no pending changesets, runs \`pnpm -r publish\`:
- 5 functype family packages: \`0.60.6\` matches npm, **skipped**.
- 2 eslint packages: \`2.60.6\` (local) ≠ \`2.3.0\` (npm), **publish** with sigstore provenance.

## Test plan

- [x] \`pnpm turbo run validate\` green across all 10 tasks
- [x] \`pnpm check-eslint-mirror\` passes (\`functype@0.60.6\` mirrored by \`2.60.6\`)
- [x] \`pnpm -F eslint-config-functype publish --dry-run\` — 19.1 KB tarball, 20 files
- [x] \`pnpm -F eslint-plugin-functype publish --dry-run\` — 45.5 KB tarball, 66 files
- [x] All eslint-plugin-functype test suites still pass via shared turbo validate
- [ ] Configure trusted publisher for both eslint packages on npmjs.com
- [ ] Merge → confirm publish.yml publishes both at 2.60.6 with provenance
- [ ] Archive \`jordanburke/eslint-functype\` repo (Phase 8 USER GATE; same delete pattern as functype-os/log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)