### PR TITLE
feat(functype-eval): guard against scoring empty / non-TS targets

### DIFF
--- a/packages/functype-eval/README.md
+++ b/packages/functype-eval/README.md
@@ -24,6 +24,10 @@ functype-eval score ./src --threshold 80   # exit 1 if score < 80 (CI gate)
 functype-eval score ./src --project tsconfig.json   # explicit tsconfig for type-coverage
 ```
 
+**Exit codes:** `0` scored ok (and at/above `--threshold` if given), `1` score below
+`--threshold`, `2` no TypeScript sources found under the target (nothing to score — guards against a
+misleading `100/100` on an empty or non-TS directory).
+
 ### Example
 
 ```

--- a/packages/functype-eval/src/cli/index.ts
+++ b/packages/functype-eval/src/cli/index.ts
@@ -25,6 +25,11 @@ Global:
   -v, --version         Show version number
   -h, --help            Show help
 
+Exit codes (score):
+  0  scored ok (and at/above --threshold if given)
+  1  score below --threshold
+  2  no TypeScript sources found under the target — nothing to score
+
 Examples:
   functype-eval score ./src
   functype-eval score ./src --json --threshold 80

--- a/packages/functype-eval/src/cli/score.ts
+++ b/packages/functype-eval/src/cli/score.ts
@@ -77,6 +77,18 @@ export const runScore = async (args: ReadonlyArray<string>): Promise<number> => 
     project: parsed.project ?? config.project,
   })
 
+  // Empty-input guard: with no source files every density dimension is trivially 1.0 and the
+  // composite is a vacuous 100. Don't present that as a passing score — report it and exit 2 (an
+  // error distinct from a threshold failure, which exits 1). JSON callers still get the payload.
+  if (result.fileCount === 0) {
+    console.error(
+      `functype-eval: no TypeScript sources found under ${result.target} — nothing to score.\n` +
+        `  (looked for **/*.ts and **/*.tsx, excluding tests, .d.ts, node_modules, dist, lib)`,
+    )
+    if (parsed.json) console.log(JSON.stringify(result, null, 2))
+    return 2
+  }
+
   console.log(parsed.json ? JSON.stringify(result, null, 2) : formatTable(result))
 
   if (parsed.threshold !== undefined && result.score < parsed.threshold) {

--- a/packages/functype-eval/src/scorers/aggregate.ts
+++ b/packages/functype-eval/src/scorers/aggregate.ts
@@ -103,6 +103,7 @@ export const aggregate = (inputs: AggregateInputs): ScoreResult => {
     target: inputs.target,
     score: Math.round(composite * 100),
     loc,
+    fileCount: inputs.tsMorph.fileCount,
     dimensions,
   }
 }

--- a/packages/functype-eval/src/types/index.ts
+++ b/packages/functype-eval/src/types/index.ts
@@ -82,10 +82,12 @@ export type DimensionScore = {
 
 export type ScoreResult = {
   readonly target: string
-  /** Composite fitness score, 0–100 (rounded). */
+  /** Composite fitness score, 0–100 (rounded). Meaningless when `fileCount` is 0 — see CLI guard. */
   readonly score: number
   /** Total non-blank lines of code scanned. */
   readonly loc: number
+  /** Number of TypeScript source files scanned. 0 means nothing was scored (empty / non-TS target). */
+  readonly fileCount: number
   readonly dimensions: ReadonlyArray<DimensionScore>
 }
 

--- a/packages/functype-eval/test/cli/score.test.ts
+++ b/packages/functype-eval/test/cli/score.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { runScore } from "../../src/cli/score"
+import { removeProject, writeProject } from "../helpers/tmp"
+
+describe("runScore", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("exits 2 and reports when no TypeScript sources are found", async () => {
+    const dir = writeProject({ "readme.md": "no ts here" })
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    vi.spyOn(console, "log").mockImplementation(() => undefined)
+
+    const code = await runScore([dir])
+
+    expect(code).toBe(2)
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("no TypeScript sources found"))
+    removeProject(dir)
+  })
+
+  it("scores a real directory (exit 0) and gates on --threshold (exit 1)", async () => {
+    const dir = writeProject({ "good.ts": "export const add = (a: number, b: number): number => a + b\n" })
+    vi.spyOn(console, "log").mockImplementation(() => undefined)
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    expect(await runScore([dir])).toBe(0)
+    // No real codebase reaches 101, so this always trips the gate → exit 1 (distinct from the
+    // empty-input exit 2).
+    expect(await runScore([dir, "--threshold", "101"])).toBe(1)
+    removeProject(dir)
+  })
+
+  it("exits 1 with a usage message when no target is given", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const code = await runScore([])
+    expect(code).toBe(1)
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("Usage:"))
+  })
+})

--- a/packages/functype-eval/test/scorers/aggregate.test.ts
+++ b/packages/functype-eval/test/scorers/aggregate.test.ts
@@ -62,10 +62,17 @@ describe("aggregate", () => {
     expect(nonNull?.score).toBeLessThan(1)
   })
 
-  it("treats an empty target (0 LOC) as a perfect density score", () => {
+  it("treats an empty target (0 LOC) as a perfect density score but reports fileCount 0", () => {
     const result = aggregate(baseInputs({ tsMorph: { nonNull: 0, loc: 0, fileCount: 0 } }))
     expect(result.score).toBe(100)
     expect(result.loc).toBe(0)
+    // fileCount 0 is how callers (the CLI guard) detect that nothing was actually scored.
+    expect(result.fileCount).toBe(0)
+  })
+
+  it("surfaces the scanned file count", () => {
+    const result = aggregate(baseInputs({ tsMorph: { nonNull: 0, loc: 1000, fileCount: 7 } }))
+    expect(result.fileCount).toBe(7)
   })
 
   it("honors weight overrides passed via the dimensions list", () => {

--- a/packages/functype/CHANGELOG.md
+++ b/packages/functype/CHANGELOG.md
@@ -12,6 +12,11 @@ the ESLint Node API, plus `type-coverage-core` and a ts-morph non-null-assertion
 them by violation density. `functype-eval score <dir>` supports `--json` and `--threshold N` for CI
 gating; `bench` (the Phase 2 LLM eval harness) ships as a stub. Joins the family release line (1.x).
 
+**`functype-eval` empty-input guard.** `score` on a directory with no TypeScript sources no longer
+prints a misleading `100/100` (0 LOC trivially scores every density dimension 1.0). It now reports
+"no TypeScript sources found" and exits `2` (distinct from `1` = below `--threshold`). `ScoreResult`
+gains a `fileCount` field so library callers can detect the same condition.
+
 ## 1.3.1 - 2026-06-06
 
 **`exports` subpaths now all build (#180):**


### PR DESCRIPTION
## What

`functype-eval score <dir>` on a directory with **no TypeScript sources** printed a misleading **`100/100`** — with 0 LOC, every density dimension trivially scores 1.0 and type-coverage skips. A user could read that as "perfect" when nothing was actually scanned. (Surfaced by dogfooding: `score ./src` at the monorepo root, where the real code lives in `packages/*/src`.)

This adds an empty-input guard:

- The CLI detects **0 source files** and prints `no TypeScript sources found under <target> — nothing to score` (with the glob it looked for), then **exits `2`** — distinct from `1` (below `--threshold`) and `0` (scored ok). `--json` still emits the payload.
- `ScoreResult` gains a **`fileCount`** field so library callers can detect the same condition programmatically.
- Help text and README document the exit codes.

## Behavior

```
$ functype-eval score ./src        # no .ts under ./src
functype-eval: no TypeScript sources found under ./src — nothing to score.
  (looked for **/*.ts and **/*.tsx, excluding tests, .d.ts, node_modules, dist, lib)
$ echo $?
2
```

Real directories are unchanged (`packages/functype-eval/src` → 73/100, exit 0).

## Exit codes
`0` scored ok (and at/above `--threshold` if given) · `1` below `--threshold` · `2` no sources found.

## Tests
- `aggregate.test.ts`: asserts `fileCount` is surfaced (incl. the 0-LOC case).
- new `test/cli/score.test.ts`: empty-input guard (exit 2), normal scoring (exit 0), threshold gating (exit 1), and missing-target usage error.

24 tests pass; full `pnpm -F functype-eval validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)