### PR TITLE
chore: add changesets for #155 and #156

### DIFF
--- a/.changeset/cli-data-sync.md
+++ b/.changeset/cli-data-sync.md
@@ -1,0 +1,13 @@
+---
+"functype": patch
+"functype-os": patch
+"functype-log": patch
+"functype-react": patch
+"functype-mcp-server": patch
+"eslint-config-functype": patch
+"eslint-plugin-functype": patch
+---
+
+Family-cadence patch release.
+
+- **functype** — `src/cli/data.ts` interface lists are now source-derived. A new parser (`scripts/parse-interfaces.ts`) walks each type's `extends` clause and recursively expands wrapper interfaces (`Functype`/`FunctypeBase`/`FunctypeSum`/`FunctypeCollection`/`AsyncMonad`/`Monad`/`Applicative`); `scripts/generate-interfaces.ts` writes `src/cli/interfaces.generated.ts`; a `test/cli/data-sync.spec.ts` superset-check fails CI if `TYPES[name].interfaces` ever drops anything in the source extends chain. Effect: `Doable`, `Promisable`, `Reshapeable`, `Applicative`, `AsyncMonad` now correctly surface for `Option`, `Either`, `Try`, `List`, `Obj`, `Lazy`, `Task` in `npx functype <Type>` and `functype-mcp-server`'s `search_docs`. Closes a discoverability gap that hid `Doable` for the entire monadic family.

--- a/.changeset/http-before-request.md
+++ b/.changeset/http-before-request.md
@@ -1,0 +1,11 @@
+---
+"functype": minor
+"functype-os": patch
+"functype-log": patch
+"functype-react": patch
+"functype-mcp-server": patch
+"eslint-config-functype": patch
+"eslint-plugin-functype": patch
+---
+
+- **functype** — Adds `HttpClientConfig.beforeRequest`: an effectful (IO-returning) transformer that runs after `defaultHeaders` and per-call headers are merged but before the request is sent. Closes the request/response asymmetry called out in [#154](https://github.com/jordanburke/functype/issues/154) — the response side already composes via `.tap`/`.map`/`.flatMap`/`.catchTag` on the returned IO; `beforeRequest` lets request-side concerns (auth refresh, request IDs, entry logging) compose the same way using standard IO operators. Returning a failed IO short-circuits the call with the produced `HttpError` and `fetch` is never invoked. Strictly additive; no breaking changes. New `HttpRequestView` type re-exported from `functype/fetch`. `Http`'s CLI/MCP entry now also surfaces the full IO chain methods (`.tap` etc.) that were previously not discoverable from the type's own listing, and `npx functype Http --full` now shows the JSDoc'd `HttpClientConfig` interface. Closes [#154](https://github.com/jordanburke/functype/issues/154).


### PR DESCRIPTION
## Summary

Adds changesets for PRs #155 and #156, which merged without them. Required so the open Version Packages PR (#145) picks them up and the next release actually publishes the new code.

- **#155** (cli/data-sync) → `patch` for the family. Internal infra to make `src/cli/data.ts` interface lists source-derived, fixing a discoverability gap (Doable was missing from Option/Either/Try/Lazy/Task in CLI + MCP output).
- **#156** (Http.beforeRequest) → **`minor`** for `functype`, `patch` for siblings. New additive public API field on `HttpClientConfig` — closes #154. No breaking changes; existing fetch override / defaultHeaders behavior unchanged.

## Effect on PR #145

Once this merges, `changesets/action` will refresh the open Version Packages PR (#145) to bundle all three changesets:
- bracket-exit-mkdir-guard (functype, functype-os) — existing
- cli-data-sync (functype) — new
- http-before-request (functype) — new

Result: next release bumps `functype` to `0.61.0` (minor wins from http-before-request), siblings to their next patch.

## Test plan

- [x] `pnpm validate` clean (unchanged; no code changes)
- [x] Both `.changeset/*.md` files lint as valid frontmatter
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)