### PR TITLE
docs(cli): register TypedError + Validation in the doc catalog

### DIFF
--- a/packages/functype/docs/FUNCTYPE_FEATURE_MATRIX.md
+++ b/packages/functype/docs/FUNCTYPE_FEATURE_MATRIX.md
@@ -145,6 +145,33 @@ HttpError.match(error, { NetworkError, HttpStatusError, DecodeError })
 HttpError.isNetworkError(e) / .isHttpStatusError(e) / .isDecodeError(e)
 ```
 
+### Validation & Typed Errors
+
+Error-accumulating validation — functype's "Validated" applicative role. `Validation`
+collects **all** field errors rather than short-circuiting on the first (unlike
+`Either.sequence`, which fails fast). Not a typeclass-grid container, so it lives
+here rather than in the interface matrix above (same as `HttpError` / `DecoderError`).
+
+```typescript
+// FormValidation<T> — the accumulating result type
+type FormValidation<T> = Either<List<TypedError<"VALIDATION_FAILED">>, T>
+
+// TypedError — code-tagged structured error (extends Throwable)
+TypedError.validation(field, value, rule)   // → TypedError<"VALIDATION_FAILED">, context { field, value, rule }
+TypedError.isTypedError(v) / TypedError.hasCode(e, code)
+
+// Validation — rule DSL + form validator
+Validation.rule<T>("min:18" | "email" | "required" | "pattern:..." | "in:a,b" | ...)
+Validation.combine(...validators)                 // all must pass (fail-fast per field)
+Validation.custom<T>(predicate, message)          // custom per-field rule
+Validation.validators.email / .url / .required / .positiveNumber / .nonEmptyString
+Validation.form(schema, data)                     // → FormValidation<T>, accumulates every field error
+
+// Validator<T> = (value: unknown) => Either<TypedError<"VALIDATION_FAILED">, T>
+// form() is flat/per-field. For cross-field (lo < hi) or dynamic-key (weights.*) checks,
+// hand-accumulate TypedError.validation(...) into a List and return the same FormValidation shape.
+```
+
 ### Type Guards
 
 Static type guards for narrowing types:

--- a/packages/functype/src/cli/data.ts
+++ b/packages/functype/src/cli/data.ts
@@ -582,6 +582,49 @@ export const TYPES: Record<string, TypeData> = {
       ],
     },
   },
+
+  TypedError: {
+    description:
+      "Code-tagged structured error ADT (extends Throwable); TypedError.validation(...) feeds accumulating validation.",
+    interfaces: [],
+    methods: {
+      create: [
+        'TypedError.validation(field, value, rule) → TypedError<"VALIDATION_FAILED">',
+        "TypedError.badRequest(reason, expected?)",
+        "TypedError.notFound(resource, id)",
+        "TypedError.auth(resource, requiredRole?)",
+        "TypedError.permission(action, resource, userId?)",
+        "TypedError.conflict(resource, value) / .rateLimit(limit, window, retryAfter?)",
+        "TypedError.timeout(ms, operation) / .network(url, method, status?) / .internal(errorId)",
+      ],
+      check: ["TypedError.isTypedError(v)", "TypedError.hasCode(e, code)"],
+      other: [
+        "Fields: .code, .message, .status (HTTP), .context, .timestamp, .traceId?",
+        "VALIDATION_FAILED context shape: { field, value, rule }",
+      ],
+    },
+  },
+
+  Validation: {
+    description:
+      "Error-accumulating validation (functype's Validated role) — FormValidation<T> collects all field errors, not fail-fast.",
+    interfaces: [],
+    methods: {
+      create: [
+        "Validation.rule<T>('min:18' | 'email' | 'required' | 'in:a,b' | ...)",
+        "Validation.combine(...validators) / Validation.custom(predicate, message)",
+        "Validation.validators.email / .url / .uuid / .required / .numeric / .positiveNumber / .nonEmptyString",
+      ],
+      transform: [
+        "Validation.form(schema, data) → FormValidation<T> (accumulates all field errors)",
+        "Validator<T> = (value: unknown) => Either<TypedError<'VALIDATION_FAILED'>, T>",
+      ],
+      other: [
+        'FormValidation<T> = Either<List<TypedError<"VALIDATION_FAILED">>, T> — functype\'s "Validated" accumulating result type',
+        "form() is flat/per-field: for cross-field (lo < hi) or dynamic-key (weights.*) checks, hand-accumulate into a List<TypedError> and return the FormValidation shape",
+      ],
+    },
+  },
 }
 
 export const INTERFACES: Record<string, InterfaceData> = {
@@ -648,6 +691,7 @@ export const CATEGORIES = {
   Collection: ["List", "Set", "Map", "LazyList", "Tuple", "Stack"],
   Effect: ["IO", "Task", "TaskOutcome", "TaskResult", "Http", "HttpError", "Decoder", "DecoderError"],
   Utility: ["Lazy", "Cond", "Match", "Brand", "ValidatedBrand"],
+  Validation: ["TypedError", "Validation"],
   Serialization: ["Serialization", "SerializedError"],
   Service: ["Logger"],
 }


### PR DESCRIPTION
## Problem

functype's error-accumulating validation system — `TypedError`, `Validation`, and the `FormValidation<T>` result type — is fully exported from the barrel, but was **absent from `packages/functype/src/cli/data.ts`**. That file is what `functype/cli` exposes, and the MCP server (`search_docs`/`get_type_api`) plus `npx functype` read it verbatim.

Result: searching the docs for "Validated" returned only the unrelated `ValidatedBrand` (runtime-branded types), so consumers concluded functype lacks applicative validation and hand-rolled `Either<List<Error>, _>` reinventions of `FormValidation`. Same failure mode as the `Doable` drift in 0.60.x.

## Fix

- Register `TypedError` and `Validation` in `TYPES`, under a new `Validation` category, with `.validation(...)`, the rule DSL, `.form`, and the `FormValidation<T>` shape documented in their `methods`.
- Add a "Validation & Typed Errors" prose subsection to `docs/FUNCTYPE_FEATURE_MATRIX.md` — following the `HttpError`/`DecoderError` precedent (prose block, **not** typeclass-grid rows, since these aren't Functor/Monad containers).
- Descriptions kept terse to stay under the CLI overview word budget; search keywords also live in the `methods` arrays.

## Verification

- `npx functype TypedError` / `npx functype Validation` resolve; both show under a new `VALIDATION` category in the overview.
- `search_docs("Validated")` now surfaces `Validation` (token present in description + methods) instead of only `ValidatedBrand`.
- Typecheck clean; **95 tests pass** (cli + data-sync + error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)