### PR TITLE
fix(release): include functype-eval in publish-safety guard

### DIFF
--- a/scripts/check-publish-safety.ts
+++ b/scripts/check-publish-safety.ts
@@ -10,8 +10,8 @@
  *   2. Downgrade (local < npm) — never auto-authorized. Will not publish.
  *   3. Alignment-group drift: each Changesets `fixed` group must publish at
  *      the same version. Two groups today:
- *        - Functype family (5 packages): functype, functype-os, functype-log,
- *          functype-react, functype-mcp-server — all on the `1.x` line.
+ *        - Functype family (6 packages): functype, functype-os, functype-log,
+ *          functype-react, functype-eval, functype-mcp-server — all on the `1.x` line.
  *        - Eslint pair: eslint-config-functype, eslint-plugin-functype —
  *          both on the `2.100.x` line (intentional offset from functype).
  *      Drift here means something bypassed the Changesets bump step (manual
@@ -42,6 +42,7 @@ const PACKAGE_DIRS = [
   "packages/functype-os",
   "packages/functype-log",
   "packages/functype-react",
+  "packages/functype-eval",
   "packages/mcp-server",
   "packages/eslint-config-functype",
   "packages/eslint-plugin-functype",
@@ -52,7 +53,7 @@ const PACKAGE_DIRS = [
  * in `.changeset/config.json` — every member of a group must have the same
  * version at publish time.
  *
- * - Functype family: 5 packages on the `1.x` line, bumped together.
+ * - Functype family: 6 packages on the `1.x` line, bumped together.
  * - Eslint pair: config + plugin on the `2.100.x` line, bumped together but
  *   independent from the functype family (intentional version-line offset).
  *
@@ -62,7 +63,14 @@ const PACKAGE_DIRS = [
 const ALIGNMENT_GROUPS: ReadonlyArray<{ readonly label: string; readonly members: ReadonlySet<string> }> = [
   {
     label: "functype-* family",
-    members: new Set<string>(["functype", "functype-os", "functype-log", "functype-react", "functype-mcp-server"]),
+    members: new Set<string>([
+      "functype",
+      "functype-os",
+      "functype-log",
+      "functype-react",
+      "functype-eval",
+      "functype-mcp-server",
+    ]),
   },
   {
     label: "eslint pair",


### PR DESCRIPTION
## What

Follow-up to #184. `functype-eval` was added to `FAMILY_PACKAGE_DIRS` in `scripts/release.ts` but **not** to `scripts/check-publish-safety.ts`, which carries its own independent lists. This adds it to both:

- **`PACKAGE_DIRS`** — so functype-eval appears in the publish-plan preview and the downgrade / surprise-major checks.
- **family `ALIGNMENT_GROUPS`** — so the lockstep-version guard catches functype-eval drifting out of family alignment (the exact class of bug that guard exists to prevent, per the `0.60.7 → 1.0.0` cascade post-mortem).

Comment counts updated 5 → 6.

## Why it matters

Neither gap blocked the initial publish (functype-eval@1.3.1 is already live, and `pnpm -r publish` walks every workspace package regardless). But without these entries the **next** release would not verify functype-eval's version against npm or enforce that it stays in lockstep with the rest of the `1.x` family.

## Verified

```
$ pnpm check-publish-safety
  functype             1.3.1 = 1.3.1  [same]
  functype-os          1.3.1 = 1.3.1  [same]
  functype-log         1.3.1 = 1.3.1  [same]
  functype-react       1.3.1 = 1.3.1  [same]
  functype-eval        1.3.1 = 1.3.1  [same]   ← now covered
  functype-mcp-server  1.3.1 = 1.3.1  [same]
✓ all alignment groups in sync — safe to publish
```

## Out of scope

The file's comments still reference Changesets / `.changeset/config.json`, which no longer exists (repo is fully tag-driven). Pre-existing drift, left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)