### PR TITLE
fix(family): close #128, #138, #137 — appendFile, expect, prefer-flatmap heuristic

### DIFF
--- a/.changeset/cadence-issue-batch.md
+++ b/.changeset/cadence-issue-batch.md
@@ -1,0 +1,15 @@
+---
+"functype": patch
+"functype-os": patch
+"functype-log": patch
+"functype-react": patch
+"functype-mcp-server": patch
+"eslint-config-functype": patch
+"eslint-plugin-functype": patch
+---
+
+Family-cadence patch release.
+
+- **functype** — `Either`, `Option`, and `Try` now have `.expect(handler)` for unwrap-or-panic with a `never`-returning handler. Sidesteps the TS narrowing trap where arrow-typed `(...): never` helpers fail to propagate through `isLeft()`/`isNone()`/`isFailure()` checks. Closes #138.
+- **functype-os** — `Fs.appendFile` (TaskResult) and `Fs.appendFileSync` (Either) added, mapping errno → `FsError` consistent with the existing read/write helpers. Lets consumers ndjson-append without giving up O_APPEND atomicity. Closes #128.
+- **eslint-plugin-functype** — `prefer-flatmap` no longer flags `[...arr, x]` / `[...arr]` / `[x, ...arr]` (append/identity) or tuple-shaped literals like `[k, v]`. Only fires when the array literal contains at least one nested `ArrayExpression`. Closes #137.

--- a/packages/eslint-plugin-functype/src/rules/prefer-flatmap.ts
+++ b/packages/eslint-plugin-functype/src/rules/prefer-flatmap.ts
@@ -56,12 +56,27 @@ const rule: Rule.RuleModule = {
       return false
     }
 
+    /**
+     * Heuristic for array literals that look like flatten candidates.
+     * Skips append/identity patterns (`[...arr, x]`, `[...arr]`) and tuple
+     * shapes (`[k, v]`) — those are not nested arrays, so .flatMap()
+     * doesn't apply. Only flag when at least one element is itself an
+     * ArrayExpression, signaling a true nested-array shape.
+     */
+    function isFlattenCandidateArrayLiteral(arrayExpr: ASTNode): boolean {
+      const elements = arrayExpr.elements ?? []
+      if (elements.some((el: ASTNode | null) => el && el.type === "SpreadElement")) {
+        return false
+      }
+      return elements.some((el: ASTNode | null) => el && el.type === "ArrayExpression")
+    }
+
     function returnsArray(functionNode: ASTNode): boolean {
       if (!functionNode || !functionNode.body) return false
 
       // Arrow function with expression body
       if (functionNode.body.type === "ArrayExpression") {
-        return true
+        return isFlattenCandidateArrayLiteral(functionNode.body)
       }
 
       // Arrow function with call expression body
@@ -84,7 +99,8 @@ const rule: Rule.RuleModule = {
         for (const stmt of statements) {
           if (stmt.type === "ReturnStatement" && stmt.argument) {
             if (stmt.argument.type === "ArrayExpression") {
-              return true
+              if (isFlattenCandidateArrayLiteral(stmt.argument)) return true
+              continue
             }
 
             // Check for method calls that return arrays

--- a/packages/eslint-plugin-functype/tests/rules/prefer-flatmap.test.ts
+++ b/packages/eslint-plugin-functype/tests/rules/prefer-flatmap.test.ts
@@ -25,6 +25,31 @@ describe("prefer-flatmap", () => {
         name: "Other functional methods are allowed",
         code: "const filtered = items.filter(item => item.active)",
       },
+      // Tuple-shaped literal (Object.fromEntries pattern) — not a flatten candidate
+      {
+        name: "Tuple literal [k, v] is not a flatten candidate",
+        code: "const pairs = items.map(item => [item.id, item.name])",
+      },
+      // Append/identity with spread — not a flatten candidate
+      {
+        name: "Spread + appended element is not a flatten candidate",
+        code: "const acc = items.reduce((out, item) => [...out, item], [])",
+      },
+      // Spread-only — not a flatten candidate
+      {
+        name: "Spread-only array literal is not a flatten candidate",
+        code: "const copy = items.map(arr => [...arr])",
+      },
+      // Either-flatMap accumulator pattern (Either<E, U[]>)
+      {
+        name: "Either-flatMap accumulator with [...out, u] is not a flatten candidate",
+        code: `
+          const result = items.reduce(
+            (acc, item, i) => acc.flatMap(out => f(item, i).map(u => [...out, u])),
+            Right([])
+          )
+        `,
+      },
     ],
     invalid: [
       // map().flat() pattern
@@ -70,10 +95,10 @@ describe("prefer-flatmap", () => {
           },
         ],
       },
-      // Map with array return in arrow function
+      // Map returning a literal containing nested array literal — true flatten candidate
       {
-        name: "Map with array literal return should consider flatMap",
-        code: "const pairs = items.map(item => [item.id, item.name])",
+        name: "Map returning literal with nested array element should consider flatMap",
+        code: "const grouped = items.map(item => [[item.id, item.value], [item.id, item.label]])",
         errors: [
           {
             messageId: "preferFlatMapNested",

--- a/packages/functype-os/src/fs/Fs.ts
+++ b/packages/functype-os/src/fs/Fs.ts
@@ -128,6 +128,15 @@ export const Fs = {
     }
   },
 
+  appendFile: async (p: string, data: string, encoding: BufferEncoding = "utf8"): TaskResult<void> => {
+    try {
+      await fs.appendFile(p, data, { encoding })
+      return Ok(undefined as void)
+    } catch (error) {
+      return Err(toFsError(p, "appendFile", error))
+    }
+  },
+
   mkdir: async (p: string, options?: { recursive?: boolean }): TaskResult<void> => {
     try {
       await fs.mkdir(p, options)
@@ -207,6 +216,15 @@ export const Fs = {
       return Right(undefined as void)
     } catch (error) {
       return Left(toFsError(p, "writeFileSync", error))
+    }
+  },
+
+  appendFileSync: (p: string, data: string, encoding: BufferEncoding = "utf8"): Either<FsError, void> => {
+    try {
+      fsSync.appendFileSync(p, data, { encoding })
+      return Right(undefined as void)
+    } catch (error) {
+      return Left(toFsError(p, "appendFileSync", error))
     }
   },
 

--- a/packages/functype-os/test/fs/fs.spec.ts
+++ b/packages/functype-os/test/fs/fs.spec.ts
@@ -243,6 +243,50 @@ describe("Fs", () => {
     })
   })
 
+  describe("appendFile", () => {
+    it("should append to existing file and return Ok(undefined)", async () => {
+      const target = path.join(tmpDir, "append-test.txt")
+      fs.writeFileSync(target, "first")
+      const result = await Fs.appendFile(target, "-second")
+      expect(result.isOk()).toBe(true)
+      expect(fs.readFileSync(target, "utf8")).toBe("first-second")
+    })
+
+    it("should create the file if it does not exist", async () => {
+      const target = path.join(tmpDir, "append-create.txt")
+      const result = await Fs.appendFile(target, "hello")
+      expect(result.isOk()).toBe(true)
+      expect(fs.readFileSync(target, "utf8")).toBe("hello")
+    })
+
+    it("should return Err for invalid path", async () => {
+      const result = await Fs.appendFile("/no-such-dir/append.txt", "data")
+      expect(result.isErr()).toBe(true)
+    })
+  })
+
+  describe("appendFileSync", () => {
+    it("should append to existing file and return Right(undefined)", () => {
+      const target = path.join(tmpDir, "append-sync-test.txt")
+      fs.writeFileSync(target, "first")
+      const result = Fs.appendFileSync(target, "-second")
+      expect(result.isRight()).toBe(true)
+      expect(fs.readFileSync(target, "utf8")).toBe("first-second")
+    })
+
+    it("should create the file if it does not exist", () => {
+      const target = path.join(tmpDir, "append-sync-create.txt")
+      const result = Fs.appendFileSync(target, "hello")
+      expect(result.isRight()).toBe(true)
+      expect(fs.readFileSync(target, "utf8")).toBe("hello")
+    })
+
+    it("should return Left for invalid path", () => {
+      const result = Fs.appendFileSync("/no-such-dir/append.txt", "data")
+      expect(result.isLeft()).toBe(true)
+    })
+  })
+
   describe("writeFileSync", () => {
     it("should write content and return Right(undefined)", () => {
       const target = path.join(tmpDir, "write-sync-test.txt")

--- a/packages/functype/src/cli/data.ts
+++ b/packages/functype/src/cli/data.ts
@@ -31,7 +31,15 @@ export const TYPES: Record<string, TypeData> = {
     methods: {
       create: ["Option(v)", "Option.none()", "Some(v)", "None()"],
       transform: [".map(f)", ".flatMap(f)", ".filter(p)", ".ap(ff)"],
-      extract: [".fold(n, s)", ".foldAsync(n, s)", ".orElse(d)", ".orThrow()", ".orNull()", ".match({Some, None})"],
+      extract: [
+        ".fold(n, s)",
+        ".foldAsync(n, s)",
+        ".orElse(d)",
+        ".orThrow()",
+        ".expect(() => never)",
+        ".orNull()",
+        ".match({Some, None})",
+      ],
       check: [".isSome", ".isNone", ".isDefined", ".isEmpty"],
       other: ["Option.sequence(arr)", "Option.traverse(arr, f)"],
     },
@@ -43,7 +51,14 @@ export const TYPES: Record<string, TypeData> = {
     methods: {
       create: ["Right(v)", "Left(e)", "Either.right(v)", "Either.left(e)", "Either.void()"],
       transform: [".map(f)", ".flatMap(f)", ".mapLeft(f)", ".swap()"],
-      extract: [".fold(l, r)", ".foldAsync(l, r)", ".orElse(d)", ".orThrow()", ".match({Left, Right})"],
+      extract: [
+        ".fold(l, r)",
+        ".foldAsync(l, r)",
+        ".orElse(d)",
+        ".orThrow()",
+        ".expect((l) => never)",
+        ".match({Left, Right})",
+      ],
       check: [".isRight", ".isLeft"],
       other: ["Either.sequence(arr)", "Either.traverse(arr, f)", "Either.fromNullable(v, e)"],
     },
@@ -55,7 +70,15 @@ export const TYPES: Record<string, TypeData> = {
     methods: {
       create: ["Try(() => expr)", "Try.success(v)", "Try.failure(e)", "Try.fromPromise(p)"],
       transform: [".map(f)", ".flatMap(f)", ".recover(f)", ".recoverWith(f)"],
-      extract: [".fold(f, s)", ".foldAsync(f, s)", ".orElse(d)", ".orThrow()", ".toOption()", ".toEither()"],
+      extract: [
+        ".fold(f, s)",
+        ".foldAsync(f, s)",
+        ".orElse(d)",
+        ".orThrow()",
+        ".expect((e) => never)",
+        ".toOption()",
+        ".toEither()",
+      ],
       check: [".isSuccess", ".isFailure"],
       other: ["Try.sequence(arr)", "Try.traverse(arr, f)"],
     },
@@ -378,7 +401,13 @@ export const INTERFACES: Record<string, InterfaceData> = {
 
   Extractable: {
     description: "Get contained value with fallback",
-    methods: [".orElse(d: T): T", ".orThrow(e?: Error): T", ".orNull(): T | null", ".orUndefined(): T | undefined"],
+    methods: [
+      ".orElse(d: T): T",
+      ".orThrow(e?: Error): T",
+      ".expect(handler: (e?) => never): T",
+      ".orNull(): T | null",
+      ".orUndefined(): T | undefined",
+    ],
   },
 
   Matchable: {

--- a/packages/functype/src/cli/full-interfaces.ts
+++ b/packages/functype/src/cli/full-interfaces.ts
@@ -36,6 +36,14 @@ export const FULL_INTERFACES: Record<string, string> = {
    */
   orThrow(error?: Error): T
   /**
+   * Returns the contained value, or calls the never-returning handler if None.
+   * Use this when you have a helper like \`(msg) => fail(msg, 2)\` that terminates the
+   * program — the result type is unconditionally \`T\`, so you avoid the TypeScript
+   * narrowing trap where \`if (o.isNone()) fail(...)\` fails to narrow \`o.value\` when
+   * \`fail\` is an arrow function typed as \`(...): never\`.
+   */
+  expect(handler: () => never): T
+  /**
    * Returns this Option if it contains a value, otherwise returns the alternative container.
    * The alternative may hold a different type; the result widens to \`Option<T | T2>\`.
    * @param alternative - The alternative Option to return if this is None
@@ -159,6 +167,7 @@ const RightConstructor = <L extends Type, R extends Type>(value: R): RightOf<L, 
   },
   orElse: <R2 extends Type>(_defaultValue: R2): R | R2 => value,
   orThrow: () => value,
+  expect: (_handler: (value: L) => never): R => value,
   or: <L2 extends Type, R2 extends Type>(_alternative: Either<L2, R2>): Either<L | L2, R | R2> =>
     Right<L | L2, R | R2>(value),
   orNull: () => value,
@@ -238,6 +247,14 @@ export interface EitherBase<out L extends Type, out R extends Type>
   isRight(): this is RightOf<L, R>
   orElse<R2 extends Type>(defaultValue: R2): R | R2
   orThrow: (error?: Error) => R
+  /**
+   * Returns the right value, or calls the never-returning handler with the Left's value.
+   * Use this when you have a helper like \`(msg) => fail(msg, 2)\` that terminates the
+   * program — the result type is unconditionally \`R\`, so you avoid the TypeScript
+   * narrowing trap where \`if (e.isLeft()) fail(...)\` fails to narrow \`e.value\` when
+   * \`fail\` is an arrow function typed as \`(...): never\`.
+   */
+  expect: (handler: (value: L) => never) => R
   or<L2 extends Type, R2 extends Type>(alternative: Either<L2, R2>): Either<L | L2, R | R2>
   orNull: () => R | null
   orUndefined: () => R | undefined
@@ -304,6 +321,14 @@ export interface RightOf<out L extends Type, out R extends Type> extends EitherB
   isFailure(): this is Try<T> & { readonly _tag: "Failure"; error: Error }
   orElse<T2 extends Type>(defaultValue: T2): T | T2
   orThrow: (error?: Error) => T
+  /**
+   * Returns the success value, or calls the never-returning handler with the Failure's error.
+   * Use this when you have a helper like \`(msg) => fail(msg, 2)\` that terminates the program —
+   * the result type is unconditionally \`T\`, so you avoid the TypeScript narrowing trap where
+   * \`if (t.isFailure()) fail(...)\` fails to narrow \`t.value\` when \`fail\` is an arrow function
+   * typed as \`(...): never\`.
+   */
+  expect: (handler: (error: Error) => never) => T
   or<T2 extends Type>(alternative: Try<T2>): Try<T | T2>
   orNull: () => T | null
   orUndefined: () => T | undefined

--- a/packages/functype/src/either/Either.ts
+++ b/packages/functype/src/either/Either.ts
@@ -31,6 +31,14 @@ export interface EitherBase<out L extends Type, out R extends Type>
   isRight(): this is RightOf<L, R>
   orElse<R2 extends Type>(defaultValue: R2): R | R2
   orThrow: (error?: Error) => R
+  /**
+   * Returns the right value, or calls the never-returning handler with the Left's value.
+   * Use this when you have a helper like `(msg) => fail(msg, 2)` that terminates the
+   * program — the result type is unconditionally `R`, so you avoid the TypeScript
+   * narrowing trap where `if (e.isLeft()) fail(...)` fails to narrow `e.value` when
+   * `fail` is an arrow function typed as `(...): never`.
+   */
+  expect: (handler: (value: L) => never) => R
   or<L2 extends Type, R2 extends Type>(alternative: Either<L2, R2>): Either<L | L2, R | R2>
   orNull: () => R | null
   orUndefined: () => R | undefined
@@ -117,6 +125,7 @@ const RightConstructor = <L extends Type, R extends Type>(value: R): RightOf<L, 
   },
   orElse: <R2 extends Type>(_defaultValue: R2): R | R2 => value,
   orThrow: () => value,
+  expect: (_handler: (value: L) => never): R => value,
   or: <L2 extends Type, R2 extends Type>(_alternative: Either<L2, R2>): Either<L | L2, R | R2> =>
     Right<L | L2, R | R2>(value),
   orNull: () => value,
@@ -204,6 +213,7 @@ const LeftConstructor = <L extends Type, R extends Type>(value: L): LeftOf<L, R>
   orThrow: (error?: Error) => {
     throw error ?? value
   },
+  expect: (handler: (value: L) => never): R => handler(value),
   or: <L2 extends Type, R2 extends Type>(alternative: Either<L2, R2>): Either<L | L2, R | R2> =>
     alternative as Either<L | L2, R | R2>,
   orNull: () => null,

--- a/packages/functype/src/option/Option.ts
+++ b/packages/functype/src/option/Option.ts
@@ -52,6 +52,14 @@ export interface Option<out T extends Type>
    */
   orThrow(error?: Error): T
   /**
+   * Returns the contained value, or calls the never-returning handler if None.
+   * Use this when you have a helper like `(msg) => fail(msg, 2)` that terminates the
+   * program — the result type is unconditionally `T`, so you avoid the TypeScript
+   * narrowing trap where `if (o.isNone()) fail(...)` fails to narrow `o.value` when
+   * `fail` is an arrow function typed as `(...): never`.
+   */
+  expect(handler: () => never): T
+  /**
    * Returns this Option if it contains a value, otherwise returns the alternative container.
    * The alternative may hold a different type; the result widens to `Option<T | T2>`.
    * @param alternative - The alternative Option to return if this is None
@@ -178,6 +186,7 @@ export const Some = <T extends Type>(value: T): Option<T> => ({
   },
   orElse: <T2 extends Type>(_defaultValue: T2): T | T2 => value,
   orThrow: () => value,
+  expect: (_handler: () => never): T => value,
   or: <T2 extends Type>(_alternative: Option<T2>): Option<T | T2> => Some<T | T2>(value),
   orNull: () => value,
   orUndefined: () => value,
@@ -249,6 +258,9 @@ const NONE: Option<never> = {
   orElse: <T2 extends Type>(defaultValue: T2): never | T2 => defaultValue,
   orThrow<T>(error?: Error): T {
     throw error ?? new Error("Cannot extract value from None")
+  },
+  expect(handler: () => never): never {
+    return handler()
   },
   or: <T2 extends Type>(alternative: Option<T2>): Option<never | T2> => alternative,
   orNull: () => null,

--- a/packages/functype/src/try/Try.ts
+++ b/packages/functype/src/try/Try.ts
@@ -26,6 +26,14 @@ export interface Try<out T>
   isFailure(): this is Try<T> & { readonly _tag: "Failure"; error: Error }
   orElse<T2 extends Type>(defaultValue: T2): T | T2
   orThrow: (error?: Error) => T
+  /**
+   * Returns the success value, or calls the never-returning handler with the Failure's error.
+   * Use this when you have a helper like `(msg) => fail(msg, 2)` that terminates the program —
+   * the result type is unconditionally `T`, so you avoid the TypeScript narrowing trap where
+   * `if (t.isFailure()) fail(...)` fails to narrow `t.value` when `fail` is an arrow function
+   * typed as `(...): never`.
+   */
+  expect: (handler: (error: Error) => never) => T
   or<T2 extends Type>(alternative: Try<T2>): Try<T | T2>
   orNull: () => T | null
   orUndefined: () => T | undefined
@@ -92,6 +100,7 @@ const Success = <T>(value: T): Try<T> => ({
   },
   orElse: <T2 extends Type>(_defaultValue: T2): T | T2 => value,
   orThrow: (_error?: Error) => value,
+  expect: (_handler: (error: Error) => never): T => value,
   or: <T2 extends Type>(_alternative: Try<T2>): Try<T | T2> => Success<T | T2>(value),
   orNull: () => value,
   orUndefined: () => value,
@@ -147,6 +156,7 @@ const Failure = <T>(error: Error): Try<T> => ({
   orThrow: (e?: Error) => {
     throw e ?? error
   },
+  expect: (handler: (error: Error) => never): T => handler(error),
   or: <T2 extends Type>(alternative: Try<T2>): Try<T | T2> => alternative as Try<T | T2>,
   orNull: () => null,
   orUndefined: () => undefined,

--- a/packages/functype/test/either/either.spec.ts
+++ b/packages/functype/test/either/either.spec.ts
@@ -82,6 +82,25 @@ describe("Either", () => {
     expect(() => left.orThrow()).toThrow("error")
   })
 
+  it("expect on Right returns the value, handler not called", () => {
+    const right = Right<string, number>(5)
+    let called = false
+    const handler = (_e: string): never => {
+      called = true
+      throw new Error("should not be called")
+    }
+    expect(right.expect(handler)).toBe(5)
+    expect(called).toBe(false)
+  })
+
+  it("expect on Left calls the handler with the left value", () => {
+    const left = Left<string, number>("missing-config")
+    const handler = (e: string): never => {
+      throw new Error(`fatal: ${e}`)
+    }
+    expect(() => left.expect(handler)).toThrow("fatal: missing-config")
+  })
+
   it("flatMap on Right", () => {
     const right = Right<string, number>(5)
     const result = right.flatMap((x) => Right<string, string>(x.toString()))

--- a/packages/functype/test/option/option.spec.ts
+++ b/packages/functype/test/option/option.spec.ts
@@ -84,6 +84,25 @@ describe("Option", () => {
     })
   })
 
+  describe("expect", () => {
+    it("returns the value on Some without calling the handler", () => {
+      let called = false
+      const handler = (): never => {
+        called = true
+        throw new Error("should not be called")
+      }
+      expect(something.expect(handler)).toBe("hello")
+      expect(called).toBe(false)
+    })
+
+    it("calls the never-returning handler on None", () => {
+      const handler = (): never => {
+        throw new Error("missing required value")
+      }
+      expect(() => nothing.expect(handler)).toThrow("missing required value")
+    })
+  })
+
   describe("flatMapAsync", () => {
     it("should handle Some with async function", async () => {
       const asyncFunction = async (value: string) => {

--- a/packages/functype/test/try/try.spec.ts
+++ b/packages/functype/test/try/try.spec.ts
@@ -117,6 +117,29 @@ describe("Try", () => {
     })
   })
 
+  describe("expect()", () => {
+    it("returns the value on Success without calling the handler", () => {
+      let called = false
+      const handler = (_e: Error): never => {
+        called = true
+        throw new Error("should not be called")
+      }
+      const myTry = Try(() => 42)
+      expect(myTry.expect(handler)).toBe(42)
+      expect(called).toBe(false)
+    })
+
+    it("calls the handler with the underlying Error on Failure", () => {
+      const myTry = Try<number>(() => {
+        throw new Error("yaml parse failed: unexpected indent")
+      })
+      const handler = (e: Error): never => {
+        throw new Error(`scope error: ${e.message}`)
+      }
+      expect(() => myTry.expect(handler)).toThrow("scope error: yaml parse failed: unexpected indent")
+    })
+  })
+
   describe("Try.success()", () => {
     it("should create a Success directly", () => {
       const result = Try.success(42)


### PR DESCRIPTION
## Summary

Closes three discrete issues from triage. Family-cadence patch release.

- **#128** (`functype-os`) — Adds `Fs.appendFile` (TaskResult) and `Fs.appendFileSync` (Either). Maps errno → `FsError` consistent with read/write helpers. Lets ndjson consumers keep O_APPEND atomicity instead of `readFileSync → concat → writeFileSync` with a race window.
- **#138** (`functype`) — Adds `.expect(handler)` to `Either`, `Option`, and `Try`. Handler is `(...) => never`, so the result type is unconditionally the success type. Sidesteps the TS narrowing trap where arrow-typed `(...): never` helpers fail to propagate through `isLeft()`/`isNone()`/`isFailure()` checks. Cheatsheet entry added to `cli/data.ts`.
- **#137** (`eslint-plugin-functype`) — `prefer-flatmap` no longer flags `[...arr, x]` / `[...arr]` / `[x, ...arr]` (append/identity patterns) or tuple-shaped `[k, v]` literals. Only fires when the array literal contains at least one nested `ArrayExpression`, a clear flatten candidate.

Heads-up on **#139** (`Try.toEither` lazy builder): inspection of the 0.60.6 tarball shows the lazy `(err: Error) => E` overload is already implemented on `Try.toEither`. I'll close that issue separately rather than ship a no-op.

## Versioning

Changeset bumps all 7 publishable packages by patch — preserves the mirror invariant (`eslint-{config,plugin}-functype@2.<minor>.<patch>` = `functype.<minor>.<patch>`). Expected after Version Packages: family → `0.60.7`, eslint pair → `2.60.7`.

## Test plan

- [x] `pnpm -F functype-os test` — 140 passed (added 6 for appendFile/appendFileSync)
- [x] `pnpm -F functype test` — 1590 passed (added 6 for `.expect` on Either/Option/Try)
- [x] `pnpm -F eslint-plugin-functype test` — 174 passed (4 new valid cases for spread/tuple, 1 new invalid case for true nested-array flatten candidate)
- [x] `pnpm turbo run validate` — 10 tasks green, full build clean
- [x] Mirror invariant script (`pnpm check-eslint-mirror`) — current versions all aligned; will re-check post `changeset version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)