### PR TITLE
fix(release): wrap publish chain in `pnpm release` script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,13 +49,17 @@ jobs:
           # version + identifier track package.json. Without this wrapper
           # the MCP registry manifest would drift on every release.
           #
-          # `check-publish-safety` runs before `pnpm publish` and refuses
-          # major version bumps or downgrades unless explicitly authorized
-          # via ALLOW_MAJOR env var. Added after the 0.60.7 → 1.0.0
-          # cascade caused by a `workspace:^` peerDependency. See
-          # docs/RELEASE.md "Independent cadence" for the post-mortem.
+          # `release` runs `check-publish-safety` (pre-publish gate;
+          # refuses unauthorized majors and downgrades; honors
+          # ALLOW_MAJOR env) and then `pnpm -r publish --no-git-checks`.
+          # NOTE: changesets/action feeds `publish:` to @actions/exec
+          # WITHOUT a shell, so chaining commands with `&&` does NOT work
+          # inline — the second command would be parsed as args. The
+          # `release` script wraps both under one pnpm invocation so
+          # shell semantics apply. See post-mortem in docs/RELEASE.md
+          # "Independent cadence".
           version: pnpm run version-packages
-          publish: pnpm check-publish-safety && pnpm -r publish --no-git-checks
+          publish: pnpm release
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "clean": "pnpm -r clean && rm -rf .turbo",
     "version-packages": "changeset version && pnpm -F functype-mcp-server sync:registry",
     "check-changesets": "tsx scripts/check-changesets.ts",
-    "check-publish-safety": "tsx scripts/check-publish-safety.ts"
+    "check-publish-safety": "tsx scripts/check-publish-safety.ts",
+    "release": "pnpm check-publish-safety && pnpm -r publish --no-git-checks"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "engines": {


### PR DESCRIPTION
## The bug

PR #160 merged successfully, validate passed, workflow concluded \"success\" — but **nothing got published**. All seven packages on npm are still at their pre-reset versions.

Root cause: `changesets/action` feeds the `publish:` parameter to `@actions/exec`, which does NOT use a shell. The value:

```yaml
publish: pnpm check-publish-safety && pnpm -r publish --no-git-checks
```

parses as:

```
command: pnpm
args:    [check-publish-safety, &&, pnpm, -r, publish, --no-git-checks]
```

pnpm silently dropped the trailing args, ran `check-publish-safety` (which passed), exited 0. `pnpm publish` was never invoked. The action saw exit 0 and reported success. No publish, no error.

## Fix

Wrap both commands in a single `pnpm release` script in root `package.json`:

```jsonc
\"release\": \"pnpm check-publish-safety && pnpm -r publish --no-git-checks\"
```

Workflow uses `publish: pnpm release` — one command, no chaining at the changesets/action layer. Shell semantics apply inside the npm script as expected.

Added an explanatory comment in publish.yml so the obvious-looking inline `&&` doesn't get reintroduced.

## After merge

Publish workflow re-runs and this time actually publishes the family-cadence reset versions:
- functype, functype-mcp-server: 0.61.0 → 1.0.1
- functype-os, -log, -react: 1.0.0 → 1.0.1
- eslint-config-functype, eslint-plugin-functype: 2.61.0 → 2.100.1

ALLOW_MAJOR is still set on the publish.yml step from PR #160, so the safety gate authorizes functype + functype-mcp-server's major bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)