### PR TITLE
chore(housekeeping): fix yaml vuln, relax eslint engines, dedupe bin

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"cd6fa14a-f7d8-45e8-b0c4-468e0a3967f6","pid":70298,"procStart":"Mon May 11 23:37:33 2026","acquiredAt":1779152952623}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"cd6fa14a-f7d8-45e8-b0c4-468e0a3967f6","pid":70298,"procStart":"Mon May 11 23:37:33 2026","acquiredAt":1779152952623}

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ typedocs/
 
 # Generated files
 README.processed.md
+.claude/

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "pnpm": {
     "overrides": {
-      "unrun": "0.2.37"
+      "unrun": "0.2.37",
+      "yaml": "^2.8.3"
     }
   },
   "devDependencies": {

--- a/packages/eslint-config-functype/package.json
+++ b/packages/eslint-config-functype/package.json
@@ -99,6 +99,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.20.0"
   }
 }

--- a/packages/eslint-plugin-functype/package.json
+++ b/packages/eslint-plugin-functype/package.json
@@ -20,7 +20,7 @@
     "LICENSE"
   ],
   "bin": {
-    "functype-list-rules": "dist/cli/list-rules.js"
+    "functype-plugin-rules": "dist/cli/list-rules.js"
   },
   "keywords": [
     "eslint",
@@ -85,6 +85,6 @@
   },
   "homepage": "https://github.com/jordanburke/functype/tree/main/packages/eslint-plugin-functype#readme",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.20.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   unrun: 0.2.37
+  yaml: ^2.8.3
 
 importers:
 
@@ -4836,7 +4837,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5115,11 +5116,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.9.0:
@@ -10668,9 +10664,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

Addresses the housekeeping flagged after the eslint-functype import:

| Item | Status | Notes |
|---|---|---|
| 1 real vulnerability (\`yaml\` <2.8.3, stack overflow on nested) | **Fixed** | Added \`pnpm.overrides.yaml: ^2.8.3\`. \`pnpm audit\` now clean. |
| ~47 stale Dependabot alerts | **Will auto-close** | Lockfile already past them; next scan will reconcile. |
| \`engines.node: >=24.0.0\` on eslint packages | **Relaxed to >=20.20.0** | Matches ESLint 10's actual minimum. Unblocks Node 22 dev environments. |
| Duplicate \`bin: functype-list-rules\` collision | **Fixed** | Plugin's bin renamed to \`functype-plugin-rules\`. Config keeps the canonical name (more featureful CLI). |
| \`ts-builds@2.8.0\` wants \`vite@^8.x\` (have 7.3.3) | **Deferred** | Bumping vite would cascade through astro@6 + @tailwindcss/vite + @vitejs/plugin-react. Multi-package upgrade out of scope for housekeeping; warning is informational. |

## Test plan

- [x] \`pnpm audit\` returns clean
- [x] \`pnpm turbo run validate\` green (10/10 tasks)
- [x] \`pnpm check-eslint-mirror\` passes — invariant intact
- [ ] Merge, confirm publish.yml has nothing to do (no version diffs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)