### PR TITLE
feat(functype-eval): add FP fitness scoring CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file provides guidance to Claude Code when working in this monorepo. Per-pa
 | `functype-os` | `packages/functype-os` | `functype-os` | OS utilities |
 | `functype-log` | `packages/functype-log` | `functype-log` | IO-native logging via LogLayer |
 | `functype-react` | `packages/functype-react` | `functype-react` | React bindings (v0.1 scaffold) |
+| `functype-eval` | `packages/functype-eval` | `functype-eval` | FP fitness scoring CLI (consumes `eslint-plugin-functype`) |
 | `functype-mcp-server` | `packages/mcp-server` | `functype-mcp-server` | Documentation/validation MCP server |
 | `site` | `site` | (not published) | Astro docs site |
 
@@ -18,7 +19,7 @@ This file provides guidance to Claude Code when working in this monorepo. Per-pa
 - **Package manager:** pnpm 10.x with workspaces (`packages/*` + `site`).
 - **Task runner:** Turborepo (`turbo.json`) — pipelines: `build`, `test`, `lint`, `lint:check`, `format`, `format:check`, `typecheck`, `compile`, `validate`, `dev`. `build`/`test`/`validate` declare `^build` deps so workspace consumers wait for producers.
 - **Build:** Each package builds via `ts-builds` (calls `tsdown` under the hood) — uniform across the workspace.
-- **Versioning + publish:** **tag-driven release flow** (`scripts/release.ts` + `.github/workflows/publish.yml` on tag push). The 5 functype-* packages bump together on the `1.x` line. The eslint pair bumps together on the `2.100.x` line, **mirroring functype** per the encoding `eslint = 2.{functype.major*100 + functype.minor}.{functype.patch}` — so `functype@1.1.0` ↔ `eslint@2.101.0`, `functype@1.20.1` ↔ `eslint@2.120.1`. Run `pnpm release patch|minor|major` locally; it bumps all 7 packages, syncs the mirror, syncs `mcp-server/server.json`, cuts the `## Unreleased` section of `packages/functype/CHANGELOG.md`, commits, and tags. `git push --follow-tags` triggers CI publish. See [`docs/RELEASE.md`](./docs/RELEASE.md) for the full runbook including npm trusted-publisher setup.
+- **Versioning + publish:** **tag-driven release flow** (`scripts/release.ts` + `.github/workflows/publish.yml` on tag push). The 6 functype-* packages bump together on the `1.x` line. The eslint pair bumps together on the `2.100.x` line, **mirroring functype** per the encoding `eslint = 2.{functype.major*100 + functype.minor}.{functype.patch}` — so `functype@1.1.0` ↔ `eslint@2.101.0`, `functype@1.20.1` ↔ `eslint@2.120.1`. Run `pnpm release patch|minor|major` locally; it bumps all 8 packages, syncs the mirror, syncs `mcp-server/server.json`, cuts the `## Unreleased` section of `packages/functype/CHANGELOG.md`, commits, and tags. `git push --follow-tags` triggers CI publish. See [`docs/RELEASE.md`](./docs/RELEASE.md) for the full runbook including npm trusted-publisher setup.
   - **Major bumps require explicit publish-time authorization** via the `ALLOW_MAJOR=<pkg>[,<pkg>]` env on `pnpm release major` AND on the publish workflow step. Added after the 2026-05-30 `0.60.7 → 1.0.0` cascade — see history for the post-mortem.
   - **Peer dep convention:** packages in this workspace that peer-depend on `functype` use broad ranges like `">=0.60.0"` (NOT `"workspace:^"`). The narrow `workspace:^` range is what caused the cascade — it published as `^0.60.7` which goes out of scope on a 0.61 bump, and Changesets's auto-cascade force-major-bumped the dependents. The tag-driven flow no longer has Changesets's auto-cascade, but the broad range stays as defensive practice (peer ranges should accept the actual consumer surface).
 - **Node version:** Read from `.nvmrc` (currently `24`). Required by `publish.yml` to avoid the npm 10.x OIDC bug.
@@ -47,7 +48,7 @@ pnpm changeset status              # see what's queued
 ## Workflows
 
 - **`.github/workflows/ci.yml`** — runs on PR + push to main. `pnpm turbo run validate`. Includes a path-filtered bundle-size job for `packages/functype/**`.
-- **`.github/workflows/publish.yml`** — runs on push to main. Uses `changesets/action@v1` to either open a "Version Packages" PR (when changesets are queued) or run `pnpm -r publish` when that PR merges. Provenance + OIDC for `functype`, `functype-os`, `functype-log`, `functype-react`; token auth for `functype-mcp-server`.
+- **`.github/workflows/publish.yml`** — runs on push to main. Uses `changesets/action@v1` to either open a "Version Packages" PR (when changesets are queued) or run `pnpm -r publish` when that PR merges. Provenance + OIDC for `functype`, `functype-os`, `functype-log`, `functype-react`, `functype-eval`; token auth for `functype-mcp-server`.
 - **`.github/workflows/deploy-docs.yml`** — builds the Astro site + TypeDoc on push to main, publishes to GitHub Pages.
 - **`.github/workflows/auto-merge-dependabot.yml`** — auto-merges patch/minor Dependabot PRs.
 

--- a/packages/functype-eval/CHANGELOG.md
+++ b/packages/functype-eval/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+`functype-eval` is part of the 5-package functype family and bumps in lockstep with `functype`. The
+canonical changelog for the family is [`packages/functype/CHANGELOG.md`](../functype/CHANGELOG.md).
+Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions; `pnpm release` cuts the
+`## Unreleased` section into a dated version header.
+
+## Unreleased
+
+### Added
+
+- Initial release: `functype-eval score <target>` — a 0–100 FP fitness score with a per-dimension
+  breakdown, running `eslint-plugin-functype` via the ESLint Node API, `type-coverage-core`, and a
+  ts-morph non-null-assertion scan. Supports `--json` and `--threshold N` for CI gating. `bench`
+  (Phase 2 LLM eval) ships as a stub.

--- a/packages/functype-eval/CLAUDE.md
+++ b/packages/functype-eval/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md — functype-eval
+
+Guidance for Claude Code when working in this package. Repo-wide conventions live in the root
+[`CLAUDE.md`](../../CLAUDE.md); the library reference lives in
+[`packages/functype/CLAUDE.md`](../functype/CLAUDE.md).
+
+## What this package does
+
+`functype-eval` measures how well a TypeScript codebase adheres to functype/FP idioms and produces a
+**0–100 fitness score** with a per-dimension breakdown. One scorer, two intended use cases:
+
+1. **Codebase fitness** — `functype-eval score ./src` → how functional is this code.
+2. **LLM eval** (future) — `functype-eval bench` → can models write functype-compliant code, scored
+   by the same engine.
+
+## Phases
+
+- **Phase 1 (current): the `score` CLI.** Fully implemented.
+- **Phase 2 (future): `bench`** — run programming tasks through LLMs (Anthropic API) under varying
+  context conditions, score each solution with the Phase 1 scorer. Currently a stub.
+- **Phase 3 (future): MCP server** — expose `score-codebase` / `suggest-functype-fix` as MCP tools.
+
+## Scoring model
+
+The composite is a weighted sum of dimension scores (each 0.0–1.0), ×100.
+
+| Dimension     | Weight | Source                 | Rules                                                       |
+| ------------- | ------ | ---------------------- | ----------------------------------------------------------- |
+| immutability  | 0.15   | eslint-plugin-functype | `no-let`                                                    |
+| option        | 0.15   | eslint-plugin-functype | `prefer-option`                                             |
+| either        | 0.15   | eslint-plugin-functype | `prefer-either`                                             |
+| composition   | 0.10   | eslint-plugin-functype | `prefer-flatmap`, `prefer-fold`, `prefer-map`               |
+| collections   | 0.10   | eslint-plugin-functype | `prefer-list`, `prefer-functype-map`, `prefer-functype-set` |
+| do-notation   | 0.05   | eslint-plugin-functype | `prefer-do-notation`                                        |
+| safety        | 0.10   | eslint-plugin-functype | `no-get-unsafe`                                             |
+| loops         | 0.05   | eslint-plugin-functype | `no-imperative-loops`                                       |
+| type-coverage | 0.10   | type-coverage-core     | (native percent)                                            |
+| non-null      | 0.05   | ts-morph               | `!` non-null assertion density                              |
+
+All 12 plugin rules are scored. Weights sum to 1.0 and are overridable via an optional
+`functype-eval.config.json`.
+
+### Normalization (density, not adherence ratio)
+
+ESLint reports violation **counts**, not how many places _could_ have used the pattern. So lint
+dimensions (and the non-null dimension) normalize by **density vs KLOC**:
+
+```
+score_d = 1 / (1 + (violations_d / KLOC) * k_d)
+```
+
+`k_d` is a per-dimension sensitivity constant (defaults in `src/types/index.ts`). `type-coverage` is
+already a native ratio (`percent / 100`) and skips density normalization.
+
+> **Future, fix-at-the-source path:** a _true_ adherence ratio (`1 - violations/opportunities`) would
+> need an opportunity denominator. That belongs in `eslint-plugin-functype` (have rules emit
+> opportunity counts), consumed here — **not** a second ts-morph pass that re-detects the same
+> patterns. See anti-patterns.
+
+### type-coverage tsconfig resolution
+
+Only this dimension needs the target's TS program. Resolution: `--project <path>` → else autodetect
+`tsconfig.json` in the target → else **skip the dimension and renormalize the other 9 weights** to
+sum to 1.0 (breakdown shows `type-coverage: skipped`).
+
+## Architecture
+
+```
+src/
+  types/index.ts          # DimensionId, DimensionConfig, ScoreResult, DEFAULT_DIMENSIONS
+  scorers/
+    eslint.ts             # eslint-plugin-functype via ESLint Node API (plugin registered)
+    type-coverage.ts      # type-coverage-core (native percent)
+    ts-morph.ts           # non-null assertion scan
+    aggregate.ts          # density formula + weighted composite + renormalization
+  cli/
+    index.ts              # bin entry (shebang): score | bench | --help
+    score.ts              # `functype-eval score <target>` — table / --json / --threshold
+    bench.ts              # Phase 2 stub
+  index.ts                # public API: score(), ScoreResult
+test/scorers/             # mirrors src/scorers
+```
+
+## Anti-patterns
+
+- **Don't shell out to ESLint.** Use the Node API (`new ESLint(...)`).
+- **Don't reimplement lint rules.** If a new pattern needs detection, add it to
+  `eslint-plugin-functype` first, then consume it here. This is why scoring is density-based rather
+  than opportunity-based today.
+- **Don't couple scoring to an LLM.** The scorer is pure static analysis; Phase 2 `bench` calls LLMs
+  but scoring stays deterministic.
+- **No `any`.** Use `unknown` and narrow. functype patterns for state (Option/Either/List).
+- **Don't hand-edit CHANGELOG.** The tag-driven release flow (`pnpm release`) manages versions.
+
+## Conventions
+
+- TypeScript strict; build/lint/format/test via `ts-builds`. Vitest, tests colocated in `test/`.
+- ESM-only (`"type": "module"`).
+- **Runtime deps** (`eslint-plugin-functype`, `@typescript-eslint/parser`, `ts-morph`,
+  `type-coverage-core`) — this package evaluates code that _uses_ functype, so functype itself is a
+  **devDep only**, not a peer.
+- **Versioning:** part of the 5-package functype family on the `1.x` line. It must be listed in
+  `FAMILY_PACKAGE_DIRS` in [`scripts/release.ts`](../../scripts/release.ts). Release with
+  `pnpm release patch|minor|major` from the repo root (tag-driven).

--- a/packages/functype-eval/README.md
+++ b/packages/functype-eval/README.md
@@ -1,0 +1,74 @@
+# functype-eval
+
+Fitness scoring for functional TypeScript codebases using the [functype](https://github.com/jordanburke/functype) ecosystem.
+
+`functype-eval` measures how well a TypeScript codebase adheres to functype / functional-programming
+idioms and produces a **0–100 fitness score** with a per-dimension breakdown. It runs
+[`eslint-plugin-functype`](https://www.npmjs.com/package/eslint-plugin-functype) programmatically (no
+shelling out), plus type-coverage and a non-null-assertion scan, and aggregates the results.
+
+## Install
+
+```bash
+pnpm add -D functype-eval
+# or run directly
+npx functype-eval score ./src
+```
+
+## Usage
+
+```bash
+functype-eval score <target>            # score a directory, print breakdown + 0–100
+functype-eval score ./src --json        # machine-readable output (for CI)
+functype-eval score ./src --threshold 80   # exit 1 if score < 80 (CI gate)
+functype-eval score ./src --project tsconfig.json   # explicit tsconfig for type-coverage
+```
+
+### Example
+
+```
+functype-eval score ./src
+
+  Dimension       Weight   Score
+  ─────────────────────────────────
+  immutability     0.15     0.94
+  option           0.15     0.88
+  either           0.15     0.91
+  composition      0.10     0.97
+  collections      0.10     1.00
+  do-notation      0.05     1.00
+  safety           0.10     1.00
+  loops            0.05     0.96
+  type-coverage    0.10     0.99
+  non-null         0.05     1.00
+  ─────────────────────────────────
+  Fitness score:  94 / 100
+```
+
+## How the score works
+
+The composite is a weighted sum of ten dimensions (see [CLAUDE.md](./CLAUDE.md) for the full table
+and weights). The eight ESLint dimensions and the non-null dimension are normalized by **violation
+density** per 1000 lines of code:
+
+```
+score = 1 / (1 + (violations / KLOC) * k)
+```
+
+`type-coverage` contributes its native percentage. If the target has no resolvable `tsconfig.json`,
+the type-coverage dimension is skipped and the remaining weights are renormalized — you still get a
+score. Weights and per-dimension sensitivity are overridable via an optional
+`functype-eval.config.json`.
+
+The score is **deterministic**: same input → same output. No network, no LLM calls.
+
+## Roadmap
+
+- **Phase 1 (current):** the `score` CLI.
+- **Phase 2:** `functype-eval bench` — run programming tasks through LLMs and score the output with
+  this same engine.
+- **Phase 3:** an MCP server exposing `score-codebase` / `suggest-functype-fix`.
+
+## License
+
+MIT © Jordan Burke

--- a/packages/functype-eval/eslint.config.mjs
+++ b/packages/functype-eval/eslint.config.mjs
@@ -1,0 +1,23 @@
+import baseConfig from "ts-builds/eslint-functype"
+
+export default [
+  ...baseConfig,
+  {
+    // functype-eval is a static-analysis tool with ZERO functype runtime dependency by design — it
+    // scores code that *uses* functype but must not require functype itself (so consumers don't pull
+    // it in transitively). The "prefer the functype API" rules therefore don't apply to its own
+    // source; we still keep no-let / no-imperative-loops, which need no runtime dependency.
+    rules: {
+      "functype/prefer-option": "off",
+      "functype/prefer-either": "off",
+      "functype/prefer-fold": "off",
+      "functype/prefer-map": "off",
+      "functype/prefer-flatmap": "off",
+      "functype/prefer-list": "off",
+      "functype/prefer-functype-map": "off",
+      "functype/prefer-functype-set": "off",
+      "functype/prefer-do-notation": "off",
+      "functype/no-get-unsafe": "off",
+    },
+  },
+]

--- a/packages/functype-eval/package.json
+++ b/packages/functype-eval/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "functype-eval",
+  "version": "1.3.1",
+  "description": "Fitness scoring and LLM evaluation for functional TypeScript codebases using the functype ecosystem",
+  "keywords": [
+    "functype",
+    "functional",
+    "typescript",
+    "eval",
+    "fitness",
+    "score",
+    "llm",
+    "code-quality",
+    "static-analysis"
+  ],
+  "author": {
+    "name": "Jordan Burke",
+    "url": "https://github.com/jordanburke"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/jordanburke/functype/tree/main/packages/functype-eval#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jordanburke/functype.git",
+    "directory": "packages/functype-eval"
+  },
+  "bugs": {
+    "url": "https://github.com/jordanburke/functype/issues"
+  },
+  "scripts": {
+    "validate": "ts-builds validate",
+    "format": "ts-builds format",
+    "format:check": "ts-builds format:check",
+    "lint": "ts-builds lint",
+    "lint:check": "ts-builds lint:check",
+    "typecheck": "ts-builds typecheck",
+    "test": "ts-builds test",
+    "test:watch": "ts-builds test:watch",
+    "test:coverage": "ts-builds test:coverage",
+    "build": "NODE_ENV=production ts-builds build",
+    "dev": "ts-builds dev",
+    "prepublishOnly": "pnpm validate"
+  },
+  "bin": {
+    "functype-eval": "dist/cli/index.js"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "prettier": "ts-builds/prettier",
+  "peerDependencies": {
+    "eslint": "^10.2.1",
+    "typescript": ">=5.3.0"
+  },
+  "dependencies": {
+    "@typescript-eslint/parser": "^8.60.1",
+    "eslint-plugin-functype": "workspace:^",
+    "ts-morph": "^25.0.0",
+    "type-coverage-core": "^2.29.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.4",
+    "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
+    "functype": "workspace:^",
+    "ts-builds": "^3.0.0",
+    "tsdown": "^0.22.1",
+    "vitest": "^4.1.8"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=20.20.0"
+  }
+}

--- a/packages/functype-eval/src/cli/bench.ts
+++ b/packages/functype-eval/src/cli/bench.ts
@@ -1,0 +1,19 @@
+/**
+ * `functype-eval bench` — Phase 2 LLM eval harness. Not yet implemented.
+ *
+ * Planned: run a suite of TypeScript programming tasks through LLMs under varying context conditions
+ * (zero-shot, few-shot, full docs, MCP), then score each generated solution with the Phase 1 scorer
+ * (`score()` from the package root) to produce a model × context results table.
+ */
+
+export const runBench = (_args: ReadonlyArray<string>): number => {
+  console.error(
+    [
+      "functype-eval bench — not yet implemented (Phase 2).",
+      "",
+      "Phase 1 (`functype-eval score <target>`) is the deterministic scorer that Phase 2 will use as",
+      "its metric. The LLM eval harness lands in a future release.",
+    ].join("\n"),
+  )
+  return 1
+}

--- a/packages/functype-eval/src/cli/index.ts
+++ b/packages/functype-eval/src/cli/index.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { runBench } from "./bench"
+import { runScore } from "./score"
+
+declare const __VERSION__: string
+
+const HELP = `
+functype-eval v${__VERSION__}
+
+FP fitness scoring for functional TypeScript codebases using the functype ecosystem.
+
+Usage: functype-eval <command> [options]
+
+Commands:
+  score <target>        Score a directory's functype/FP adherence (0–100)
+  bench                 LLM eval harness (Phase 2, not yet implemented)
+
+Score options:
+  --json                Emit the result as JSON (for CI)
+  --threshold <n>       Exit 1 if the score is below <n>
+  --project <tsconfig>  tsconfig for the type-coverage dimension (else autodetected, else skipped)
+
+Global:
+  -v, --version         Show version number
+  -h, --help            Show help
+
+Examples:
+  functype-eval score ./src
+  functype-eval score ./src --json --threshold 80
+`
+
+const main = async (argv: ReadonlyArray<string>): Promise<number> => {
+  const args = argv.slice(2)
+  const command = args[0]
+
+  if (args.includes("--version") || args.includes("-v")) {
+    console.log(__VERSION__)
+    return 0
+  }
+  if (args.length === 0 || command === "--help" || command === "-h" || command === "help") {
+    console.log(HELP)
+    return 0
+  }
+  if (command === "score") return runScore(args.slice(1))
+  if (command === "bench") return runBench(args.slice(1))
+
+  console.error(`Unknown command: ${command}`)
+  console.error(HELP)
+  return 1
+}
+
+main(process.argv)
+  .then((code) => process.exit(code))
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })

--- a/packages/functype-eval/src/cli/score.ts
+++ b/packages/functype-eval/src/cli/score.ts
@@ -1,0 +1,89 @@
+/**
+ * `functype-eval score <target>` — prints a per-dimension breakdown and a 0–100 fitness score.
+ * Flags: `--json` (machine-readable), `--threshold N` (exit 1 when below), `--project <tsconfig>`.
+ * An optional `functype-eval.config.json` in cwd may supply `{ "weights": { ... } }` overrides.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { score } from "../index"
+import { type ScoreOptions, type ScoreResult } from "../types/index"
+
+type ParsedArgs = {
+  readonly target?: string
+  readonly json: boolean
+  readonly threshold?: number
+  readonly project?: string
+}
+
+const EMPTY_ARGS: ParsedArgs = { json: false }
+
+const parseArgs = (args: ReadonlyArray<string>): ParsedArgs =>
+  args.reduce<{ acc: ParsedArgs; skip: boolean }>(
+    ({ acc, skip }, arg, index) => {
+      if (skip) return { acc, skip: false }
+      const next = args[index + 1]
+      if (arg === "--json") return { acc: { ...acc, json: true }, skip: false }
+      if (arg === "--threshold") return { acc: { ...acc, threshold: Number(next) }, skip: true }
+      if (arg.startsWith("--threshold=")) return { acc: { ...acc, threshold: Number(arg.slice(12)) }, skip: false }
+      if (arg === "--project") return { acc: { ...acc, project: next }, skip: true }
+      if (arg.startsWith("--project=")) return { acc: { ...acc, project: arg.slice(10) }, skip: false }
+      if (!arg.startsWith("-") && acc.target === undefined) return { acc: { ...acc, target: arg }, skip: false }
+      return { acc, skip: false }
+    },
+    { acc: EMPTY_ARGS, skip: false },
+  ).acc
+
+const loadConfig = (): ScoreOptions => {
+  const path = resolve(process.cwd(), "functype-eval.config.json")
+  if (!existsSync(path)) return {}
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as { weights?: ScoreOptions["weights"] }
+  return parsed.weights === undefined ? {} : { weights: parsed.weights }
+}
+
+const pad = (value: string, width: number): string => value.padEnd(width)
+const padStart = (value: string, width: number): string => value.padStart(width)
+
+const formatTable = (result: ScoreResult): string => {
+  const header = `  ${pad("Dimension", 15)}${padStart("Weight", 8)}${padStart("Score", 8)}   Detail`
+  const divider = `  ${"─".repeat(46)}`
+  const rows = result.dimensions.map(
+    (d) =>
+      `  ${pad(d.id, 15)}${padStart(d.weight.toFixed(2), 8)}${padStart(d.skipped ? "—" : d.score.toFixed(2), 8)}   ${d.detail}`,
+  )
+  return [
+    `\n  functype-eval — ${result.target}`,
+    "",
+    header,
+    divider,
+    ...rows,
+    divider,
+    `  Fitness score:  ${result.score} / 100   (${result.loc} LOC)`,
+    "",
+  ].join("\n")
+}
+
+export const runScore = async (args: ReadonlyArray<string>): Promise<number> => {
+  const parsed = parseArgs(args)
+  if (parsed.target === undefined) {
+    console.error("Usage: functype-eval score <target> [--json] [--threshold N] [--project <tsconfig>]")
+    return 1
+  }
+
+  const config = loadConfig()
+  const result = await score(parsed.target, {
+    weights: config.weights,
+    project: parsed.project ?? config.project,
+  })
+
+  console.log(parsed.json ? JSON.stringify(result, null, 2) : formatTable(result))
+
+  if (parsed.threshold !== undefined && result.score < parsed.threshold) {
+    if (!parsed.json) {
+      console.error(`✗ score ${result.score} is below threshold ${parsed.threshold}`)
+    }
+    return 1
+  }
+  return 0
+}

--- a/packages/functype-eval/src/eslint-plugin-functype.d.ts
+++ b/packages/functype-eval/src/eslint-plugin-functype.d.ts
@@ -1,0 +1,12 @@
+// `eslint-plugin-functype` is an ESM-only sibling workspace package whose emitted types live in its
+// `dist/`. During `turbo run validate` that `dist/` is rebuilt with `clean: true`, so it can briefly
+// vanish and race our typecheck (intermittent `TS2307: Cannot find module 'eslint-plugin-functype'`).
+//
+// We only consume the default export as an opaque ESLint plugin object (registered under the
+// `functype` namespace and cast to `ESLint.Plugin` at the use site), so this minimal ambient
+// declaration decouples our typecheck from the sibling's build artifacts. When the real `dist` types
+// are present TypeScript still resolves them; this only provides a stable fallback.
+declare module "eslint-plugin-functype" {
+  const plugin: unknown
+  export default plugin
+}

--- a/packages/functype-eval/src/index.ts
+++ b/packages/functype-eval/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * functype-eval public API.
+ *
+ * `score(target, options)` runs the three scorers and aggregates them into a `ScoreResult`. The
+ * result is deterministic: same input → same output, no network, no LLM calls.
+ */
+
+import { aggregate } from "./scorers/aggregate"
+import { scoreEslint } from "./scorers/eslint"
+import { scoreTsMorph } from "./scorers/ts-morph"
+import { scoreTypeCoverage } from "./scorers/type-coverage"
+import { DEFAULT_DIMENSIONS, type DimensionConfig, type ScoreOptions, type ScoreResult } from "./types/index"
+
+export type { DimensionConfig, DimensionId, DimensionScore, ScoreOptions, ScoreResult } from "./types/index"
+export { DEFAULT_DIMENSIONS } from "./types/index"
+
+/** Apply per-dimension weight overrides (e.g. from `functype-eval.config.json`) to the defaults. */
+const applyWeightOverrides = (
+  dimensions: ReadonlyArray<DimensionConfig>,
+  weights?: ScoreOptions["weights"],
+): ReadonlyArray<DimensionConfig> =>
+  weights === undefined
+    ? dimensions
+    : dimensions.map((dim) => {
+        const override = weights[dim.id]
+        return override === undefined ? dim : { ...dim, weight: override }
+      })
+
+/** Score a directory for functype/FP fitness. */
+export const score = async (target: string, options: ScoreOptions = {}): Promise<ScoreResult> => {
+  const dimensions = applyWeightOverrides(DEFAULT_DIMENSIONS, options.weights)
+
+  // scoreEslint is the only async scorer; type-coverage (lintSync) and ts-morph are CPU-bound and
+  // synchronous, so there's nothing to parallelize — sequence them after the lint pass.
+  const ruleCounts = await scoreEslint(target, dimensions)
+  const typeCoverage = scoreTypeCoverage(target, options.project)
+  const tsMorph = scoreTsMorph(target)
+
+  return aggregate({ target, dimensions, ruleCounts, typeCoverage, tsMorph })
+}

--- a/packages/functype-eval/src/scorers/aggregate.ts
+++ b/packages/functype-eval/src/scorers/aggregate.ts
@@ -1,0 +1,108 @@
+/**
+ * Combines the three scorer outputs into a single `ScoreResult`.
+ *
+ * Lint and non-null dimensions normalize by violation density:
+ *   score = 1 / (1 + (violations / KLOC) * k)
+ * `type-coverage` contributes its native ratio. The composite is a weighted average over the active
+ * (non-skipped) dimensions — weights are normalized by the active-weight sum, so it stays a proper
+ * 0–1 average even when `type-coverage` is skipped or weights are overridden.
+ */
+
+import { type DimensionConfig, type DimensionScore, type ScoreResult } from "../types/index"
+import { type RuleCounts } from "./eslint"
+import { type TsMorphResult } from "./ts-morph"
+import { type TypeCoverageResult } from "./type-coverage"
+
+export type AggregateInputs = {
+  readonly target: string
+  readonly dimensions: ReadonlyArray<DimensionConfig>
+  readonly ruleCounts: RuleCounts
+  readonly typeCoverage: TypeCoverageResult
+  readonly tsMorph: TsMorphResult
+}
+
+const density = (violations: number, kloc: number, k: number): number =>
+  kloc <= 0 ? 1 : 1 / (1 + (violations / kloc) * k)
+
+/** Sum the violation counts for the rules owning a given dimension. */
+const lintViolations = (dim: DimensionConfig, ruleCounts: RuleCounts): number =>
+  dim.rules.reduce((total, rule) => total + (ruleCounts.get(`functype/${rule}`) ?? 0), 0)
+
+type RawDimension = {
+  readonly id: DimensionConfig["id"]
+  readonly weight: number
+  readonly score: number
+  readonly violations: number
+  readonly detail: string
+  readonly skipped: boolean
+}
+
+const scoreDimension = (dim: DimensionConfig, inputs: AggregateInputs, kloc: number): RawDimension => {
+  const klocLabel = `${kloc.toFixed(2)} KLOC`
+  switch (dim.kind) {
+    case "lint": {
+      const violations = lintViolations(dim, inputs.ruleCounts)
+      return {
+        id: dim.id,
+        weight: dim.weight,
+        score: density(violations, kloc, dim.k),
+        violations,
+        detail: `${violations} violations / ${klocLabel}`,
+        skipped: false,
+      }
+    }
+    case "non-null": {
+      const violations = inputs.tsMorph.nonNull
+      return {
+        id: dim.id,
+        weight: dim.weight,
+        score: density(violations, kloc, dim.k),
+        violations,
+        detail: `${violations} non-null assertions / ${klocLabel}`,
+        skipped: false,
+      }
+    }
+    case "type-coverage": {
+      const tc = inputs.typeCoverage
+      return tc.skipped
+        ? { id: dim.id, weight: dim.weight, score: 0, violations: 0, detail: "skipped (no tsconfig)", skipped: true }
+        : {
+            id: dim.id,
+            weight: dim.weight,
+            score: tc.score,
+            violations: 0,
+            detail: `${tc.percent.toFixed(1)}% typed`,
+            skipped: false,
+          }
+    }
+  }
+}
+
+export const aggregate = (inputs: AggregateInputs): ScoreResult => {
+  const { loc } = inputs.tsMorph
+  const kloc = loc / 1000
+
+  const raw = inputs.dimensions.map((dim) => scoreDimension(dim, inputs, kloc))
+
+  const activeWeight = raw.filter((d) => !d.skipped).reduce((sum, d) => sum + d.weight, 0)
+  const composite =
+    activeWeight <= 0
+      ? 0
+      : raw.filter((d) => !d.skipped).reduce((sum, d) => sum + (d.weight / activeWeight) * d.score, 0)
+
+  const dimensions: ReadonlyArray<DimensionScore> = raw.map((d) => ({
+    id: d.id,
+    weight: d.weight,
+    score: d.score,
+    violations: d.violations,
+    detail: d.detail,
+    skipped: d.skipped,
+  }))
+
+  return {
+    target: inputs.target,
+    score: Math.round(composite * 100),
+    loc,
+    dimensions,
+  }
+}

--- a/packages/functype-eval/src/scorers/eslint.ts
+++ b/packages/functype-eval/src/scorers/eslint.ts
@@ -1,0 +1,91 @@
+/**
+ * Runs `eslint-plugin-functype` against a target directory via the ESLint Node API (flat config,
+ * ESLint 10+) and returns raw per-rule violation counts. No shelling out, no reimplemented rules.
+ *
+ * The plugin is registered under the `functype` namespace so `functype/<rule>` ids resolve, and
+ * `@typescript-eslint/parser` is supplied so `.ts`/`.tsx` sources parse — the rules themselves are
+ * purely syntactic (AST-only), so no type information / target tsconfig is required here.
+ */
+
+import { resolve } from "node:path"
+
+import tsParser from "@typescript-eslint/parser"
+import { ESLint, type Linter } from "eslint"
+import functypePlugin from "eslint-plugin-functype"
+
+import { DEFAULT_DIMENSIONS, type DimensionConfig, enabledRuleNames } from "../types/index"
+
+/** Files excluded from scoring across all scorers (build output, deps, tests, declarations). */
+export const IGNORE_GLOBS: ReadonlyArray<string> = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/lib/**",
+  "**/coverage/**",
+  "**/*.d.ts",
+  "**/*.test.ts",
+  "**/*.test.tsx",
+  "**/*.spec.ts",
+  "**/*.spec.tsx",
+]
+
+/** Per-rule violation counts keyed by full rule id (`functype/<rule>`). */
+export type RuleCounts = ReadonlyMap<string, number>
+
+const buildEslint = (cwd: string, rules: ReadonlyArray<string>): ESLint => {
+  const ruleRecord: Linter.RulesRecord = Object.fromEntries(rules.map((rule) => [`functype/${rule}`, "error"]))
+
+  return new ESLint({
+    // Run with cwd = target so flat-config `files` globs match the target's files (they're matched
+    // relative to cwd; a target outside our own cwd would otherwise match nothing → no rules applied).
+    cwd,
+    // Ignore any ESLint config the target ships — the score must reflect our rule set, not theirs.
+    overrideConfigFile: true,
+    overrideConfig: [
+      { ignores: [...IGNORE_GLOBS] },
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: {
+          parser: tsParser as Linter.Parser,
+          ecmaVersion: "latest",
+          sourceType: "module",
+        },
+        plugins: { functype: functypePlugin as unknown as ESLint.Plugin },
+        rules: ruleRecord,
+      },
+    ],
+  })
+}
+
+/**
+ * Lint every `.ts`/`.tsx` file under `target` and tally violations per rule. Returns zero counts
+ * (an empty map's `get` semantics) when no source files match.
+ */
+export const scoreEslint = async (
+  target: string,
+  dimensions: ReadonlyArray<DimensionConfig> = DEFAULT_DIMENSIONS,
+): Promise<RuleCounts> => {
+  const rules = enabledRuleNames(dimensions)
+  const eslint = buildEslint(resolve(target), rules)
+
+  const results = await lintOrEmpty(eslint, "**/*.{ts,tsx}")
+
+  const initial = new Map<string, number>(rules.map((rule) => [`functype/${rule}`, 0]))
+  return results
+    .flatMap((result) => result.messages)
+    .reduce((counts, message) => {
+      const id = message.ruleId
+      return id !== null && counts.has(id) ? counts.set(id, (counts.get(id) ?? 0) + 1) : counts
+    }, initial)
+}
+
+/** `lintFiles` throws when a pattern matches nothing; treat that as "no violations". */
+const lintOrEmpty = async (eslint: ESLint, pattern: string): Promise<ESLint.LintResult[]> => {
+  try {
+    return await eslint.lintFiles([pattern])
+  } catch (error) {
+    if (error instanceof Error && /No files matching|were found|were ignored/i.test(error.message)) {
+      return []
+    }
+    throw error
+  }
+}

--- a/packages/functype-eval/src/scorers/ts-morph.ts
+++ b/packages/functype-eval/src/scorers/ts-morph.ts
@@ -1,0 +1,46 @@
+/**
+ * ts-morph pass over the target sources. Produces:
+ *  - `nonNull`: count of `!` non-null assertion expressions (escape hatches — a penalty dimension)
+ *  - `loc`:     total non-blank lines of code, used as the density denominator for every dimension
+ *
+ * Purely syntactic — no tsconfig or type information required; files are added by glob.
+ */
+
+import { join } from "node:path"
+
+import { Project, SyntaxKind } from "ts-morph"
+
+import { IGNORE_GLOBS } from "./eslint"
+
+export type TsMorphResult = {
+  readonly nonNull: number
+  readonly loc: number
+  readonly fileCount: number
+}
+
+const sourceGlobs = (target: string): ReadonlyArray<string> => [
+  join(target, "**/*.ts"),
+  join(target, "**/*.tsx"),
+  ...IGNORE_GLOBS.map((glob) => `!${glob}`),
+]
+
+const nonBlankLines = (text: string): number => text.split(/\r?\n/).filter((line) => line.trim() !== "").length
+
+export const scoreTsMorph = (target: string): TsMorphResult => {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    skipFileDependencyResolution: true,
+    skipLoadingLibFiles: true,
+    compilerOptions: { allowJs: false },
+  })
+
+  const files = project.addSourceFilesAtPaths(sourceGlobs(target))
+
+  const nonNull = files.reduce(
+    (total, file) => total + file.getDescendantsOfKind(SyntaxKind.NonNullExpression).length,
+    0,
+  )
+  const loc = files.reduce((total, file) => total + nonBlankLines(file.getFullText()), 0)
+
+  return { nonNull, loc, fileCount: files.length }
+}

--- a/packages/functype-eval/src/scorers/type-coverage.ts
+++ b/packages/functype-eval/src/scorers/type-coverage.ts
@@ -1,0 +1,86 @@
+/**
+ * type-coverage dimension. This is the one dimension that needs the target's TypeScript program, so
+ * it resolves a tsconfig per decision 2A: explicit `--project` → autodetect (walk up from target) →
+ * else skip (the aggregator then renormalizes the remaining weights).
+ *
+ * We resolve the tsconfig with the TypeScript compiler API rather than letting `type-coverage-core`
+ * do it: tcc resolves `extends` with naive `node_modules/<pkg>/tsconfig.json` path-joins and does
+ * NOT honor package.json `exports`, so it chokes on `extends: "ts-builds/tsconfig"` (used across this
+ * repo). TS's resolver honors exports/extends; we then hand the resolved options + file list to
+ * `lintSync`. `notOnlyInCWD` + `absolutePath` make it count the target's files regardless of cwd.
+ *
+ * Returns a native ratio (`correctCount / totalCount`), not a density score.
+ */
+
+import { existsSync } from "node:fs"
+import { dirname, isAbsolute, join, resolve } from "node:path"
+
+import { lintSync } from "type-coverage-core"
+import ts from "typescript"
+
+export type TypeCoverageResult = {
+  readonly skipped: boolean
+  /** Coverage ratio 0.0–1.0 (`correctCount / totalCount`). Meaningless when `skipped`. */
+  readonly score: number
+  /** Coverage percentage 0–100, for display. */
+  readonly percent: number
+  /** The tsconfig actually used, if any. */
+  readonly tsconfigPath?: string
+}
+
+const SKIPPED: TypeCoverageResult = { skipped: true, score: 0, percent: 0 }
+
+/** Walk up from `dir` to the filesystem root looking for the nearest tsconfig.json. */
+const findTsconfigUp = (dir: string): string | undefined => {
+  const candidate = join(dir, "tsconfig.json")
+  if (existsSync(candidate)) return candidate
+  const parent = dirname(dir)
+  return parent === dir ? undefined : findTsconfigUp(parent)
+}
+
+/** Resolve the nearest tsconfig: explicit path, else walk up from the target directory. */
+export const resolveTsconfig = (target: string, explicit?: string): string | undefined => {
+  if (explicit !== undefined && explicit !== "") {
+    const path = isAbsolute(explicit) ? explicit : resolve(process.cwd(), explicit)
+    return existsSync(path) ? path : undefined
+  }
+  return findTsconfigUp(resolve(target))
+}
+
+/** Fully resolve a tsconfig (following `extends`, honoring package `exports`) to options + files. */
+const parseProject = (
+  tsconfigPath: string,
+): { options: ts.CompilerOptions; fileNames: ReadonlyArray<string> } | undefined => {
+  const host: ts.ParseConfigFileHost = {
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    readDirectory: ts.sys.readDirectory,
+    useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+    getCurrentDirectory: ts.sys.getCurrentDirectory,
+    onUnRecoverableConfigFileDiagnostic: () => undefined,
+  }
+  const parsed = ts.getParsedCommandLineOfConfigFile(tsconfigPath, undefined, host)
+  return parsed === undefined ? undefined : { options: parsed.options, fileNames: parsed.fileNames }
+}
+
+export const scoreTypeCoverage = (target: string, explicit?: string): TypeCoverageResult => {
+  const tsconfigPath = resolveTsconfig(target, explicit)
+  if (tsconfigPath === undefined) return SKIPPED
+
+  const project = parseProject(tsconfigPath)
+  if (project === undefined || project.fileNames.length === 0) return SKIPPED
+
+  // `files` whitelists the target's OWN sources (absolute paths). Without it, type-coverage-core
+  // also walks resolved dependency `.d.ts` (e.g. functype's dist, which lives outside node_modules
+  // and so isn't auto-excluded) — inflating the ratio toward 100% and spamming "unhandled node kind"
+  // diagnostics on AST kinds its TS-5-era checker doesn't recognize under TS 6.
+  const ownFiles = [...project.fileNames]
+  const { correctCount, totalCount } = lintSync(project.options, ownFiles, {
+    strict: false,
+    absolutePath: true,
+    notOnlyInCWD: true,
+    files: ownFiles,
+  })
+  const score = totalCount === 0 ? 1 : correctCount / totalCount
+  return { skipped: false, score, percent: score * 100, tsconfigPath }
+}

--- a/packages/functype-eval/src/types/index.ts
+++ b/packages/functype-eval/src/types/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Score types and the default dimension configuration.
+ *
+ * The fitness score is a weighted sum of dimension scores (each 0.0–1.0) scaled to 0–100. Lint and
+ * non-null dimensions normalize by violation density (see `aggregate.ts`); `type-coverage` uses its
+ * native percentage. Weights sum to 1.0 and are overridable via `functype-eval.config.json`.
+ */
+
+export type DimensionId =
+  | "immutability"
+  | "option"
+  | "either"
+  | "composition"
+  | "collections"
+  | "do-notation"
+  | "safety"
+  | "loops"
+  | "type-coverage"
+  | "non-null"
+
+/**
+ * How a dimension's raw signal is produced.
+ * - `lint`        — violation counts from `eslint-plugin-functype` rules
+ * - `type-coverage` — native percentage from `type-coverage-core`
+ * - `non-null`    — `!` non-null assertion count from a ts-morph scan
+ */
+export type DimensionKind = "lint" | "type-coverage" | "non-null"
+
+export type DimensionConfig = {
+  readonly id: DimensionId
+  readonly weight: number
+  readonly kind: DimensionKind
+  /** ESLint rule names (without the `functype/` prefix) feeding this dimension. Empty for non-lint. */
+  readonly rules: ReadonlyArray<string>
+  /** Density sensitivity for `score = 1 / (1 + (violations / KLOC) * k)`. Unused for `type-coverage`. */
+  readonly k: number
+}
+
+/**
+ * The ten default dimensions. All 12 `eslint-plugin-functype` rules are mapped here
+ * (`prefer-map` lives under `composition`). Weights sum to 1.0.
+ */
+export const DEFAULT_DIMENSIONS: ReadonlyArray<DimensionConfig> = [
+  { id: "immutability", weight: 0.15, kind: "lint", rules: ["no-let"], k: 0.5 },
+  { id: "option", weight: 0.15, kind: "lint", rules: ["prefer-option"], k: 0.5 },
+  { id: "either", weight: 0.15, kind: "lint", rules: ["prefer-either"], k: 0.5 },
+  {
+    id: "composition",
+    weight: 0.1,
+    kind: "lint",
+    rules: ["prefer-flatmap", "prefer-fold", "prefer-map"],
+    k: 0.3,
+  },
+  {
+    id: "collections",
+    weight: 0.1,
+    kind: "lint",
+    rules: ["prefer-list", "prefer-functype-map", "prefer-functype-set"],
+    k: 0.3,
+  },
+  { id: "do-notation", weight: 0.05, kind: "lint", rules: ["prefer-do-notation"], k: 0.2 },
+  { id: "safety", weight: 0.1, kind: "lint", rules: ["no-get-unsafe"], k: 1.0 },
+  { id: "loops", weight: 0.05, kind: "lint", rules: ["no-imperative-loops"], k: 0.3 },
+  { id: "type-coverage", weight: 0.1, kind: "type-coverage", rules: [], k: 0 },
+  { id: "non-null", weight: 0.05, kind: "non-null", rules: [], k: 0.5 },
+] as const
+
+/** Per-dimension result after scoring and (if needed) weight renormalization. */
+export type DimensionScore = {
+  readonly id: DimensionId
+  /** Effective weight used in the composite — renormalized if any dimension was skipped. */
+  readonly weight: number
+  /** Normalized dimension score, 0.0–1.0. */
+  readonly score: number
+  /** Raw violation/assertion count (0 for `type-coverage` and skipped dimensions). */
+  readonly violations: number
+  /** Human-readable detail, e.g. `"3 violations / 1.20 KLOC"`, `"98.7% typed"`, `"skipped (no tsconfig)"`. */
+  readonly detail: string
+  /** True when the dimension was excluded and its weight redistributed (only `type-coverage` today). */
+  readonly skipped: boolean
+}
+
+export type ScoreResult = {
+  readonly target: string
+  /** Composite fitness score, 0–100 (rounded). */
+  readonly score: number
+  /** Total non-blank lines of code scanned. */
+  readonly loc: number
+  readonly dimensions: ReadonlyArray<DimensionScore>
+}
+
+export type ScoreOptions = {
+  /** Explicit tsconfig path for the `type-coverage` dimension. Falls back to autodetect, then skip. */
+  readonly project?: string
+  /** Per-dimension weight overrides (e.g. from `functype-eval.config.json`). */
+  readonly weights?: Partial<Record<DimensionId, number>>
+}
+
+/** All ESLint rule names (without prefix) that feed any lint dimension. */
+export const enabledRuleNames = (
+  dimensions: ReadonlyArray<DimensionConfig> = DEFAULT_DIMENSIONS,
+): ReadonlyArray<string> => dimensions.flatMap((d) => d.rules)
+
+/** Reverse map: `functype/<rule>` rule id → owning dimension id. */
+export const ruleToDimension = (
+  dimensions: ReadonlyArray<DimensionConfig> = DEFAULT_DIMENSIONS,
+): ReadonlyMap<string, DimensionId> =>
+  new Map(dimensions.flatMap((d) => d.rules.map((rule) => [`functype/${rule}`, d.id] as const)))

--- a/packages/functype-eval/test/helpers/tmp.ts
+++ b/packages/functype-eval/test/helpers/tmp.ts
@@ -1,0 +1,20 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+/** Write a throwaway project (relative path → file contents) to a fresh temp dir and return its path. */
+export const writeProject = (files: Record<string, string>): string => {
+  const dir = mkdtempSync(join(tmpdir(), "functype-eval-"))
+  Object.entries(files).forEach(([rel, content]) => {
+    const path = join(dir, rel)
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, content)
+  })
+  return dir
+}
+
+export const removeProject = (dir: string): void => rmSync(dir, { recursive: true, force: true })
+
+/** Total violations across a RuleCounts map. */
+export const totalViolations = (counts: ReadonlyMap<string, number>): number =>
+  [...counts.values()].reduce((sum, n) => sum + n, 0)

--- a/packages/functype-eval/test/scorers/aggregate.test.ts
+++ b/packages/functype-eval/test/scorers/aggregate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { aggregate, type AggregateInputs } from "../../src/scorers/aggregate"
+import { DEFAULT_DIMENSIONS } from "../../src/types/index"
+
+const baseInputs = (overrides: Partial<AggregateInputs> = {}): AggregateInputs => ({
+  target: "fixture",
+  dimensions: DEFAULT_DIMENSIONS,
+  ruleCounts: new Map<string, number>(),
+  typeCoverage: { skipped: false, score: 1, percent: 100 },
+  tsMorph: { nonNull: 0, loc: 1000, fileCount: 1 },
+  ...overrides,
+})
+
+describe("aggregate", () => {
+  it("scores a clean codebase 100", () => {
+    const result = aggregate(baseInputs())
+    expect(result.score).toBe(100)
+    expect(result.dimensions).toHaveLength(DEFAULT_DIMENSIONS.length)
+  })
+
+  it("applies the density formula (2 no-let violations over 1 KLOC, k=0.5 → 0.5)", () => {
+    const result = aggregate(baseInputs({ ruleCounts: new Map([["functype/no-let", 2]]) }))
+    const immutability = result.dimensions.find((d) => d.id === "immutability")
+    expect(immutability?.score).toBeCloseTo(0.5, 5)
+    expect(immutability?.violations).toBe(2)
+    expect(result.score).toBeLessThan(100)
+  })
+
+  it("sums multiple rules into the composition dimension (incl. prefer-map)", () => {
+    const result = aggregate(
+      baseInputs({
+        ruleCounts: new Map([
+          ["functype/prefer-flatmap", 1],
+          ["functype/prefer-fold", 1],
+          ["functype/prefer-map", 1],
+        ]),
+      }),
+    )
+    expect(result.dimensions.find((d) => d.id === "composition")?.violations).toBe(3)
+  })
+
+  it("is monotonic — more violations never raises the score", () => {
+    const few = aggregate(baseInputs({ ruleCounts: new Map([["functype/prefer-option", 1]]) }))
+    const many = aggregate(baseInputs({ ruleCounts: new Map([["functype/prefer-option", 10]]) }))
+    expect(many.score).toBeLessThan(few.score)
+  })
+
+  it("skips type-coverage and renormalizes the remaining 9 weights", () => {
+    const result = aggregate(baseInputs({ typeCoverage: { skipped: true, score: 0, percent: 0 } }))
+    const tc = result.dimensions.find((d) => d.id === "type-coverage")
+    expect(tc?.skipped).toBe(true)
+    expect(tc?.detail).toMatch(/skipped/)
+    // Everything else perfect → renormalized composite is still 100.
+    expect(result.score).toBe(100)
+  })
+
+  it("counts the non-null dimension from the ts-morph scan", () => {
+    const result = aggregate(baseInputs({ tsMorph: { nonNull: 5, loc: 1000, fileCount: 2 } }))
+    const nonNull = result.dimensions.find((d) => d.id === "non-null")
+    expect(nonNull?.violations).toBe(5)
+    expect(nonNull?.score).toBeLessThan(1)
+  })
+
+  it("treats an empty target (0 LOC) as a perfect density score", () => {
+    const result = aggregate(baseInputs({ tsMorph: { nonNull: 0, loc: 0, fileCount: 0 } }))
+    expect(result.score).toBe(100)
+    expect(result.loc).toBe(0)
+  })
+
+  it("honors weight overrides passed via the dimensions list", () => {
+    const heavyImmutability = DEFAULT_DIMENSIONS.map((d) =>
+      d.id === "immutability" ? { ...d, weight: 0.9 } : { ...d, weight: 0.0125 },
+    )
+    const result = aggregate(
+      baseInputs({ dimensions: heavyImmutability, ruleCounts: new Map([["functype/no-let", 2]]) }),
+    )
+    // immutability (score 0.5) dominates the weighting → composite near 50.
+    expect(result.score).toBeGreaterThan(45)
+    expect(result.score).toBeLessThan(60)
+  })
+})

--- a/packages/functype-eval/test/scorers/eslint.test.ts
+++ b/packages/functype-eval/test/scorers/eslint.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, describe, expect, it } from "vitest"
+
+import { scoreEslint } from "../../src/scorers/eslint"
+import { removeProject, totalViolations, writeProject } from "../helpers/tmp"
+
+// Functype-idiomatic: pure scalar functions — no `let`, no nullable returns, no imperative loops,
+// no try/catch, and no native collection types (which prefer-list / prefer-functype-* would flag).
+const GOOD = `export const add = (a: number, b: number): number => a + b
+export const greet = (name: string): string => \`hello \${name}\`
+export const square = (n: number): number => n * n
+`
+
+// Imperative: mutable bindings, a for-loop, and a nullable return — multiple rules fire.
+const BAD = `export function total(items: number[]): number {
+  let sum = 0
+  for (let i = 0; i < items.length; i++) {
+    sum += items[i]
+  }
+  return sum
+}
+export function firstName(name: string | null): string | null {
+  if (name) {
+    return name
+  }
+  return null
+}
+`
+
+const goodDir = writeProject({ "good.ts": GOOD })
+const badDir = writeProject({ "bad.ts": BAD })
+
+afterAll(() => {
+  removeProject(goodDir)
+  removeProject(badDir)
+})
+
+describe("scoreEslint", () => {
+  it("reports zero violations for idiomatic functype code", async () => {
+    const counts = await scoreEslint(goodDir)
+    expect(totalViolations(counts)).toBe(0)
+  })
+
+  it("reports violations for imperative code", async () => {
+    const counts = await scoreEslint(badDir)
+    expect(totalViolations(counts)).toBeGreaterThan(0)
+    // `let` bindings should be flagged by no-let.
+    expect(counts.get("functype/no-let") ?? 0).toBeGreaterThan(0)
+  })
+
+  it("ranks imperative code above idiomatic code in violation count", async () => {
+    const [good, bad] = await Promise.all([scoreEslint(goodDir), scoreEslint(badDir)])
+    expect(totalViolations(bad)).toBeGreaterThan(totalViolations(good))
+  })
+
+  it("returns zeroed counts (no throw) for an empty directory", async () => {
+    const emptyDir = writeProject({ "readme.md": "no ts here" })
+    const counts = await scoreEslint(emptyDir)
+    expect(totalViolations(counts)).toBe(0)
+    removeProject(emptyDir)
+  })
+})

--- a/packages/functype-eval/test/scorers/ts-morph.test.ts
+++ b/packages/functype-eval/test/scorers/ts-morph.test.ts
@@ -1,0 +1,33 @@
+import { afterAll, describe, expect, it } from "vitest"
+
+import { scoreTsMorph } from "../../src/scorers/ts-morph"
+import { removeProject, writeProject } from "../helpers/tmp"
+
+const SRC = `export const first = (x: string | null): string => x!
+export const second = (y: string | null): string => y!
+export const third = (z: number): number => z
+`
+
+const dir = writeProject({ "sample.ts": SRC })
+
+afterAll(() => removeProject(dir))
+
+describe("scoreTsMorph", () => {
+  it("counts non-null assertion expressions", () => {
+    const result = scoreTsMorph(dir)
+    expect(result.nonNull).toBe(2)
+  })
+
+  it("counts non-blank lines of code and files", () => {
+    const result = scoreTsMorph(dir)
+    expect(result.loc).toBe(3)
+    expect(result.fileCount).toBe(1)
+  })
+
+  it("returns zeros for a directory with no TypeScript sources", () => {
+    const emptyDir = writeProject({ "notes.md": "nothing here" })
+    const result = scoreTsMorph(emptyDir)
+    expect(result).toEqual({ nonNull: 0, loc: 0, fileCount: 0 })
+    removeProject(emptyDir)
+  })
+})

--- a/packages/functype-eval/test/scorers/type-coverage.test.ts
+++ b/packages/functype-eval/test/scorers/type-coverage.test.ts
@@ -1,0 +1,43 @@
+import { fileURLToPath } from "node:url"
+
+import { afterAll, describe, expect, it } from "vitest"
+
+import { resolveTsconfig, scoreTypeCoverage } from "../../src/scorers/type-coverage"
+import { removeProject, writeProject } from "../helpers/tmp"
+
+const ownSrc = fileURLToPath(new URL("../../src/", import.meta.url))
+
+describe("resolveTsconfig", () => {
+  const root = writeProject({ "tsconfig.json": "{}", "nested/deep/file.ts": "export const x = 1\n" })
+  afterAll(() => removeProject(root))
+
+  it("uses an explicit path when it exists", () => {
+    expect(resolveTsconfig(root, `${root}/tsconfig.json`)).toBe(`${root}/tsconfig.json`)
+  })
+
+  it("returns undefined for an explicit path that does not exist", () => {
+    expect(resolveTsconfig(root, `${root}/nope.json`)).toBeUndefined()
+  })
+
+  it("walks up from a nested target to the nearest tsconfig", () => {
+    expect(resolveTsconfig(`${root}/nested/deep`)).toBe(`${root}/tsconfig.json`)
+  })
+})
+
+describe("scoreTypeCoverage", () => {
+  it("skips when no tsconfig can be resolved", () => {
+    const dir = writeProject({ "loose.ts": "export const x = 1\n" })
+    // A temp dir under the OS tmp root has no tsconfig ancestor.
+    const result = scoreTypeCoverage(`${dir}/__no_tsconfig_here__`)
+    expect(result.skipped).toBe(true)
+    removeProject(dir)
+  })
+
+  it("computes a coverage ratio against a real project (this package's own src)", () => {
+    const result = scoreTypeCoverage(ownSrc)
+    expect(result.skipped).toBe(false)
+    expect(result.score).toBeGreaterThan(0)
+    expect(result.score).toBeLessThanOrEqual(1)
+    expect(result.tsconfigPath).toMatch(/tsconfig\.json$/)
+  })
+})

--- a/packages/functype-eval/test/scorers/type-coverage.test.ts
+++ b/packages/functype-eval/test/scorers/type-coverage.test.ts
@@ -1,11 +1,7 @@
-import { fileURLToPath } from "node:url"
-
 import { afterAll, describe, expect, it } from "vitest"
 
 import { resolveTsconfig, scoreTypeCoverage } from "../../src/scorers/type-coverage"
 import { removeProject, writeProject } from "../helpers/tmp"
-
-const ownSrc = fileURLToPath(new URL("../../src/", import.meta.url))
 
 describe("resolveTsconfig", () => {
   const root = writeProject({ "tsconfig.json": "{}", "nested/deep/file.ts": "export const x = 1\n" })
@@ -33,11 +29,32 @@ describe("scoreTypeCoverage", () => {
     removeProject(dir)
   })
 
-  it("computes a coverage ratio against a real project (this package's own src)", () => {
-    const result = scoreTypeCoverage(ownSrc)
+  it("computes a coverage ratio against a self-contained typed project", () => {
+    // A standalone tsconfig (no `extends`, no external deps) keeps this deterministic across
+    // environments — exercises resolve → parse → lintSync without depending on ts-builds resolution.
+    const dir = writeProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          skipLibCheck: true,
+          module: "esnext",
+          moduleResolution: "bundler",
+          target: "es2020",
+        },
+        files: ["index.ts"],
+      }),
+      "index.ts": [
+        'export const greet = (name: string): string => "hi " + name',
+        "export const answer: number = 42",
+        "export const sum = (a: number, b: number): number => a + b",
+        "",
+      ].join("\n"),
+    })
+    const result = scoreTypeCoverage(dir)
     expect(result.skipped).toBe(false)
     expect(result.score).toBeGreaterThan(0)
     expect(result.score).toBeLessThanOrEqual(1)
     expect(result.tsconfigPath).toMatch(/tsconfig\.json$/)
+    removeProject(dir)
   })
 })

--- a/packages/functype-eval/ts-builds.config.json
+++ b/packages/functype-eval/ts-builds.config.json
@@ -1,0 +1,4 @@
+{
+  "srcDir": "./src",
+  "validateChain": ["format", "lint", "typecheck", "test", "build"]
+}

--- a/packages/functype-eval/tsconfig.json
+++ b/packages/functype-eval/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "ts-builds/tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/functype-eval/tsdown.config.ts
+++ b/packages/functype-eval/tsdown.config.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "tsdown"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8")) as { version: string }
+
+const isProduction = process.env.NODE_ENV === "production"
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "cli/index": "src/cli/index.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: isProduction,
+  clean: true,
+  target: "node20",
+  outDir: isProduction ? "dist" : "lib",
+  platform: "node",
+  treeshake: true,
+  // `dependencies` + `peerDependencies` (eslint, eslint-plugin-functype, @typescript-eslint/parser,
+  // ts-morph, type-coverage-core, typescript) are externalized by tsdown automatically.
+  define: {
+    __VERSION__: JSON.stringify(pkg.version),
+  },
+  outExtensions: () => ({
+    js: ".js",
+    dts: ".d.ts",
+  }),
+})

--- a/packages/functype-eval/vitest.config.ts
+++ b/packages/functype-eval/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from "vitest/config"
+import baseConfig from "ts-builds/vitest"
+
+export default mergeConfig(baseConfig, defineConfig({}))

--- a/packages/functype/CHANGELOG.md
+++ b/packages/functype/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-This CHANGELOG covers the 5-package functype family (`functype`, `functype-os`, `functype-log`, `functype-react`, `functype-mcp-server`) — all bumped together. The eslint pair (`eslint-config-functype`, `eslint-plugin-functype`) mirrors functype's version line per the encoding in `docs/RELEASE.md` and ships in lockstep.
+This CHANGELOG covers the 6-package functype family (`functype`, `functype-os`, `functype-log`, `functype-react`, `functype-eval`, `functype-mcp-server`) — all bumped together. The eslint pair (`eslint-config-functype`, `eslint-plugin-functype`) mirrors functype's version line per the encoding in `docs/RELEASE.md` and ships in lockstep.
 
 Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions: write notes under `## Unreleased` as you land changes, and `pnpm release patch|minor|major` cuts that section into a dated version header when you cut a release.
 
 ## Unreleased
+
+**New package: `functype-eval`.** A CLI that scores a TypeScript codebase's functype/FP adherence as
+a 0–100 fitness number with a per-dimension breakdown. It runs `eslint-plugin-functype`'s 12 rules via
+the ESLint Node API, plus `type-coverage-core` and a ts-morph non-null-assertion scan, and aggregates
+them by violation density. `functype-eval score <dir>` supports `--json` and `--threshold N` for CI
+gating; `bench` (the Phase 2 LLM eval harness) ships as a stub. Joins the family release line (1.x).
 
 ## 1.3.1 - 2026-06-06
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,46 @@ importers:
         specifier: ^0.28.19
         version: 0.28.19(typescript@6.0.3)
 
+  packages/functype-eval:
+    dependencies:
+      '@typescript-eslint/parser':
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint-plugin-functype:
+        specifier: workspace:^
+        version: link:../eslint-plugin-functype
+      ts-morph:
+        specifier: ^25.0.0
+        version: 25.0.1
+      type-coverage-core:
+        specifier: ^2.29.0
+        version: 2.29.7(typescript@6.0.3)
+      typescript:
+        specifier: '>=5.3.0'
+        version: 6.0.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.12.4
+      eslint:
+        specifier: ^10.2.1
+        version: 10.4.1(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.4.1(jiti@2.7.0))
+      functype:
+        specifier: workspace:^
+        version: link:../functype
+      ts-builds:
+        specifier: ^3.0.0
+        version: 3.0.0(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(jiti@2.7.0)(jsdom@26.1.0)(tsdown@0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.37(synckit@0.11.13)))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      tsdown:
+        specifier: ^0.22.1
+        version: 0.22.2(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.37(synckit@0.11.13))
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/functype-log:
     dependencies:
       loglayer:
@@ -1140,6 +1180,18 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -1682,6 +1734,9 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@ts-morph/common@0.26.1':
+    resolution: {integrity: sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA==}
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -2105,9 +2160,16 @@ packages:
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -2179,6 +2241,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -2663,6 +2728,10 @@ packages:
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2690,6 +2759,9 @@ packages:
       jose:
         optional: true
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2713,6 +2785,10 @@ packages:
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -2821,6 +2897,10 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -3046,6 +3126,10 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -3379,6 +3463,10 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
@@ -3484,6 +3572,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -3510,6 +3602,10 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -3751,6 +3847,9 @@ packages:
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
@@ -3880,6 +3979,10 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rolldown-plugin-dts@0.25.2:
     resolution: {integrity: sha512-nMhN/R+vmR8GM45ZW1FWMSjRTSDDn/6w4GTf8RNrEFCBdl8B1kySWrU1ixPtbwzXoRlcO+R/S88VgXuJQwfdDg==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -3920,6 +4023,9 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -4138,6 +4244,10 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -4192,6 +4302,9 @@ packages:
     peerDependencies:
       typescript: '>=4.0.0'
 
+  ts-morph@25.0.1:
+    resolution: {integrity: sha512-QJEiTdnz1YjrB3JFhd626gX4rKHDLSjSVMvGGG4v7ONc3RBwa0Eei98G9AT9uNFDMtV54JyuXsFeC+OH0n6bXQ==}
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -4240,12 +4353,21 @@ packages:
       unrun:
         optional: true
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
+
+  tsutils@3.21.0:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
@@ -4259,6 +4381,11 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-coverage-core@2.29.7:
+    resolution: {integrity: sha512-bt+bnXekw3p5NnqiZpNupOOxfUKGw2Z/YJedfGHkxpeyGLK7DZ59a6Wds8eq1oKjJc5Wulp2xL207z8FjFO14Q==}
+    peerDependencies:
+      typescript: 2 || 3 || 4 || 5
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -5614,6 +5741,18 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/types@0.127.0':
@@ -5987,6 +6126,12 @@ snapshots:
       - supports-color
 
   '@tokenizer/token@0.3.0': {}
+
+  '@ts-morph/common@0.26.1':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 9.0.9
+      path-browserify: 1.0.1
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -6585,9 +6730,17 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   browserslist@4.28.2:
     dependencies:
@@ -6650,6 +6803,8 @@ snapshots:
       wrap-ansi: 9.0.2
 
   clsx@2.1.1: {}
+
+  code-block-writer@13.0.3: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -7184,6 +7339,14 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -7224,6 +7387,10 @@ snapshots:
       - supports-color
       - sury
 
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -7246,6 +7413,10 @@ snapshots:
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -7349,6 +7520,10 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -7649,6 +7824,8 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -8082,6 +8259,8 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  merge2@1.4.1: {}
+
   micromark-core-commonmark@2.0.3:
     dependencies:
       decode-named-character-reference: 1.3.0
@@ -8346,6 +8525,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -8367,6 +8551,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
 
   mrmime@2.0.1: {}
 
@@ -8585,6 +8773,8 @@ snapshots:
 
   quansync@1.0.0: {}
 
+  queue-microtask@1.2.3: {}
+
   radix3@1.1.2: {}
 
   range-parser@1.2.1: {}
@@ -8773,6 +8963,8 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
+  reusify@1.1.0: {}
+
   rolldown-plugin-dts@0.25.2(rolldown@1.1.0)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
@@ -8874,6 +9066,10 @@ snapshots:
       - supports-color
 
   rrweb-cssom@0.8.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
 
@@ -9126,6 +9322,10 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   toidentifier@1.0.1: {}
 
   token-types@6.1.2:
@@ -9243,6 +9443,11 @@ snapshots:
       picomatch: 4.0.4
       typescript: 6.0.3
 
+  ts-morph@25.0.1:
+    dependencies:
+      '@ts-morph/common': 0.26.1
+      code-block-writer: 13.0.3
+
   ts-node@10.9.2(@types/node@24.10.15)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -9288,10 +9493,16 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tslib@2.8.1:
-    optional: true
+  tslib@1.14.1: {}
+
+  tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
+
+  tsutils@3.21.0(typescript@6.0.3):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 6.0.3
 
   tsx@4.22.4:
     dependencies:
@@ -9311,6 +9522,15 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-coverage-core@2.29.7(typescript@6.0.3):
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 10.2.5
+      normalize-path: 3.0.0
+      tslib: 2.8.1
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   type-is@2.1.0:
     dependencies:

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -14,7 +14,7 @@
  *   1. Verify clean working tree, on main, in sync with origin/main
  *   2. Run `pnpm validate` (full workspace lint + typecheck + test + build)
  *   3. Compute new functype version from current + bump level
- *   4. Apply to all 5 family package.jsons
+ *   4. Apply to all 6 family package.jsons
  *   5. Run `pnpm sync:eslint-mirror` → eslint pair = 2.{major*100+minor}.{patch}
  *   6. Run `pnpm -F functype-mcp-server sync:registry` → server.json tracks pkg.version
  *   7. Cut `## Unreleased` section in packages/functype/CHANGELOG.md to `## {version} - {date}`
@@ -23,7 +23,7 @@
  *  10. Print push instructions
  *
  * CI on tag push runs validate + check-publish-safety + `pnpm -r publish`. The
- * 4 OIDC-trusted-publisher packages (functype, -os, -log, -react) get
+ * 5 OIDC-trusted-publisher packages (functype, -os, -log, -react, -eval) get
  * provenance attestations; functype-mcp-server publishes with NPM_TOKEN.
  *
  * Implementation note: uses spawnSync with argument arrays (not exec/execSync
@@ -45,6 +45,7 @@ const FAMILY_PACKAGE_DIRS = [
   "packages/functype-os",
   "packages/functype-log",
   "packages/functype-react",
+  "packages/functype-eval",
   "packages/mcp-server",
 ] as const
 
@@ -130,7 +131,7 @@ if (!/^\d+\.\d+\.\d+$/.test(next)) {
 
 console.log(`\nReleasing functype family: ${current} → ${next} (${bumpLevel})`)
 
-// 4. Bump all 5 family packages
+// 4. Bump all 6 family packages
 for (const dir of FAMILY_PACKAGE_DIRS) {
   const pkg = readPkg(dir)
   pkg.version = next


### PR DESCRIPTION
## What

Adds a new published workspace package, **`functype-eval`** — a CLI that scores how well a TypeScript codebase adheres to functype/FP idioms, producing a **0–100 fitness score** with a per-dimension breakdown.

This is **Phase 1** (the `score` command), fully implemented. `bench` (Phase 2 LLM eval) ships as a documented stub; the MCP server (Phase 3) is future work.

```
functype-eval score ./src                 # breakdown + 0–100 score
functype-eval score ./src --json          # machine-readable (CI)
functype-eval score ./src --threshold 80  # exit 1 if below
functype-eval score ./src --project tsconfig.json
```

## How it scores

The composite is a weighted sum of ten dimensions (each 0.0–1.0), ×100:

| Dimension | Weight | Source |
|---|---|---|
| immutability / option / either | 0.15 each | `no-let` / `prefer-option` / `prefer-either` |
| composition | 0.10 | `prefer-flatmap`, `prefer-fold`, `prefer-map` |
| collections | 0.10 | `prefer-list`, `prefer-functype-map`, `prefer-functype-set` |
| safety | 0.10 | `no-get-unsafe` |
| do-notation / loops | 0.05 each | `prefer-do-notation` / `no-imperative-loops` |
| type-coverage | 0.10 | type-coverage-core (native %) |
| non-null | 0.05 | ts-morph `!` scan |

All 12 `eslint-plugin-functype` rules are scored. Three passes, aggregated by **violation density** (`1 / (1 + (violations / KLOC) * k)`); `type-coverage` contributes its native ratio. Weights overridable via `functype-eval.config.json`. Deterministic — same input, same output.

### Key design decisions
- **ESLint Node API, not shelling out.** Plugin registered under the `functype` namespace; the target's own ESLint config is ignored so the score reflects our rule set.
- **No reimplemented rules.** `eslint-plugin-functype` is the source of truth; this consumes it.
- **Zero functype runtime dependency by design** — it evaluates code that *uses* functype but doesn't need functype itself. Its own source is written functype-free, and the "prefer the functype API" rules are disabled for it.
- **type-coverage tsconfig resolution:** `--project` → autodetect → skip + renormalize the other 9 weights. Resolved via the **TS compiler API** so `extends` / package `exports` are honored (type-coverage-core's own resolver can't), and scoped to the target's own files.

## Verified
- `pnpm -F functype-eval validate` green; **20 tests pass**.
- Full `pnpm turbo run validate` green (12/12), confirmed deterministic across repeated forced runs.
- End-to-end discrimination: imperative fixture **35** < `functype-os/src` **57** < `functype-eval/src` **73**; `--json` / `--threshold` / skip-path / `bench` stub all behave.

## Monorepo wiring
- Added to `FAMILY_PACKAGE_DIRS` in `scripts/release.ts` (bumps with the family on the `1.x` line).
- Root `CLAUDE.md` workspace table + family `CHANGELOG`; package counts updated (5→6 family, 7→8 total).

## Notes for review / before first release
- **npm trusted publisher:** the package has `provenance: true` and publishes via OIDC like the other 4 family packages. A brand-new package needs its **trusted-publisher config created on npmjs.com** before the first `pnpm release`, or that first publish fails.
- A one-file ambient `eslint-plugin-functype.d.ts` decouples this package's typecheck from that sibling's `dist/` (rebuilt with `clean:true` during validate), fixing an intermittent `TS2307` race under turbo.
- Score `k` constants in `src/types/index.ts` are reasonable v1 defaults; worth retuning against real codebases (config-overridable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)