### PR TITLE
chore: bump all packages to minor in http-before-request changeset

### DIFF
--- a/.changeset/http-before-request.md
+++ b/.changeset/http-before-request.md
@@ -1,11 +1,11 @@
 ---
 "functype": minor
-"functype-os": patch
-"functype-log": patch
-"functype-react": patch
-"functype-mcp-server": patch
-"eslint-config-functype": patch
-"eslint-plugin-functype": patch
+"functype-os": minor
+"functype-log": minor
+"functype-react": minor
+"functype-mcp-server": minor
+"eslint-config-functype": minor
+"eslint-plugin-functype": minor
 ---
 
 - **functype** — Adds `HttpClientConfig.beforeRequest`: an effectful (IO-returning) transformer that runs after `defaultHeaders` and per-call headers are merged but before the request is sent. Closes the request/response asymmetry called out in [#154](https://github.com/jordanburke/functype/issues/154) — the response side already composes via `.tap`/`.map`/`.flatMap`/`.catchTag` on the returned IO; `beforeRequest` lets request-side concerns (auth refresh, request IDs, entry logging) compose the same way using standard IO operators. Returning a failed IO short-circuits the call with the produced `HttpError` and `fetch` is never invoked. Strictly additive; no breaking changes. New `HttpRequestView` type re-exported from `functype/fetch`. `Http`'s CLI/MCP entry now also surfaces the full IO chain methods (`.tap` etc.) that were previously not discoverable from the type's own listing, and `npx functype Http --full` now shows the JSDoc'd `HttpClientConfig` interface. Closes [#154](https://github.com/jordanburke/functype/issues/154).


### PR DESCRIPTION
## Summary

The Version Packages workflow failed because `check-eslint-mirror` requires every changeset to bump all 7 publishable packages at the same level:

\`\`\`
✗ check-eslint-mirror: eslint packages drifted from functype@0.61.0 (expected 2.61.0):
    eslint-config-functype: 2.60.8 (expected 2.61.0)
    eslint-plugin-functype: 2.60.8 (expected 2.61.0)
\`\`\`

My `http-before-request.md` had `functype: minor` but siblings at `patch`. Bumping all 7 to minor restores the mirror invariant. The bracket-exit-mkdir-guard changeset already follows this pattern (all 7 at patch) — same convention, just at minor for this release because of the new public API.

## Effect

Release becomes:
- functype 0.61.0
- functype-os/log/react/mcp-server 0.61.0
- eslint-config-functype 2.61.0
- eslint-plugin-functype 2.61.0

Once this merges, Version Packages PR #145 will rerun successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)