### PR TITLE
feat(serialization): tighten toEnvelope output to JSONValue (1.2.2)

### DIFF
--- a/packages/functype/CHANGELOG.md
+++ b/packages/functype/CHANGELOG.md
@@ -6,6 +6,17 @@ Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions: writ
 
 ## Unreleased
 
+Type-tightening on `toEnvelope` output (and new `JSONValue` type export) so the DBOS / SuperJSON consumer recipe slots in with zero casts at the boundary. Asymmetric by design — only the OUTPUT tightens; `fromEnvelope`'s input stays `unknown` to preserve Postel's law (be conservative in what you send, liberal in what you accept — same pattern stdlib uses for `JSON.parse`/`stringify`, `Array.from`, etc.). Tightening the input too would push casts up the chain to every less-typed host plumbing layer for no runtime benefit.
+
+**New (additive):**
+
+- `Serialization.JSONValue` — exported recursive type: `string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue }`. The canonical JSON value type — anything `JSON.parse` can return and anything `JSON.stringify` can accept. Used by `toEnvelope` to express its output contract precisely.
+
+**Type-only change (no runtime change, no breaking change):**
+
+- `Serialization.toEnvelope(value: unknown): JSONValue` — output type tightened from `unknown` to `JSONValue`. Consumers wiring `serialize: Serialization.toEnvelope` into a host serializer (DBOS / SuperJSON custom transformer) whose hook expects a JSON-shaped return can now slot it in without a boundary cast.
+- `Serialization.fromEnvelope(envelope: unknown): Try<unknown>` — **unchanged**. Input stays `unknown` (the deliberate asymmetry — see above).
+
 ## 1.2.1 - 2026-06-01
 
 Post-1.2.0 conformance review (civala PDOS engine, which nests functype values inside DBOS durable-workflow checkpoints via SuperJSON) verified that 1.2.0's universal codec is correct and complete — all 12 Serializable types round-trip with methods intact, the `@functype` marker dispatches without Effect/fp-ts collision, malformed input returns `Failure` instead of throwing. This patch lands the one small enhancement that surfaced + two doc clarifications. None block 1.2.0 adoption; consumers can drop their inline shims once 1.2.1 ships. See `docs/proposals/serialization-1.2.1-followups.md`.

--- a/packages/functype/src/cli/data.ts
+++ b/packages/functype/src/cli/data.ts
@@ -469,8 +469,9 @@ export const TYPES: Record<string, TypeData> = {
         "Serialization.serialize(value: unknown): string — lenient JSON codec",
         "Serialization.deserialize(json: string): Try<unknown> — lenient; pass-through for unmarked JSON",
         "Serialization.deserializeStrict(json: string): Try<unknown> — Failure if no @functype marker at top level",
-        "Serialization.toEnvelope(value: unknown): unknown — parsed JSON shape (for SuperJSON/DBOS custom transformers)",
-        "Serialization.fromEnvelope(envelope: unknown): Try<unknown> — inverse of toEnvelope",
+        "Serialization.toEnvelope(value: unknown): JSONValue — parsed JSON shape (1.2.2 tightened from unknown)",
+        "Serialization.fromEnvelope(envelope: unknown): Try<unknown> — inverse of toEnvelope; input stays permissive (Postel's law)",
+        "Serialization.JSONValue — exported recursive type for the envelope shape",
       ],
       check: ["Serialization.isFunctypeValue(v): v is Serializable<unknown>"],
       other: [

--- a/packages/functype/src/serialization/Serialization.ts
+++ b/packages/functype/src/serialization/Serialization.ts
@@ -39,6 +39,19 @@ import { deserializeError, type SerializedError } from "./error-envelope"
 import { FUNCTYPE_MARKER } from "./SerializationCompanion"
 
 /**
+ * The canonical JSON value type — anything `JSON.parse` can return and
+ * anything `JSON.stringify` can accept as input. Used by `toEnvelope` /
+ * `fromEnvelope` to express the contract precisely: the envelope is a
+ * structured JSON shape, not opaque `unknown`. Lets consumers wiring this
+ * API into another structured serializer (SuperJSON, DBOS custom
+ * transformers) slot it in without a cast at the boundary.
+ *
+ * Added in 1.2.2 — `toEnvelope`/`fromEnvelope` previously typed input/output
+ * as `unknown`, which forced a cast at the consumer side.
+ */
+export type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue }
+
+/**
  * A reconstructor takes an already-revived parsed envelope object (with any
  * nested functype values already materialized into instances) and produces the
  * outer functype value. Distinct from each type's public `fromJSON(string)` —
@@ -209,12 +222,14 @@ export const serialize = (value: unknown): string => JSON.stringify(value ?? nul
  * destroying the round-trip.
  *
  * Equivalent to `JSON.parse(serialize(value))` but exposed as a named entry
- * point so consumers don't carry the parse/stringify shim. The output is
- * pure JSON (object, array, string, number, boolean, or null) — typed as
- * `unknown` for honesty (TS can't statically prove "JSON-shaped").
+ * point so consumers don't carry the parse/stringify shim.
+ *
+ * Returns `JSONValue` (tightened from `unknown` in 1.2.2) so consumers can
+ * drop the result straight into a host serializer's `serialize` hook without
+ * a boundary cast.
  *
  * @example
- *   // Inside a DBOS custom serialization recipe:
+ *   // Inside a DBOS custom serialization recipe — zero casts:
  *   DBOS.registerSerialization({
  *     name: "functype",
  *     isApplicable: Serialization.isFunctypeValue,
@@ -222,7 +237,7 @@ export const serialize = (value: unknown): string => JSON.stringify(value ?? nul
  *     deserialize: (o) => Serialization.fromEnvelope(o).orThrow(),
  *   })
  */
-export const toEnvelope = (value: unknown): unknown => JSON.parse(JSON.stringify(value ?? null)) as unknown
+export const toEnvelope = (value: unknown): JSONValue => JSON.parse(JSON.stringify(value ?? null)) as JSONValue
 
 /**
  * Inverse of `toEnvelope`: reconstruct any value from a parsed JSON envelope
@@ -232,6 +247,13 @@ export const toEnvelope = (value: unknown): unknown => JSON.parse(JSON.stringify
  *
  * Pass-through policy matches `deserialize`: a parsed value without an
  * `@functype` marker is returned verbatim as `Success(value)`.
+ *
+ * Input is `unknown` (intentionally permissive — Postel's law). Host
+ * serializers typically hand the deserialize callback a JSON-shaped value
+ * that they parsed themselves, but their callback typing varies (some are
+ * `JSONValue`, some are `unknown`, some are `any`). Accepting `unknown`
+ * here means the function slots into any host shape without forcing a
+ * cast at the consumer site.
  */
 export const fromEnvelope = (envelope: unknown): Try<unknown> => Try(() => revive(envelope))
 

--- a/packages/functype/test/serialization/conformance.spec.ts
+++ b/packages/functype/test/serialization/conformance.spec.ts
@@ -505,15 +505,24 @@ describe("Serialization — toEnvelope / fromEnvelope (structured-serializer nes
     expect(project(viaEnvelope)).toBe(project(viaDeserialize))
   })
 
-  it("structured-serializer integration (simulates SuperJSON / DBOS custom transformer)", () => {
+  it("structured-serializer integration (simulates SuperJSON / DBOS custom transformer) — zero casts", () => {
     // SuperJSON / DBOS custom transformers expect their hook to return a JSON
     // VALUE, not a string. If you pass `serialize` (string) the host re-walks
     // the result and explodes the string character-by-character. Simulating
     // that contract: the transformer hook must accept and return plain JSON.
-    const transformer = {
+    //
+    // 1.2.2 type-tightening: `toEnvelope: unknown → JSONValue` slots directly
+    // into the transformer's `serialize` slot — no cast at the boundary.
+    // `fromEnvelope` keeps its `unknown` input (Postel's law); `JSONValue` is
+    // assignable to `unknown` so the deserialize wrapper composes cleanly.
+    const transformer: {
+      isApplicable: (v: unknown) => boolean
+      serialize: (v: unknown) => Serialization.JSONValue
+      deserialize: (o: Serialization.JSONValue) => unknown
+    } = {
       isApplicable: Serialization.isFunctypeValue,
       serialize: Serialization.toEnvelope,
-      deserialize: (o: unknown) => Serialization.fromEnvelope(o).orThrow(),
+      deserialize: (o) => Serialization.fromEnvelope(o).orThrow(),
     }
 
     // Simulate the host: walks a structure, applies the transformer at each
@@ -536,7 +545,10 @@ describe("Serialization — toEnvelope / fromEnvelope (structured-serializer nes
     const hostParseAndRehydrate = (text: string): unknown => {
       const walk = (x: unknown): unknown => {
         if (x !== null && typeof x === "object" && !Array.isArray(x) && "__wrapped" in x) {
-          return transformer.deserialize((x as { __wrapped: unknown }).__wrapped)
+          // The host knows it stored a JSONValue (it walked + stringified its
+          // own structure), so it asserts that at the read boundary. The
+          // transformer itself takes JSONValue — no cast inside the hook.
+          return transformer.deserialize((x as { __wrapped: Serialization.JSONValue }).__wrapped)
         }
         if (Array.isArray(x)) return x.map(walk)
         if (x !== null && typeof x === "object") {


### PR DESCRIPTION
## Summary

Removes the consumer cast at the DBOS / SuperJSON transformer boundary called out in civala's post-1.2.1 write-up. `serialize: Serialization.toEnvelope` now slots into a `(v: unknown) => JSONValue`-shaped hook with zero casts.

## Design: asymmetric tightening (Postel's law)

```ts
toEnvelope:   (value: unknown) → JSONValue           // tightened
fromEnvelope: (envelope: unknown) → Try<unknown>     // UNCHANGED
```

Symmetric tightening would have introduced contravariant breakage — every caller with `unknown` input would need a cast at the call site. The asymmetric pattern matches stdlib precedent (`JSON.parse: string → any`, `JSON.stringify: any → string`, `Array.from(iter-like): Array<T>`): conservative output, liberal input.

## Changes

- New `Serialization.JSONValue` exported recursive type
- `toEnvelope` output type tightened from `unknown` to `JSONValue` (no runtime change, no breaking change — `JSONValue ⊂ unknown`)
- `fromEnvelope` signature unchanged
- DBOS-style structured-serializer integration test in the conformance suite updated to demonstrate zero-cast composition at the transformer boundary

## Test plan

- [x] `pnpm turbo run validate` green (10/10)
- [x] All 1725 tests still pass
- [x] The conformance test now uses the tightened `JSONValue` types in its transformer simulation — type-checks without casts at the transformer slots, with a single cast at the host plumbing boundary (which is the right place for it)
- [ ] CI re-runs the above

## Release plan

Cut as `functype@1.2.2` via `pnpm release patch` after merge. CHANGELOG `## Unreleased` is populated. Eslint pair → `2.102.2` via mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)