### PR TITLE
docs(functype): point build-guard scripts at tracking issue #179

### DIFF
--- a/packages/functype/scripts/build-verified.mjs
+++ b/packages/functype/scripts/build-verified.mjs
@@ -29,8 +29,9 @@
 //   • REMOVAL: restore `"build": "ts-builds build"` in package.json, delete this
 //     file and scripts/check-build-determinism.mjs, and restore the top-barrel
 //     re-exports that were trimmed as earlier workarounds (Logger, see src/index.ts).
-//   • Tracking: see the PR that introduced this guard; file an upstream rolldown
-//     issue (renamer determinism under code-splitting) to track the real fix.
+//   • Tracking: jordanburke/functype#179 (monitoring + removal checklist there).
+//     Upstream: file/track at rolldown/rolldown (renamer determinism under
+//     code-splitting) and link it from #179.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { execFileSync } from "node:child_process"

--- a/packages/functype/scripts/check-build-determinism.mjs
+++ b/packages/functype/scripts/check-build-determinism.mjs
@@ -16,6 +16,7 @@
 //
 // REMOVE the guard once this reports 0 failures across a representative window
 // (ideally under the constrained invocation above) on a fixed rolldown version.
+// Tracking: jordanburke/functype#179.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { execFileSync } from "node:child_process"


### PR DESCRIPTION
Doc-only follow-up to #178. Wires the in-code tracking pointer in `build-verified.mjs` and `check-build-determinism.mjs` to the concrete tracking issue #179 (which holds the monitoring + removal checklist), instead of the generic "see the PR" text. No behavior change.

Also filed #180 for the separate broken-`exports`-subpaths bug found during that investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)