### PR TITLE
fix(family): close #135, #136 — magic-FS mkdir guard + IO.bracketExit

### DIFF
--- a/.changeset/bracket-exit-mkdir-guard.md
+++ b/.changeset/bracket-exit-mkdir-guard.md
@@ -1,0 +1,14 @@
+---
+"functype": patch
+"functype-os": patch
+"functype-log": patch
+"functype-react": patch
+"functype-mcp-server": patch
+"eslint-config-functype": patch
+"eslint-plugin-functype": patch
+---
+
+Family-cadence patch release.
+
+- **functype** — Adds `IO.bracketExit(acquire, use, release)`. Same shape as `IO.bracket`, but the `release` callback receives the use-step's `Exit<E, A>` so cleanup can branch on success vs failure (matches the Effect-TS / ZIO / cats-effect convention). Existing `IO.bracket` is unchanged. Closes #136.
+- **functype-os** — `Fs.mkdir` and `Fs.mkdirSync` now refuse `recursive: true` under Linux magic filesystem roots (`/proc/`, `/sys/`, `/dev/`) and return `Left(FsError(...))` immediately. Fixes the indefinite hang reported on Linux where libuv blocks instead of erroring fast. Cross-platform behavior is now predictable. Closes #135.

--- a/packages/functype-os/src/fs/Fs.ts
+++ b/packages/functype-os/src/fs/Fs.ts
@@ -31,6 +31,16 @@ const toFileInfo = (stats: fsSync.Stats): FileInfo => ({
 const toFsError = (p: string, op: string, error: unknown): FsError =>
   FsError(p, op, error instanceof Error ? error : new Error(String(error)))
 
+/**
+ * Linux magic filesystems where recursive mkdir can hang indefinitely against
+ * unwritable subpaths (libuv quirk; macOS errors immediately instead).
+ * Refusing recursive mkdir under these prefixes keeps `mkdir({ recursive: true })`
+ * fast-failing and predictable across platforms. See issue #135.
+ */
+const MAGIC_FS_PREFIXES: ReadonlyArray<string> = ["/proc/", "/sys/", "/dev/"]
+
+const isMagicFsPath = (p: string): boolean => MAGIC_FS_PREFIXES.some((prefix) => p.startsWith(prefix))
+
 const matchGlob = (filePath: string, pattern: string): boolean => {
   // Escape every regex metachar EXCEPT '*' first, so the subsequent
   // '*' transformations are the only special characters in the output.
@@ -138,6 +148,11 @@ export const Fs = {
   },
 
   mkdir: async (p: string, options?: { recursive?: boolean }): TaskResult<void> => {
+    if (options?.recursive && isMagicFsPath(p)) {
+      return Err(
+        toFsError(p, "mkdir", new Error("recursive mkdir refused under magic filesystem root (/proc, /sys, /dev)")),
+      )
+    }
     try {
       await fs.mkdir(p, options)
       return Ok(undefined as void)
@@ -229,6 +244,11 @@ export const Fs = {
   },
 
   mkdirSync: (p: string, options?: { recursive?: boolean }): Either<FsError, void> => {
+    if (options?.recursive && isMagicFsPath(p)) {
+      return Left(
+        toFsError(p, "mkdirSync", new Error("recursive mkdir refused under magic filesystem root (/proc, /sys, /dev)")),
+      )
+    }
     try {
       fsSync.mkdirSync(p, options)
       return Right(undefined as void)

--- a/packages/functype-os/test/fs/fs.spec.ts
+++ b/packages/functype-os/test/fs/fs.spec.ts
@@ -322,6 +322,30 @@ describe("Fs", () => {
     })
   })
 
+  describe("mkdir magic-FS guard", () => {
+    it("refuses recursive mkdir under /proc with a Left(FsError)", async () => {
+      const result = await Fs.mkdir("/proc/no-write-here/a/b/c", { recursive: true })
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error.message).toContain("magic filesystem root")
+      }
+    })
+
+    it("refuses recursive mkdirSync under /sys with a Left(FsError)", () => {
+      const result = Fs.mkdirSync("/sys/something/nested", { recursive: true })
+      expect(result.isLeft()).toBe(true)
+      if (result.isLeft()) {
+        expect(result.value.message).toContain("magic filesystem root")
+      }
+    })
+
+    it("allows non-recursive mkdirSync under /proc (lets node return its own error)", () => {
+      const result = Fs.mkdirSync("/proc/no-write-here-x", {})
+      // node returns EACCES/EPERM/ENOENT depending on platform — we only assert it didn't hang and produced a Left.
+      expect(result.isLeft()).toBe(true)
+    })
+  })
+
   describe("mkdirSync", () => {
     it("should create directory and return Right(undefined)", () => {
       const target = path.join(tmpDir, "new-dir-sync")

--- a/packages/functype/src/io/IO.ts
+++ b/packages/functype/src/io/IO.ts
@@ -109,6 +109,12 @@ type IOEffect<R, E, A> =
       readonly release: (a: unknown) => IO<R, never, void>
     }
   | {
+      readonly _tag: "BracketExit"
+      readonly acquire: IO<R, E, unknown>
+      readonly use: (a: unknown) => IO<R, E, A>
+      readonly release: (a: unknown, exit: ExitType<unknown, unknown>) => IO<R, never, void>
+    }
+  | {
       readonly _tag: "Race"
       readonly effects: readonly IO<R, E, A>[]
     }
@@ -717,6 +723,20 @@ const runEffectSync = <R extends Type, E extends Type, A extends Type>(
         runEffectSync(_fx(effect.release(resource)), context)
       }
     }
+    case "BracketExit": {
+      const resource = runEffectSync(_fx(effect.acquire), context)
+      let exit: ExitType<E, A>
+      try {
+        const useResult = runEffectSync(_fx(effect.use(resource)), context)
+        exit = unsafeCoerce(Exit.succeed(useResult))
+        return useResult
+      } catch (e) {
+        exit = unsafeCoerce(Exit.fail(e as E))
+        throw e
+      } finally {
+        runEffectSync(_fx(effect.release(resource, exit!)), context)
+      }
+    }
     case "Race":
       throw new Error("Cannot run race effect synchronously")
     case "Timeout":
@@ -833,6 +853,17 @@ const runEffect = async <R extends Type, E extends Type, A extends Type>(
           // Release always runs, even if use fails
           await runEffect(_fx(effect.release(resource)), context)
         }
+      }
+      case "BracketExit": {
+        const acquireExit = await runEffect(_fx(effect.acquire), context)
+        if (!acquireExit.isSuccess()) {
+          return acquireExit as ExitType<E, A>
+        }
+        const resource = acquireExit.orThrow()
+        const useExit = await runEffect(_fx(effect.use(resource)), context)
+        // Release always runs and receives the use-step's Exit
+        await runEffect(_fx(effect.release(resource, useExit as ExitType<E, A>)), context)
+        return useExit
       }
       case "Race": {
         if (effect.effects.length === 0) {
@@ -1267,6 +1298,38 @@ const IOCompanion = {
     use: (a: A) => IO<R, E, B>,
     release: (a: A) => IO<R, never, void>,
   ): IO<R, E, B> => IOCompanion.bracket(acquire, use, release),
+
+  /**
+   * Like `bracket`, but the release callback receives the Exit of the use-step.
+   * Use this when cleanup needs to branch on whether `use` succeeded or failed —
+   * e.g., emit a different audit event on `Success` vs `Failure`.
+   *
+   * The release effect always runs (whether use succeeded, failed, or was
+   * interrupted). If `acquire` itself fails, release is not called.
+   *
+   * @example
+   * ```typescript
+   * IO.bracketExit(
+   *   appendEvent({ event: "job_start" }),
+   *   () => body,
+   *   (_a, exit) =>
+   *     exit.isSuccess()
+   *       ? appendEvent({ event: "job_complete" })
+   *       : appendEvent({ event: "job_failed", error: String(exit.toValue().value) })
+   * )
+   * ```
+   */
+  bracketExit: <R extends Type, E extends Type, A extends Type, B extends Type>(
+    acquire: IO<R, E, A>,
+    use: (a: A) => IO<R, E, B>,
+    release: (a: A, exit: ExitType<E, B>) => IO<R, never, void>,
+  ): IO<R, E, B> =>
+    createIO({
+      _tag: "BracketExit",
+      acquire: acquire as IO<R, E, unknown>,
+      use: use as (a: unknown) => IO<R, E, B>,
+      release: release as (a: unknown, exit: ExitType<unknown, unknown>) => IO<R, never, void>,
+    }),
 
   /**
    * Races multiple effects, returning the first to complete.

--- a/packages/functype/test/io/io.spec.ts
+++ b/packages/functype/test/io/io.spec.ts
@@ -1574,6 +1574,97 @@ describe("Dependency Injection", () => {
     })
   })
 
+  describe("IO.bracketExit", () => {
+    it("release receives a Success Exit when use succeeds", async () => {
+      const events: string[] = []
+
+      const program = IO.bracketExit(
+        IO.sync(() => {
+          events.push("acquire")
+          return "resource"
+        }),
+        (resource) =>
+          IO.sync(() => {
+            events.push(`use:${resource}`)
+            return "result"
+          }),
+        (resource, exit) =>
+          IO.sync(() => {
+            events.push(exit.isSuccess() ? `release-ok:${resource}` : `release-fail:${resource}`)
+          }),
+      )
+
+      const result = await program.runOrThrow()
+      expect(result).toBe("result")
+      expect(events).toEqual(["acquire", "use:resource", "release-ok:resource"])
+    })
+
+    it("release receives a Failure Exit when use fails", async () => {
+      const events: string[] = []
+
+      const program = IO.bracketExit(
+        IO.sync(() => {
+          events.push("acquire")
+          return "resource"
+        }) as unknown as IO<never, Error, string>,
+        () => IO.fail(new Error("use failed")) as unknown as IO<never, Error, string>,
+        (resource, exit) =>
+          IO.sync(() => {
+            events.push(exit.isFailure() ? `release-fail:${resource}` : `release-ok:${resource}`)
+          }),
+      )
+
+      const exit = await program.runExit()
+      expect(exit.isFailure()).toBe(true)
+      expect(events).toEqual(["acquire", "release-fail:resource"])
+    })
+
+    it("release is not called when acquire fails", async () => {
+      const events: string[] = []
+
+      const program = IO.bracketExit(
+        IO.fail(new Error("acquire failed")) as unknown as IO<never, Error, string>,
+        (resource) =>
+          IO.sync(() => {
+            events.push(`use:${resource}`)
+            return "result"
+          }),
+        (resource) =>
+          IO.sync(() => {
+            events.push(`release:${resource}`)
+          }),
+      )
+
+      const exit = await program.runExit()
+      expect(exit.isFailure()).toBe(true)
+      expect(events).toEqual([])
+    })
+
+    it("works synchronously and passes Exit to release", () => {
+      const events: string[] = []
+
+      const program = IO.bracketExit(
+        IO.sync(() => {
+          events.push("acquire")
+          return "resource"
+        }),
+        (resource) =>
+          IO.sync(() => {
+            events.push(`use:${resource}`)
+            return "result"
+          }),
+        (resource, exit) =>
+          IO.sync(() => {
+            events.push(exit.isSuccess() ? `release-ok:${resource}` : `release-fail:${resource}`)
+          }),
+      )
+
+      const result = program.runSyncOrThrow()
+      expect(result).toBe("result")
+      expect(events).toEqual(["acquire", "use:resource", "release-ok:resource"])
+    })
+  })
+
   describe("IO.race", () => {
     it("should return first effect to complete", async () => {
       const result = await IO.race([IO.sleep(100).map(() => "slow"), IO.sleep(10).map(() => "fast")]).runOrThrow()


### PR DESCRIPTION
## Summary

Two more issues from triage I deferred too eagerly last round. Both are surgical, additive, no breaking changes.

- **#136** (\`functype\`) — Adds \`IO.bracketExit(acquire, use, release)\`. Identical to \`IO.bracket\` except \`release\` receives the use-step's \`Exit<E, A>\` so cleanup can branch on success vs failure. Matches the Effect-TS / ZIO / cats-effect convention. The existing \`IO.bracket\` signature is unchanged — callers that don't need Exit-awareness keep their current call sites.
- **#135** (\`functype-os\`) — \`Fs.mkdir\` and \`Fs.mkdirSync\` now refuse \`recursive: true\` under Linux magic filesystem roots (\`/proc/\`, \`/sys/\`, \`/dev/\`) and return \`Left(FsError(...))\` immediately. Fixes the indefinite hang where libuv blocks on these paths on Linux while macOS errors fast. Cross-platform behavior is now predictable.

## Versioning

Mirror-preserving family-cadence patch: family → \`0.60.8\`, eslint pair → \`2.60.8\`.

## Implementation notes

\`bracketExit\` required a contravariant escape: \`release\`'s \`exit\` parameter is typed as \`ExitType<unknown, unknown>\` in the union member (same trick \`Bracket\` already uses for the resource type) and recast to \`ExitType<E, B>\` at the constructor boundary. Companion-method signature for callers stays correctly typed.

## Test plan

- [x] \`pnpm -F functype test\` — 1594 passed (4 new for bracketExit: success path, failure path, acquire-fails-no-release, sync path)
- [x] \`pnpm -F functype-os test\` — 143 passed (3 new for magic-FS guard: /proc recursive, /sys recursive, /proc non-recursive still tries node)
- [x] \`pnpm turbo run validate\` — 10/10 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)