### PR TITLE
fix(functype): build all advertised exports subpaths (#180)

### DIFF
--- a/packages/functype/tsdown.config.ts
+++ b/packages/functype/tsdown.config.ts
@@ -2,33 +2,40 @@ import { defineConfig } from "tsdown"
 
 const isProduction = process.env.NODE_ENV === "production"
 
-// Define the modules we want to expose as separate entry points
-const modules = ["option", "either", "try", "list", "map", "set", "tuple", "branded", "do", "logger"]
-
-// Create entry points for each module
+// Build entry points. One entry per published `exports` subpath in package.json —
+// every `./x` → `dist/x/index.js` must have a matching entry here, or the subpath
+// resolves to an unbuilt file (ERR_MODULE_NOT_FOUND). Kept as an explicit map so a
+// new subpath can't silently drift out of the build (see #180).
 const entries = {
   index: "src/index.ts",
   "cli/index": "src/cli/index.ts",
   "cli/exports": "src/cli/exports.ts",
-  ...Object.fromEntries(
-    modules.map((module) => {
-      // Special case for task which is in core/task
-      if (module === "task") {
-        return [`core/task/index`, `src/core/task/Task.ts`]
-      }
-      // Special case for branded module
-      if (module === "branded") {
-        return [`${module}/index`, `src/${module}/Brand.ts`]
-      }
-      // Special case for do module (just index.ts)
-      if (module === "do") {
-        return [`${module}/index`, `src/${module}/index.ts`]
-      }
-      // Handle regular modules
-      const path = module.includes("/") ? module : `${module}/${module.charAt(0).toUpperCase() + module.slice(1)}`
-      return [`${module}/index`, `src/${path}.ts`]
-    }),
-  ),
+  // Core types — entry points target each type's main file (not its barrel index.ts,
+  // whose surface intentionally differs, e.g. list/index re-exports LazyList too).
+  "option/index": "src/option/Option.ts",
+  "either/index": "src/either/Either.ts",
+  "try/index": "src/try/Try.ts",
+  "list/index": "src/list/List.ts",
+  "map/index": "src/map/Map.ts",
+  "set/index": "src/set/Set.ts",
+  "tuple/index": "src/tuple/Tuple.ts",
+  "branded/index": "src/branded/Brand.ts",
+  "do/index": "src/do/index.ts",
+  "logger/index": "src/logger/Logger.ts",
+  // Subpaths advertised in `exports` but previously never built (#180) — each maps to
+  // its module barrel, matching what the top barrel re-exports (`export * from "@/io"` …).
+  "conditional/index": "src/conditional/index.ts",
+  "decoder/index": "src/decoder/index.ts",
+  "lazy/index": "src/lazy/index.ts",
+  "core/task/index": "src/core/task/index.ts",
+  "io/index": "src/io/index.ts",
+  "functype/index": "src/functype/index.ts",
+  "typeclass/index": "src/typeclass/index.ts",
+  "obj/index": "src/obj/index.ts",
+  "companion/index": "src/companion/index.ts",
+  "serialization/index": "src/serialization/index.ts",
+  "util/index": "src/util/index.ts",
+  "fetch/index": "src/fetch/index.ts",
 }
 
 export default defineConfig({


### PR DESCRIPTION
Fixes #180.

## Problem
12 of the 24 `exports` subpaths resolved to `dist/*/index.js` files that were never built — only the modules listed in `tsdown.config.ts`'s `modules` array became entries (and a dead `task` special-case that never ran). So these all failed at runtime with `ERR_MODULE_NOT_FOUND`:

`conditional`, `decoder`, `lazy`, `task`, `io`, `functype`, `typeclass`, `obj`, `companion`, `serialization`, `util`, `fetch`

## Fix
Replaced the implicit `modules`-array entry logic with an **explicit entry map** — one entry per published subpath, so a subpath can't silently drift out of the build again.

- The 12 working core-type entries keep their existing main-file sources (`option`→`Option.ts`, `list`→`List.ts`, …), so their published surface is **unchanged**.
- The 12 missing subpaths map to their module barrel (`src/<x>/index.ts`), matching what the top barrel already re-exports (`export * from "@/io"`, …).

## Verification
- All **24** `exports` subpaths now resolve and load — 0 missing, 0 load-failures.
- All `types` (`.d.ts`) targets present.
- `pnpm -F functype validate` green — 1757 tests pass.
- New entries are thin re-export shims (~100–250 B) over existing shared chunks; negligible bundle impact (dist 396 KB → 403 KB).
- Build-guard (#179) exercised the new entries fine (caught the rolldown race once, retried, shipped clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)