### PR TITLE
fix(release): sync mcp-server server.json + close safety-check gap

### DIFF
--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/jordanburke/functype",
     "source": "github"
   },
-  "version": "0.61.0",
+  "version": "1.0.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "functype-mcp-server",
-      "version": "0.61.0",
+      "version": "1.0.1",
       "transport": {
         "type": "stdio"
       },

--- a/scripts/check-publish-safety.ts
+++ b/scripts/check-publish-safety.ts
@@ -130,4 +130,23 @@ if (surpriseMajors.length > 0) {
   process.exit(1)
 }
 
+// Side-file consistency: functype-mcp-server bakes its version into
+// server.json (MCP registry manifest) in addition to package.json. The
+// package's `prepublishOnly` runs `sync:registry:check` which catches
+// drift, but that fires DURING `pnpm publish` — too late, after this
+// safety gate has already greenlit the release. Invoke it here so a
+// missed `pnpm -F functype-mcp-server sync:registry` after a manual
+// version bump fails the gate up front instead of mid-publish.
+console.log(`\nRunning functype-mcp-server side-file sync check...`)
+const syncCheck = spawnSync("pnpm", ["-F", "functype-mcp-server", "sync:registry:check"], {
+  stdio: "inherit",
+  cwd: repoRoot,
+})
+if (syncCheck.status !== 0) {
+  console.error(
+    `\n✗ check-publish-safety: functype-mcp-server server.json is out of sync with package.json.\n  Run \`pnpm -F functype-mcp-server sync:registry\` and commit the result.`,
+  )
+  process.exit(1)
+}
+
 console.log(`\n✓ check-publish-safety: no surprise majors or downgrades — safe to publish`)


### PR DESCRIPTION
## What broke

The 1.0.1 publish (PR #160 → #161) succeeded for 6 of 7 packages. `functype-mcp-server` failed at publish-time because its `prepublishOnly` ran `sync:registry:check`, which detected that `packages/mcp-server/server.json` was still at `0.61.0` (we only bumped `package.json`).

## Why check-publish-safety didn't catch it

`scripts/check-publish-safety.ts` compares each package's `package.json` version against npm. It didn't know about side files. `server.json` (the MCP registry manifest) duplicates the version, and the existing sync check only fired during `pnpm publish` — after the safety gate had already passed.

## Fix

1. **server.json synced**: ran `pnpm -F functype-mcp-server sync:registry`. Both `version` and `packages[0].version` now `1.0.1`.
2. **Safety check extended**: `check-publish-safety.ts` now runs `pnpm -F functype-mcp-server sync:registry:check` as its final step. Any future server.json drift fails the gate up front with a clear message pointing at the sync command.

Verified locally — `pnpm check-publish-safety` now includes the sync-check output.

## After merge

Publish workflow re-runs. functype-mcp-server@1.0.1 publishes. Family-cadence reset complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)