### PR TITLE
chore(serialization): re-export JSONValue at top level

### DIFF
--- a/packages/functype/CHANGELOG.md
+++ b/packages/functype/CHANGELOG.md
@@ -6,6 +6,10 @@ Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions: writ
 
 ## Unreleased
 
+Polish on the 1.2.2 type export: `JSONValue` is now reachable two ways — `Serialization.JSONValue` (via the namespace, as before) AND `import type { JSONValue } from "functype"` (top-level, new). Type-only re-export from the serialization barrel — safe across the import cycle that prevents value-level re-exports of the `Serialization` namespace from that path. Conformance suite gains a compile-time assertion that both paths resolve to the same type.
+
+No runtime change. No release cut now — lands when the next patch ships.
+
 ## 1.2.2 - 2026-06-01
 
 Type-tightening on `toEnvelope` output (and new `JSONValue` type export) so the DBOS / SuperJSON consumer recipe slots in with zero casts at the boundary. Asymmetric by design — only the OUTPUT tightens; `fromEnvelope`'s input stays `unknown` to preserve Postel's law (be conservative in what you send, liberal in what you accept — same pattern stdlib uses for `JSON.parse`/`stringify`, `Array.from`, etc.). Tightening the input too would push casts up the chain to every less-typed host plumbing layer for no runtime benefit.

--- a/packages/functype/src/serialization/index.ts
+++ b/packages/functype/src/serialization/index.ts
@@ -5,5 +5,11 @@ export * from "./SerializationCompanion"
 // index would create a cycle: per-type module → @/serialization → Serialization
 // → per-type module (undefined at evaluation time).
 //
-// Public access goes through the root `src/index.ts` instead, where it appears
-// AFTER all per-type modules have loaded.
+// Public access to the namespace goes through the root `src/index.ts` instead,
+// where it appears AFTER all per-type modules have loaded.
+//
+// Type-only re-exports are safe here — TS erases them at compile time, so they
+// can't cause a runtime cycle. This lets consumers do
+// `import type { JSONValue } from "functype"` in addition to the namespaced
+// `Serialization.JSONValue` form.
+export type { JSONValue } from "./Serialization"

--- a/packages/functype/test/serialization/conformance.spec.ts
+++ b/packages/functype/test/serialization/conformance.spec.ts
@@ -28,6 +28,11 @@ import { Map as FunctypeMap } from "@/map/Map"
 import { Obj } from "@/obj/Obj"
 import { None, Option, Some } from "@/option"
 import * as Serialization from "@/serialization/Serialization"
+// 1.2.x: JSONValue is reachable two ways — via the `Serialization` namespace
+// (`Serialization.JSONValue`) AND via a direct named import from the
+// serialization barrel. The line below is a compile-time assertion that the
+// top-level path resolves; if the barrel re-export is dropped, this fails.
+import type { JSONValue as TopLevelJSONValue } from "@/serialization"
 import { Set as FunctypeSet } from "@/set/Set"
 import { Stack } from "@/stack/Stack"
 import { Task, type TaskOutcome } from "@/core/task/Task"
@@ -425,6 +430,16 @@ describe("Serialization — DBOS-style consumer pattern (no facade)", () => {
 // ───────────────────────────────────────────────────────────────────────────
 // 1.2.1 additions — envelope helpers + strict deserialize
 // ───────────────────────────────────────────────────────────────────────────
+
+describe("Serialization — JSONValue is reachable from both import paths", () => {
+  it("namespaced (Serialization.JSONValue) and top-level (import type { JSONValue }) resolve to the same type", () => {
+    // Compile-time assertion via mutual assignability — runtime is a no-op.
+    const a: Serialization.JSONValue = { foo: "bar", n: 1, nested: [true, null] }
+    const b: TopLevelJSONValue = a
+    const c: Serialization.JSONValue = b
+    expect(c).toEqual(a)
+  })
+})
 
 describe("Serialization — toEnvelope / fromEnvelope (structured-serializer nesting)", () => {
   it("toEnvelope returns a parsed JSON shape, not a string", () => {


### PR DESCRIPTION
## Summary

Closes a small consumer ergonomics gap from 1.2.2: `JSONValue` was reachable as `Serialization.JSONValue` (via the namespace) but not as a top-level named import. Adds a type-only re-export from the serialization barrel so both forms work:

\`\`\`ts
import { Serialization } from \"functype\"
type X = Serialization.JSONValue

import type { JSONValue } from \"functype\"   // ← new
type Y = JSONValue
\`\`\`

## Why type-only

The serialization barrel (`@/serialization/index.ts`) deliberately doesn't re-export `Serialization.ts` because of a runtime cycle (per-type module → `@/serialization` → `Serialization` → per-type module). Type-only re-exports are erased by TS at compile time and can't cause runtime cycles, so they're safe through the same path.

## Tests

Conformance suite gains a compile-time assertion (mutual assignability of `Serialization.JSONValue` and the top-level `JSONValue`). If the barrel re-export gets dropped in a future change, the test fails at typecheck.

## Release plan

**No release cut.** Per the original request — stages for the next patch when there's something else to bundle. CHANGELOG `## Unreleased` documents the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)