### PR TITLE
feat(functype-react): TanStack Query adapters for IO (#239)

### DIFF
--- a/packages/functype-react/README.md
+++ b/packages/functype-react/README.md
@@ -12,18 +12,19 @@ Push the same ADTs (`Option`, `Either`, `Try`, `Task`, `Validated`) you already 
 pnpm add functype functype-react react react-dom
 ```
 
-`react-dom` is an optional peer (drop it for React Native / RSC-only consumers).
+`react-dom` is an optional peer (drop it for React Native / RSC-only consumers). `@tanstack/react-query` is likewise optional — install it only if you use `functype-react/query`.
 
 ## Surface
 
-| Subpath                 | Contents                                                                                                                            |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `functype-react` (main) | Stable hooks (`useStable*`), ADT hooks (`useOption`, `useEither`, `useTry`, `useList`), `Match` family components, equality helpers |
-| `functype-react/match`  | `<Match>`, `<MatchOption>`, `<MatchEither>`, `<MatchTry>` (also re-exported from main)                                              |
-| `functype-react/async`  | `useTask`, `useTaskPromise`, `useTaskValue` (React 19 `use()` bridge), `<TaskBoundary>`                                             |
-| `functype-react/forms`  | `Validated<E, A>` type alias, `useValidatedField`, `useValidatedForm`                                                               |
+| Subpath                 | Contents                                                                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `functype-react` (main) | Stable hooks (`useStable*`), ADT hooks (`useOption`, `useEither`, `useTry`, `useList`), `Match` family components, equality helpers         |
+| `functype-react/match`  | `<Match>`, `<MatchOption>`, `<MatchEither>`, `<MatchTry>` (also re-exported from main)                                                      |
+| `functype-react/async`  | `useTask`, `useTaskPromise`, `useTaskValue` (React 19 `use()` bridge), `<TaskBoundary>`                                                     |
+| `functype-react/forms`  | `Validated<E, A>` type alias, `useValidatedField`, `useValidatedForm`                                                                       |
+| `functype-react/query`  | `useIOQuery(State)`, `useIOMutation(State)`, `ioQueryFn`, `ioMutationFn`, `IOQueryError`, `toQueryState` — TanStack Query adapters for `IO` |
 
-`./async` and `./forms` stay off the main entry so consumers who don't touch Suspense or applicative forms tree-shake them out.
+`./async`, `./forms`, and `./query` stay off the main entry so consumers who don't touch Suspense, applicative forms, or React Query tree-shake them out.
 
 ## Tier 1 — stable hooks + ADT hooks
 
@@ -134,11 +135,122 @@ function Signup() {
 
 Errors accumulate applicatively — every failing rule is surfaced in one pass, not just the first.
 
+## Tier 5 — React Query
+
+`Http.get(...)` returns `IO<never, HttpError, HttpResponse<T>>`, and neither `IO` terminal fits TanStack Query: `.run()` never throws (so React Query never sees a failure), and `.runOrThrow()` throws the raw tagged object — which is **not** an `Error`, so the ubiquitous `error instanceof Error ? error.message : fallback` handler silently degrades.
+
+`functype-react/query` owns that bridge. Failures arrive boxed as `IOQueryError<E>`: a real `Error` with a populated `.message`, whose `.error` is still the fully discriminable functype error.
+
+```ts
+import { useIOQuery } from "functype-react/query"
+import { Http, HttpErrors, type HttpError } from "functype/fetch"
+
+const { data, error } = useIOQuery(
+  ["connector-limits", userId],
+  ({ signal }) => Http.get<ConnectorLimits>(url, { headers, signal }),
+  { enabled: !!userId },
+)
+
+if (error) {
+  error instanceof Error // true
+  error.message // "HTTP 403 Forbidden — /api/limits"
+
+  HttpErrors.match(error.error, {
+    NetworkError: () => <Offline />,
+    HttpStatusError: (e) => (e.status === 403 ? <UpgradePrompt /> : <Failed />),
+    DecodeError: () => <SchemaDrift />,
+  })
+}
+```
+
+### Matching instead of flag soup
+
+The result above is still React Query's — `data` is `A | undefined`, so the success path needs a `!` or a guard. `toQueryState` projects it onto the same `TaskState` ADT that `functype-react/async` returns, so a query matches exhaustively like any other functype value:
+
+```tsx
+import { Match } from "functype-react"
+import { toQueryState, useIOQuery } from "functype-react/query"
+
+function UserPanel({ id }: { id: string }) {
+  const query = useIOQuery(["user", id], ({ signal }) => Http.get<User>(`/users/${id}`, { signal }))
+
+  return (
+    <Match value={toQueryState(query)}>
+      {{
+        Idle: () => null,
+        Pending: () => <Spinner />,
+        Failure: ({ error }) => <Err e={error.error} />,
+        Success: ({ value }) => <Profile user={value} />,
+      }}
+    </Match>
+  )
+}
+```
+
+`Success` hands you a defined `User` — no `!`, no `| undefined` — and omitting a case is a compile error. A disabled query (`enabled: false`, never fetched) projects to `Idle`, an in-flight or paused one to `Pending`. `toMutationState` does the same for mutations, where React Query's own `idle` status maps straight onto `Idle`.
+
+The projection is a pure function over the result, so you keep everything else React Query gives you (`refetch`, `isFetching`, `invalidate`) on the original object.
+
+If the ADT is all you need, `useIOQueryState` skips the projection step — it returns `TaskState` directly, plus the `isIdle`/`isPending`/`isSuccess`/`isFailure` flags and `refetch`, mirroring what `useTask` returns in Tier 3:
+
+```tsx
+const user = useIOQueryState(["user", id], ({ signal }) => Http.get<User>(url, { signal }))
+
+<Match value={user}>
+  {{
+    Idle: () => null,
+    Pending: () => <Spinner />,
+    Failure: ({ error }) => <Err e={error.error} />,
+    Success: ({ value }) => <Profile user={value} />,
+  }}
+</Match>
+```
+
+`useIOMutationState` is the mutation counterpart, carrying `mutate` / `mutateAsync` / `reset` through alongside the state. Both read only the fields they project, so React Query's tracked-properties optimization still applies — your component isn't subscribed to fields it never renders. Reach for `useIOQuery` + `toQueryState` when you need the rest of the result (`isFetching`, `dataUpdatedAt`).
+
+Mutations mirror the shape (React Query supplies no `AbortSignal` to mutations, so the callback takes only the variables):
+
+```ts
+import { useIOMutation } from "functype-react/query"
+
+const create = useIOMutation((body: CreateTokenInput) => Http.post<Token>(url, { headers, body }), {
+  onError: (e) => toast(e.message, { detail: e.error._tag }),
+})
+```
+
+For full control over the query object — or for `useSuspenseQuery` / `useInfiniteQuery` / `queryClient.prefetchQuery` — drop to the primitives. They carry no `@tanstack` types at all, so they compose with any of those:
+
+```ts
+import { ioQueryFn } from "functype-react/query"
+
+useQuery({
+  queryKey: ["connector-limits", userId],
+  queryFn: ioQueryFn(({ signal }) => Http.get<ConnectorLimits>(url, { headers, signal })),
+  enabled: !!userId,
+})
+```
+
+`ioQueryFn` is generic over the query context, so a richer one flows through unchanged — annotate the callback parameter to reach `pageParam` in an infinite query:
+
+```ts
+useInfiniteQuery({
+  queryKey: ["events"],
+  queryFn: ioQueryFn(({ signal, pageParam }: QueryFunctionContext<QueryKey, number>) =>
+    Http.get<Page>(url, { params: { cursor: pageParam }, signal }),
+  ),
+  initialPageParam: 0,
+  getNextPageParam: (last) => last.data.nextCursor,
+})
+```
+
+Both the hooks and the primitives are generic over any `IO<never, E, A>` — nothing here is HTTP-specific. `Error.message` is derived structurally (`formatIOError`); pass `formatError` to override it.
+
 ## Compatibility
 
 - **TypeScript**: `strict: true` + `noUncheckedIndexedAccess: true`. Loose configs will silently lose the type-level exhaustiveness guarantees.
 - **React**: peer dep range `>=18 <20`. Tier 3's `useTaskValue` (and consequently anything that depends on React 19's `use()` hook) is React-19-only at runtime; the rest of the package works on both.
 - **SSR / RSC**: hooks are client-only and marked with `"use client"`. `<Match>` family components are pure and render fine in Server Components.
+- **React Query**: Tier 5 targets `@tanstack/react-query` v5 (`>=5.0.0`), an optional peer. The `ioQueryFn` / `ioMutationFn` primitives type their context structurally, so they carry no `@tanstack` types and are unaffected by its major-version churn.
 
 ## Deferred to v0.2
 

--- a/packages/functype-react/README.md
+++ b/packages/functype-react/README.md
@@ -189,7 +189,7 @@ function UserPanel({ id }: { id: string }) {
 
 `Success` hands you a defined `User` — no `!`, no `| undefined` — and omitting a case is a compile error. A disabled query (`enabled: false`, never fetched) projects to `Idle`, an in-flight or paused one to `Pending`. `toMutationState` does the same for mutations, where React Query's own `idle` status maps straight onto `Idle`.
 
-The projection is a pure function over the result, so you keep everything else React Query gives you (`refetch`, `isFetching`, `invalidate`) on the original object.
+The projection is a pure function over the result, so you keep everything else React Query gives you (`refetch`, `isFetching`, `dataUpdatedAt`) on the original object. (Invalidation is a client-level operation — `queryClient.invalidateQueries()` — not a method on the result.)
 
 If the ADT is all you need, `useIOQueryState` skips the projection step — it returns `TaskState` directly, plus the `isIdle`/`isPending`/`isSuccess`/`isFailure` flags and `refetch`, mirroring what `useTask` returns in Tier 3:
 

--- a/packages/functype-react/README.md
+++ b/packages/functype-react/README.md
@@ -206,7 +206,14 @@ const user = useIOQueryState(["user", id], ({ signal }) => Http.get<User>(url, {
 </Match>
 ```
 
-`useIOMutationState` is the mutation counterpart, carrying `mutate` / `mutateAsync` / `reset` through alongside the state. Both read only the fields they project, so React Query's tracked-properties optimization still applies — your component isn't subscribed to fields it never renders. Reach for `useIOQuery` + `toQueryState` when you need the rest of the result (`isFetching`, `dataUpdatedAt`).
+`useIOMutationState` is the mutation counterpart, carrying `mutate` / `mutateAsync` / `reset` through alongside the state. Reach for `useIOQuery` + `toQueryState` when you need the rest of the result (`isFetching`, `dataUpdatedAt`).
+
+Both read only the fields they project. For **queries** that matters: React Query tracks which result properties an observer touches and re-renders only when those change, so projecting a subset keeps that optimization intact rather than subscribing your component to every field. (Tracked props accumulate over an observer's lifetime, so this is a floor, not a guarantee.) **Mutations have no such tracking** in React Query — `MutationObserver` notifies on every change regardless — so for `useIOMutationState` the narrow read is merely tidy, not an optimization.
+
+Two behaviours worth knowing before you rely on the ADT:
+
+- **A failed background refetch projects to `Failure` even though React Query still holds the last successful `data`.** `TaskState` has no "loaded but stale" variant. This is the deliberate default — it never silently hides a failure — but it does mean a transient refetch error flips a loaded view to the error branch. To keep rendering stale data, read `query.data` alongside the projection or branch on `query.isRefetchError` before projecting.
+- **If your effect factory throws synchronously** (before an `IO` is produced), the rejection is still boxed, but with `defect: true` and `.error` holding the raw thrown value rather than an `E`. Check `defect` before matching on `_tag` if that's reachable in your code.
 
 Mutations mirror the shape (React Query supplies no `AbortSignal` to mutations, so the callback takes only the variables):
 

--- a/packages/functype-react/package.json
+++ b/packages/functype-react/package.json
@@ -40,16 +40,21 @@
     "prepublishOnly": "pnpm validate"
   },
   "peerDependencies": {
+    "@tanstack/react-query": ">=5.0.0",
     "functype": ">=0.60.0",
     "react": ">=18.0.0 <20.0.0",
     "react-dom": ">=18.0.0 <20.0.0"
   },
   "peerDependenciesMeta": {
+    "@tanstack/react-query": {
+      "optional": true
+    },
     "react-dom": {
       "optional": true
     }
   },
   "devDependencies": {
+    "@tanstack/react-query": "^5.90.5",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.10.0",
     "@testing-library/react": "^16.3.2",
@@ -89,6 +94,11 @@
       "types": "./dist/forms/index.d.ts",
       "import": "./dist/forms/index.js",
       "default": "./dist/forms/index.js"
+    },
+    "./query": {
+      "types": "./dist/query/index.d.ts",
+      "import": "./dist/query/index.js",
+      "default": "./dist/query/index.js"
     }
   },
   "files": [

--- a/packages/functype-react/src/query/IOQueryError.ts
+++ b/packages/functype-react/src/query/IOQueryError.ts
@@ -11,6 +11,7 @@
  * `.message` behave as any React Query consumer expects, while `.error` preserves the
  * fully discriminable functype `E`.
  */
+import { Try } from "functype"
 
 /** Structural view of a tagged functype error (e.g. any `HttpError` variant). */
 type TaggedError = {
@@ -49,6 +50,12 @@ export const formatIOError = (error: unknown): string => {
     return `${error._tag}${where}`
   }
 
+  // `String({})` is "[object Object]", which tells a reader nothing. Prefer a JSON
+  // rendering for plain objects, falling back to String() for cycles and symbols.
+  if (typeof error === "object" && error !== null) {
+    return Try(() => JSON.stringify(error)).orElse(String(error))
+  }
+
   return String(error)
 }
 
@@ -69,13 +76,28 @@ export const formatIOError = (error: unknown): string => {
  * ```
  */
 export class IOQueryError<E> extends Error {
-  /** The raw functype error channel value — discriminable via its own `_tag`. */
+  /**
+   * The raw functype error channel value — discriminable via its own `_tag`.
+   *
+   * When {@link defect} is `true` this is **not** an `E`: it is whatever the effect
+   * factory threw before an `IO` was ever produced. Check `defect` before matching
+   * on `_tag` if your factory can throw synchronously.
+   */
   readonly error: E
 
-  constructor(error: E, message?: string) {
+  /**
+   * `true` when this wraps an unexpected throw rather than a value from the effect's
+   * typed error channel — i.e. the effect factory itself threw. Kept as an explicit
+   * flag rather than widening `E` to `unknown`, which would force every consumer to
+   * handle a case that should never occur.
+   */
+  readonly defect: boolean
+
+  constructor(error: E, message?: string, defect = false) {
     super(message ?? formatIOError(error), { cause: error })
     this.name = "IOQueryError"
     this.error = error
+    this.defect = defect
   }
 }
 

--- a/packages/functype-react/src/query/IOQueryError.ts
+++ b/packages/functype-react/src/query/IOQueryError.ts
@@ -1,0 +1,83 @@
+/**
+ * Error boxing for the React Query bridge.
+ *
+ * `IO`'s own terminals don't fit React Query's contract: `.run()` returns
+ * `Promise<Either<E, A>>` and never throws (so RQ never sees a failure), while
+ * `.runOrThrow()` throws the *raw* tagged error object — `{ _tag: "NetworkError", ... }`
+ * is not an `Error` instance, so the ubiquitous
+ * `error instanceof Error ? error.message : fallback` handler silently degrades.
+ *
+ * `IOQueryError` boxes the typed error so both worlds work: `instanceof Error` and
+ * `.message` behave as any React Query consumer expects, while `.error` preserves the
+ * fully discriminable functype `E`.
+ */
+
+/** Structural view of a tagged functype error (e.g. any `HttpError` variant). */
+type TaggedError = {
+  readonly _tag: string
+  readonly url?: unknown
+  readonly status?: unknown
+  readonly statusText?: unknown
+}
+
+const isTaggedError = (e: unknown): e is TaggedError =>
+  typeof e === "object" && e !== null && "_tag" in e && typeof (e as { _tag: unknown })._tag === "string"
+
+/**
+ * Derives a human-readable message from an arbitrary error channel value.
+ *
+ * Deliberately *structural* — this module does not import `functype/fetch`, so the
+ * query bridge stays generic over any `IO<never, E, A>` rather than being HTTP-specific.
+ * An `HttpStatusError` is recognized by its shape, not its type.
+ *
+ * Pass `formatError` to any of the query entry points to override this entirely.
+ */
+export const formatIOError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (isTaggedError(error)) {
+    const where = typeof error.url === "string" ? ` — ${error.url}` : ""
+
+    if (typeof error.status === "number") {
+      const statusText =
+        typeof error.statusText === "string" && error.statusText.length > 0 ? ` ${error.statusText}` : ""
+      return `HTTP ${error.status}${statusText}${where}`
+    }
+
+    return `${error._tag}${where}`
+  }
+
+  return String(error)
+}
+
+/**
+ * An `Error` subclass carrying the typed functype error channel.
+ *
+ * ```ts
+ * const { error } = useIOQuery(["limits", userId], ({ signal }) => Http.get(url, { signal }))
+ *
+ * error instanceof Error // true
+ * error.message          // "HTTP 403 Forbidden — /api/limits"
+ *
+ * HttpErrors.match(error.error, {
+ *   NetworkError: (e) => retryBanner(e),
+ *   HttpStatusError: (e) => (e.status === 403 ? upgradePrompt() : genericFailure(e)),
+ *   DecodeError: (e) => reportSchemaDrift(e),
+ * })
+ * ```
+ */
+export class IOQueryError<E> extends Error {
+  /** The raw functype error channel value — discriminable via its own `_tag`. */
+  readonly error: E
+
+  constructor(error: E, message?: string) {
+    super(message ?? formatIOError(error), { cause: error })
+    this.name = "IOQueryError"
+    this.error = error
+  }
+}
+
+/** Runtime guard for {@link IOQueryError}. */
+export const isIOQueryError = <E = unknown>(error: unknown): error is IOQueryError<E> => error instanceof IOQueryError

--- a/packages/functype-react/src/query/index.ts
+++ b/packages/functype-react/src/query/index.ts
@@ -1,0 +1,30 @@
+/**
+ * `functype-react/query` — TanStack Query adapters for `IO`.
+ *
+ * Bridges `IO<never, E, A>` (e.g. the `Http` client from `functype/fetch`) onto React
+ * Query's resolve/reject contract, preserving the typed error channel that both
+ * `.run()` (never throws) and `.runOrThrow()` (throws a non-`Error` tagged object) lose.
+ *
+ * Requires `@tanstack/react-query` — an *optional* peer dependency, so consumers who
+ * don't import this subpath neither install it nor bundle it.
+ *
+ * - `ioQueryFn` / `ioMutationFn` — framework-agnostic primitives; drop into any
+ *   `useQuery` / `useSuspenseQuery` / `prefetchQuery` call for full option control.
+ * - `useIOQuery` / `useIOMutation` — the common path, one call.
+ * - `toQueryState` / `toMutationState` — project a React Query result onto the
+ *   `TaskState` ADT so it can be matched exhaustively with the `<Match>` family,
+ *   rather than read through `data && !error && !isLoading` flag soup.
+ */
+export { formatIOError, IOQueryError, isIOQueryError } from "./IOQueryError"
+export type { IOBridgeOptions, IOQueryFnContext } from "./ioQueryFn"
+export { ioMutationFn, ioQueryFn } from "./ioQueryFn"
+export type { MutationResultView, QueryResultView } from "./queryState"
+export { toMutationState, toQueryState } from "./queryState"
+export type { UseIOMutationOptions } from "./useIOMutation"
+export { useIOMutation } from "./useIOMutation"
+export type { UseIOMutationStateResult } from "./useIOMutationState"
+export { useIOMutationState } from "./useIOMutationState"
+export type { UseIOQueryOptions } from "./useIOQuery"
+export { useIOQuery } from "./useIOQuery"
+export type { UseIOQueryStateResult } from "./useIOQueryState"
+export { useIOQueryState } from "./useIOQueryState"

--- a/packages/functype-react/src/query/ioQueryFn.ts
+++ b/packages/functype-react/src/query/ioQueryFn.ts
@@ -1,9 +1,12 @@
-/* eslint-disable functype/prefer-either -- This module IS the Either→throw bridge.
+/* eslint-disable functype/prefer-either -- This module IS the Either→rejection bridge.
  * React Query signals failure exclusively by promise rejection: `isError`, `onError`,
- * and retry all key off a rejected `queryFn`. Returning an `Either` here would be
+ * and retry all key off a rejected queryFn. Returning an `Either` here would be
  * indistinguishable from success to React Query — the very bug (see #239) that makes
  * `.run()` unusable as a `queryFn`. The throw is the contract, and it is confined to
- * these two functions so callers never have to write it themselves. */
+ * `runBoxed` so no caller ever has to write it. Scoped to the file rather than to each
+ * `throw` because the rule also fires on the enclosing function: three scattered
+ * suppressions would read as incidental exceptions rather than one deliberate design. */
+import { Try } from "functype"
 import type { IO } from "functype/io"
 
 import { IOQueryError } from "./IOQueryError"
@@ -28,6 +31,33 @@ export type IOBridgeOptions<E> = {
 }
 
 /**
+ * Runs an effect and returns its value, or throws a boxed {@link IOQueryError}.
+ *
+ * Two failure paths converge here:
+ * - the effect's typed error channel (`Left`) → boxed with `defect: false`
+ * - the factory throwing before an `IO` exists → boxed with `defect: true`
+ *
+ * The second matters because `.run()` itself never throws (defects raised *inside*
+ * the effect are folded into `Left` by the interpreter), but `io(input)` is ordinary
+ * user code that can throw while building the effect. Without this, that throw would
+ * escape unboxed and `error.error` would be `undefined` despite the declared type.
+ */
+const runBoxed = async <E, A>(effect: () => IO<never, E, A>, options?: IOBridgeOptions<E>): Promise<A> => {
+  const result = await Try(() => effect()).fold(
+    (thrown) => {
+      throw new IOQueryError(thrown as E, undefined, true)
+    },
+    (io) => io.run(),
+  )
+
+  if (result.isLeft()) {
+    throw new IOQueryError(result.value, options?.formatError?.(result.value))
+  }
+
+  return result.value
+}
+
+/**
  * Adapts an `IO<never, E, A>` into a React Query `queryFn`.
  *
  * `Right` resolves with the value; `Left` rejects with an {@link IOQueryError} that
@@ -47,15 +77,8 @@ export const ioQueryFn =
     io: (context: TContext) => IO<never, E, A>,
     options?: IOBridgeOptions<E>,
   ) =>
-  async (context: TContext): Promise<A> => {
-    const result = await io(context).run()
-
-    if (result.isLeft()) {
-      throw new IOQueryError(result.value, options?.formatError?.(result.value))
-    }
-
-    return result.value
-  }
+  (context: TContext): Promise<A> =>
+    runBoxed(() => io(context), options)
 
 /**
  * Adapts a variables-taking `IO<never, E, A>` into a React Query `mutationFn`.
@@ -71,12 +94,5 @@ export const ioQueryFn =
  */
 export const ioMutationFn =
   <E, A, V = void>(io: (variables: V) => IO<never, E, A>, options?: IOBridgeOptions<E>) =>
-  async (variables: V): Promise<A> => {
-    const result = await io(variables).run()
-
-    if (result.isLeft()) {
-      throw new IOQueryError(result.value, options?.formatError?.(result.value))
-    }
-
-    return result.value
-  }
+  (variables: V): Promise<A> =>
+    runBoxed(() => io(variables), options)

--- a/packages/functype-react/src/query/ioQueryFn.ts
+++ b/packages/functype-react/src/query/ioQueryFn.ts
@@ -1,0 +1,82 @@
+/* eslint-disable functype/prefer-either -- This module IS the Either→throw bridge.
+ * React Query signals failure exclusively by promise rejection: `isError`, `onError`,
+ * and retry all key off a rejected `queryFn`. Returning an `Either` here would be
+ * indistinguishable from success to React Query — the very bug (see #239) that makes
+ * `.run()` unusable as a `queryFn`. The throw is the contract, and it is confined to
+ * these two functions so callers never have to write it themselves. */
+import type { IO } from "functype/io"
+
+import { IOQueryError } from "./IOQueryError"
+
+/**
+ * Minimal structural view of React Query's `QueryFunctionContext` — the floor that
+ * every context satisfies, and the default when nothing wider is inferred.
+ *
+ * Typed structurally on purpose, so these primitives carry **no**
+ * `@tanstack/react-query` type dependency. `ioQueryFn` is generic over the context, so
+ * a richer one flows through unchanged: annotate the callback parameter (e.g. with
+ * `QueryFunctionContext<QueryKey, number>` for an infinite query) and `pageParam`,
+ * `queryKey`, and `meta` are all readable inside the effect factory.
+ */
+export type IOQueryFnContext = {
+  readonly signal: AbortSignal
+}
+
+export type IOBridgeOptions<E> = {
+  /** Override the derived `Error.message`. Defaults to a structural formatter. */
+  readonly formatError?: (error: E) => string
+}
+
+/**
+ * Adapts an `IO<never, E, A>` into a React Query `queryFn`.
+ *
+ * `Right` resolves with the value; `Left` rejects with an {@link IOQueryError} that
+ * carries the typed error on `.error`. Wire cancellation by closing over the supplied
+ * `signal`:
+ *
+ * ```ts
+ * useQuery({
+ *   queryKey: ["connector-limits", userId],
+ *   queryFn: ioQueryFn(({ signal }) => Http.get<Limits>(url, { headers, signal })),
+ *   enabled: !!userId,
+ * })
+ * ```
+ */
+export const ioQueryFn =
+  <E, A, TContext extends IOQueryFnContext = IOQueryFnContext>(
+    io: (context: TContext) => IO<never, E, A>,
+    options?: IOBridgeOptions<E>,
+  ) =>
+  async (context: TContext): Promise<A> => {
+    const result = await io(context).run()
+
+    if (result.isLeft()) {
+      throw new IOQueryError(result.value, options?.formatError?.(result.value))
+    }
+
+    return result.value
+  }
+
+/**
+ * Adapts a variables-taking `IO<never, E, A>` into a React Query `mutationFn`.
+ *
+ * React Query does not supply an `AbortSignal` to mutations, so the callback receives
+ * only the mutation variables.
+ *
+ * ```ts
+ * useMutation({
+ *   mutationFn: ioMutationFn((body: CreateTokenInput) => Http.post<Token>(url, { body })),
+ * })
+ * ```
+ */
+export const ioMutationFn =
+  <E, A, V = void>(io: (variables: V) => IO<never, E, A>, options?: IOBridgeOptions<E>) =>
+  async (variables: V): Promise<A> => {
+    const result = await io(variables).run()
+
+    if (result.isLeft()) {
+      throw new IOQueryError(result.value, options?.formatError?.(result.value))
+    }
+
+    return result.value
+  }

--- a/packages/functype-react/src/query/queryState.ts
+++ b/packages/functype-react/src/query/queryState.ts
@@ -42,6 +42,20 @@ export type MutationResultView<E, A> =
  * A disabled query (`enabled: false`, never fetched) projects to `Idle`; an
  * in-flight or paused one to `Pending`. Reuses the same `TaskState` that
  * `functype-react/async`'s `useTask` returns, so both async surfaces match alike.
+ *
+ * **Stale data on a failed refetch.** React Query keeps the last successful `data`
+ * while setting `status: "error"` when a *background refetch* fails. `TaskState` has
+ * no variant for "loaded, but the latest fetch failed", so that squashes to `Failure`
+ * and the still-held data is not surfaced through the ADT — a transient background
+ * failure will flip a loaded view to an error branch. This is the deliberate default:
+ * it never silently hides a failure. If you would rather keep rendering stale data,
+ * read `query.data` directly alongside the projection, or branch on
+ * `query.isRefetchError` before projecting.
+ *
+ * **Interruption.** `IO.run()` maps an interrupted effect to `Left(InterruptedError)`,
+ * which is not an `E`. Nothing in this subpath interrupts effects, so it will not
+ * arise here, but it is worth knowing that `.error` is `E` by construction rather
+ * than by proof.
  */
 export const toQueryState = <E, A>(result: QueryResultView<E, A>): TaskState<E, A> => {
   switch (result.status) {

--- a/packages/functype-react/src/query/queryState.ts
+++ b/packages/functype-react/src/query/queryState.ts
@@ -1,0 +1,72 @@
+import type { TaskState } from "../async/TaskState"
+
+/**
+ * Structural view of a React Query result — the discriminated shape this module
+ * actually depends on. Typed structurally (like {@link IOQueryFnContext}) so the
+ * projection carries no `@tanstack/react-query` type dependency; `UseQueryResult`
+ * satisfies it.
+ */
+export type QueryResultView<E, A> =
+  | { readonly status: "pending"; readonly fetchStatus: "fetching" | "paused" | "idle" }
+  | { readonly status: "success"; readonly data: A }
+  | { readonly status: "error"; readonly error: E }
+
+/** Structural view of a React Query mutation result. */
+export type MutationResultView<E, A> =
+  | { readonly status: "idle" }
+  | { readonly status: "pending" }
+  | { readonly status: "success"; readonly data: A }
+  | { readonly status: "error"; readonly error: E }
+
+/**
+ * Projects a React Query result onto the package's `TaskState` ADT, so a query can
+ * be folded or matched exhaustively instead of read through `data && !error && !isLoading`.
+ *
+ * This is the whole point of `functype-react`: omitting a case becomes a compile
+ * error, and the success branch hands you a defined `A` rather than `A | undefined`
+ * that needs a `!`.
+ *
+ * ```tsx
+ * const query = useIOQuery(["user", id], ({ signal }) => Http.get<User>(url, { signal }))
+ *
+ * <Match value={toQueryState(query)}>
+ *   {{
+ *     Idle: () => null,
+ *     Pending: () => <Spinner />,
+ *     Failure: ({ error }) => <Err e={error} />,
+ *     Success: ({ value }) => <Profile user={value} />,
+ *   }}
+ * </Match>
+ * ```
+ *
+ * A disabled query (`enabled: false`, never fetched) projects to `Idle`; an
+ * in-flight or paused one to `Pending`. Reuses the same `TaskState` that
+ * `functype-react/async`'s `useTask` returns, so both async surfaces match alike.
+ */
+export const toQueryState = <E, A>(result: QueryResultView<E, A>): TaskState<E, A> => {
+  switch (result.status) {
+    case "success":
+      return { _tag: "Success", value: result.data }
+    case "error":
+      return { _tag: "Failure", error: result.error }
+    case "pending":
+      return result.fetchStatus === "idle" ? { _tag: "Idle" } : { _tag: "Pending" }
+  }
+}
+
+/**
+ * Projects a React Query mutation result onto `TaskState`. React Query models an
+ * unfired mutation as `status: "idle"`, which maps directly onto `Idle`.
+ */
+export const toMutationState = <E, A>(result: MutationResultView<E, A>): TaskState<E, A> => {
+  switch (result.status) {
+    case "success":
+      return { _tag: "Success", value: result.data }
+    case "error":
+      return { _tag: "Failure", error: result.error }
+    case "pending":
+      return { _tag: "Pending" }
+    case "idle":
+      return { _tag: "Idle" }
+  }
+}

--- a/packages/functype-react/src/query/useIOMutation.ts
+++ b/packages/functype-react/src/query/useIOMutation.ts
@@ -1,0 +1,43 @@
+"use client"
+
+import type { UseMutationOptions, UseMutationResult } from "@tanstack/react-query"
+import { useMutation } from "@tanstack/react-query"
+import type { IO } from "functype/io"
+
+import type { IOQueryError } from "./IOQueryError"
+import { ioMutationFn } from "./ioQueryFn"
+
+export type UseIOMutationOptions<A, E, V, TContext> = Omit<
+  UseMutationOptions<A, IOQueryError<E>, V, TContext>,
+  "mutationFn"
+> & {
+  /** Override the derived `Error.message` on failure. */
+  readonly formatError?: (error: E) => string
+}
+
+/**
+ * `useMutation` for effects — runs an `IO<never, E, A>` per invocation and threads its
+ * typed error channel through to React Query.
+ *
+ * ```ts
+ * const create = useIOMutation((body: CreateTokenInput) => Http.post<Token>(url, { headers, body }), {
+ *   onError: (e) => toast(e.message, { detail: e.error._tag }),
+ * })
+ *
+ * create.mutate({ name: "ci" })
+ * ```
+ *
+ * React Query does not supply an `AbortSignal` to mutations, so the callback receives
+ * only the mutation variables.
+ */
+export function useIOMutation<A, E, V = void, TContext = unknown>(
+  io: (variables: V) => IO<never, E, A>,
+  options?: UseIOMutationOptions<A, E, V, TContext>,
+): UseMutationResult<A, IOQueryError<E>, V, TContext> {
+  const { formatError, ...mutationOptions } = options ?? {}
+
+  return useMutation<A, IOQueryError<E>, V, TContext>({
+    ...mutationOptions,
+    mutationFn: ioMutationFn<E, A, V>(io, { formatError }),
+  })
+}

--- a/packages/functype-react/src/query/useIOMutationState.ts
+++ b/packages/functype-react/src/query/useIOMutationState.ts
@@ -1,0 +1,61 @@
+"use client"
+
+import type { UseMutationResult } from "@tanstack/react-query"
+import type { IO } from "functype/io"
+
+import type { TaskState } from "../async/TaskState"
+import type { IOQueryError } from "./IOQueryError"
+import { toMutationState } from "./queryState"
+import type { UseIOMutationOptions } from "./useIOMutation"
+import { useIOMutation } from "./useIOMutation"
+
+/**
+ * `TaskState` plus the flags and the trigger functions. Unlike a query, a mutation is
+ * useless without its trigger, so `mutate` / `mutateAsync` / `reset` are carried
+ * through with React Query's own signatures.
+ */
+export type UseIOMutationStateResult<A, E, V, TContext> = TaskState<IOQueryError<E>, A> &
+  Pick<UseMutationResult<A, IOQueryError<E>, V, TContext>, "mutate" | "mutateAsync" | "reset"> & {
+    readonly isIdle: boolean
+    readonly isPending: boolean
+    readonly isSuccess: boolean
+    readonly isFailure: boolean
+  }
+
+/**
+ * `useIOMutation` projected onto the `TaskState` ADT, so a mutation's lifecycle matches
+ * exhaustively like a query's. React Query's own `idle` status maps directly onto `Idle`.
+ *
+ * ```tsx
+ * const create = useIOMutationState((body: CreateTokenInput) => Http.post<Token>(url, { body }))
+ *
+ * <button onClick={() => create.mutate({ name: "ci" })} disabled={create.isPending}>create</button>
+ *
+ * <Match value={create}>
+ *   {{
+ *     Idle: () => null,
+ *     Pending: () => <Spinner />,
+ *     Failure: ({ error }) => <Err e={error.error} />,
+ *     Success: ({ value }) => <TokenRow token={value} />,
+ *   }}
+ * </Match>
+ * ```
+ */
+export function useIOMutationState<A, E, V = void, TContext = unknown>(
+  io: (variables: V) => IO<never, E, A>,
+  options?: UseIOMutationOptions<A, E, V, TContext>,
+): UseIOMutationStateResult<A, E, V, TContext> {
+  const mutation = useIOMutation(io, options)
+  const state = toMutationState(mutation)
+
+  return {
+    ...state,
+    isIdle: state._tag === "Idle",
+    isPending: state._tag === "Pending",
+    isSuccess: state._tag === "Success",
+    isFailure: state._tag === "Failure",
+    mutate: mutation.mutate,
+    mutateAsync: mutation.mutateAsync,
+    reset: mutation.reset,
+  }
+}

--- a/packages/functype-react/src/query/useIOQuery.ts
+++ b/packages/functype-react/src/query/useIOQuery.ts
@@ -1,0 +1,57 @@
+"use client"
+
+import type { QueryFunctionContext, QueryKey, UseQueryOptions, UseQueryResult } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
+import type { IO } from "functype/io"
+
+import type { IOQueryError } from "./IOQueryError"
+import { ioQueryFn } from "./ioQueryFn"
+
+export type UseIOQueryOptions<A, E, TData, TQueryKey extends QueryKey> = Omit<
+  UseQueryOptions<A, IOQueryError<E>, TData, TQueryKey>,
+  "queryKey" | "queryFn"
+> & {
+  /** Override the derived `Error.message` on failure. */
+  readonly formatError?: (error: E) => string
+}
+
+/**
+ * `useQuery` for effects — runs an `IO<never, E, A>` and threads its typed error channel
+ * through to React Query's `error`.
+ *
+ * The failure is boxed as `IOQueryError<E>`, so `error instanceof Error` and
+ * `error.message` behave normally while `error.error` stays fully discriminable:
+ *
+ * ```ts
+ * const { data, error } = useIOQuery(
+ *   ["connector-limits", userId],
+ *   ({ signal }) => Http.get<Limits>(url, { headers, signal }),
+ *   { enabled: !!userId },
+ * )
+ *
+ * if (error) {
+ *   HttpErrors.match(error.error, {
+ *     NetworkError: () => <Offline />,
+ *     HttpStatusError: (e) => (e.status === 403 ? <UpgradePrompt /> : <Failed />),
+ *     DecodeError: () => <SchemaDrift />,
+ *   })
+ * }
+ * ```
+ *
+ * Every other `useQuery` option (`select`, `staleTime`, `placeholderData`, …) passes
+ * through untouched. For full control over the query object — or for
+ * `useSuspenseQuery` / `useInfiniteQuery` — use the `ioQueryFn` primitive directly.
+ */
+export function useIOQuery<A, E, TData = A, TQueryKey extends QueryKey = QueryKey>(
+  queryKey: TQueryKey,
+  io: (context: QueryFunctionContext<TQueryKey>) => IO<never, E, A>,
+  options?: UseIOQueryOptions<A, E, TData, TQueryKey>,
+): UseQueryResult<TData, IOQueryError<E>> {
+  const { formatError, ...queryOptions } = options ?? {}
+
+  return useQuery<A, IOQueryError<E>, TData, TQueryKey>({
+    ...queryOptions,
+    queryKey,
+    queryFn: ioQueryFn<E, A, QueryFunctionContext<TQueryKey>>(io, { formatError }),
+  })
+}

--- a/packages/functype-react/src/query/useIOQueryState.ts
+++ b/packages/functype-react/src/query/useIOQueryState.ts
@@ -15,7 +15,7 @@ import { useIOQuery } from "./useIOQuery"
  *
  * `refetch` keeps React Query's own signature rather than a lossy re-declaration.
  */
-export type UseIOQueryStateResult<E, A> = TaskState<IOQueryError<E>, A> &
+export type UseIOQueryStateResult<A, E> = TaskState<IOQueryError<E>, A> &
   Pick<UseQueryResult<A, IOQueryError<E>>, "refetch"> & {
     readonly isIdle: boolean
     readonly isPending: boolean
@@ -50,7 +50,7 @@ export function useIOQueryState<A, E, TData = A, TQueryKey extends QueryKey = Qu
   queryKey: TQueryKey,
   io: (context: QueryFunctionContext<TQueryKey>) => IO<never, E, A>,
   options?: UseIOQueryOptions<A, E, TData, TQueryKey>,
-): UseIOQueryStateResult<E, TData> {
+): UseIOQueryStateResult<TData, E> {
   const query = useIOQuery(queryKey, io, options)
   const state = toQueryState(query)
 

--- a/packages/functype-react/src/query/useIOQueryState.ts
+++ b/packages/functype-react/src/query/useIOQueryState.ts
@@ -1,0 +1,65 @@
+"use client"
+
+import type { QueryFunctionContext, QueryKey, UseQueryResult } from "@tanstack/react-query"
+import type { IO } from "functype/io"
+
+import type { TaskState } from "../async/TaskState"
+import type { IOQueryError } from "./IOQueryError"
+import { toQueryState } from "./queryState"
+import type { UseIOQueryOptions } from "./useIOQuery"
+import { useIOQuery } from "./useIOQuery"
+
+/**
+ * `TaskState` plus the convenience flags and refetch trigger, mirroring
+ * `UseTaskResult` from `functype-react/async` so both async surfaces read alike.
+ *
+ * `refetch` keeps React Query's own signature rather than a lossy re-declaration.
+ */
+export type UseIOQueryStateResult<E, A> = TaskState<IOQueryError<E>, A> &
+  Pick<UseQueryResult<A, IOQueryError<E>>, "refetch"> & {
+    readonly isIdle: boolean
+    readonly isPending: boolean
+    readonly isSuccess: boolean
+    readonly isFailure: boolean
+  }
+
+/**
+ * `useIOQuery` projected straight onto the `TaskState` ADT — the flag-soup-free path
+ * in one call.
+ *
+ * ```tsx
+ * const user = useIOQueryState(["user", id], ({ signal }) => Http.get<User>(url, { signal }))
+ *
+ * <Match value={user}>
+ *   {{
+ *     Idle: () => null,
+ *     Pending: () => <Spinner />,
+ *     Failure: ({ error }) => <Err e={error.error} />,
+ *     Success: ({ value }) => <Profile user={value} />,
+ *   }}
+ * </Match>
+ * ```
+ *
+ * Reads only `status` / `fetchStatus` / `data` / `error` / `refetch` off the query, so
+ * React Query's tracked-properties optimization still applies — the component is not
+ * subscribed to fields it never renders. When you need the rest of the result
+ * (`isFetching`, `dataUpdatedAt`, `invalidate`), use {@link useIOQuery} with
+ * {@link toQueryState} instead.
+ */
+export function useIOQueryState<A, E, TData = A, TQueryKey extends QueryKey = QueryKey>(
+  queryKey: TQueryKey,
+  io: (context: QueryFunctionContext<TQueryKey>) => IO<never, E, A>,
+  options?: UseIOQueryOptions<A, E, TData, TQueryKey>,
+): UseIOQueryStateResult<E, TData> {
+  const query = useIOQuery(queryKey, io, options)
+  const state = toQueryState(query)
+
+  return {
+    ...state,
+    isIdle: state._tag === "Idle",
+    isPending: state._tag === "Pending",
+    isSuccess: state._tag === "Success",
+    isFailure: state._tag === "Failure",
+    refetch: query.refetch,
+  }
+}

--- a/packages/functype-react/src/query/useIOQueryState.ts
+++ b/packages/functype-react/src/query/useIOQueryState.ts
@@ -43,7 +43,7 @@ export type UseIOQueryStateResult<A, E> = TaskState<IOQueryError<E>, A> &
  * Reads only `status` / `fetchStatus` / `data` / `error` / `refetch` off the query, so
  * React Query's tracked-properties optimization still applies — the component is not
  * subscribed to fields it never renders. When you need the rest of the result
- * (`isFetching`, `dataUpdatedAt`, `invalidate`), use {@link useIOQuery} with
+ * (`isFetching`, `dataUpdatedAt`, `failureCount`), use {@link useIOQuery} with
  * {@link toQueryState} instead.
  */
 export function useIOQueryState<A, E, TData = A, TQueryKey extends QueryKey = QueryKey>(

--- a/packages/functype-react/test/lint-suppressions.spec.ts
+++ b/packages/functype-react/test/lint-suppressions.spec.ts
@@ -1,0 +1,67 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { join, relative } from "node:path"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Ratchet on eslint suppressions in `src/`.
+ *
+ * This package gates at `eslint src --max-warnings 0`, so every remaining
+ * `eslint-disable` is a deliberate, reviewed exception rather than noise. Each one
+ * below marks a place where a React or React Query contract is genuinely
+ * incompatible with the rule's advice — a throw that must propagate to an
+ * ErrorBoundary, a nullable parameter that is the hook's entire purpose, an
+ * `Either` that a host library would read as success.
+ *
+ * The point of pinning the exact map (rather than a bare total) is that adding,
+ * moving, or removing one is visible in review instead of drifting silently.
+ *
+ * **Adding an entry is not forbidden — it just has to be a decision.** If a new
+ * suppression is right, update this map in the same commit and say why in the
+ * message. If you can instead make the rule understand the boundary structurally,
+ * prefer that: see the `@interop` marker proposal for `eslint-plugin-functype`.
+ */
+const EXPECTED_SUPPRESSIONS: Readonly<Record<string, number>> = {
+  "async/useTaskValue.ts": 1,
+  "hooks/useOption.ts": 1,
+  "hooks/useStableCallback.ts": 1,
+  "hooks/useStableEffect.ts": 1,
+  "hooks/useStableMemo.ts": 1,
+  "query/ioQueryFn.ts": 1,
+}
+
+const SRC_DIR = join(import.meta.dirname, "..", "src")
+
+const sourceFiles = (dir: string): ReadonlyArray<string> =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) return sourceFiles(full)
+    return /\.tsx?$/.test(entry.name) ? [full] : []
+  })
+
+const countSuppressions = (file: string): number => (readFileSync(file, "utf8").match(/eslint-disable/g) ?? []).length
+
+describe("eslint suppression ratchet", () => {
+  it("matches the reviewed set of suppressions exactly", () => {
+    const actual = Object.fromEntries(
+      sourceFiles(SRC_DIR)
+        .map((file) => [relative(SRC_DIR, file).split("\\").join("/"), countSuppressions(file)] as const)
+        .filter(([, count]) => count > 0)
+        .sort(([a], [b]) => a.localeCompare(b)),
+    )
+
+    expect(actual).toEqual(EXPECTED_SUPPRESSIONS)
+  })
+
+  it("keeps every suppression justified with an inline reason", () => {
+    const unjustified = sourceFiles(SRC_DIR).flatMap((file) =>
+      readFileSync(file, "utf8")
+        .split("\n")
+        .flatMap((line, index) =>
+          line.includes("eslint-disable") && !line.includes("--") ? [`${relative(SRC_DIR, file)}:${index + 1}`] : [],
+        ),
+    )
+
+    // eslint's `--` convention carries the rationale; a bare disable says nothing.
+    expect(unjustified).toEqual([])
+  })
+})

--- a/packages/functype-react/test/query/IOQueryError.spec.ts
+++ b/packages/functype-react/test/query/IOQueryError.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+
+import { formatIOError, IOQueryError, isIOQueryError } from "../../src/query/IOQueryError"
+
+type NetworkError = { readonly _tag: "NetworkError"; readonly url: string; readonly cause: unknown }
+type StatusError = {
+  readonly _tag: "HttpStatusError"
+  readonly url: string
+  readonly status: number
+  readonly statusText: string
+}
+
+describe("formatIOError", () => {
+  it("uses the message of a real Error", () => {
+    expect(formatIOError(new Error("boom"))).toBe("boom")
+  })
+
+  it("renders a status-shaped tagged error as an HTTP line", () => {
+    const error: StatusError = {
+      _tag: "HttpStatusError",
+      url: "/api/limits",
+      status: 403,
+      statusText: "Forbidden",
+    }
+    expect(formatIOError(error)).toBe("HTTP 403 Forbidden — /api/limits")
+  })
+
+  it("omits an empty statusText", () => {
+    expect(formatIOError({ _tag: "HttpStatusError", url: "/api/x", status: 500, statusText: "" })).toBe(
+      "HTTP 500 — /api/x",
+    )
+  })
+
+  it("renders a non-status tagged error as tag plus url", () => {
+    const error: NetworkError = { _tag: "NetworkError", url: "/api/limits", cause: new Error("offline") }
+    expect(formatIOError(error)).toBe("NetworkError — /api/limits")
+  })
+
+  it("renders a tagged error with no url as the bare tag", () => {
+    expect(formatIOError({ _tag: "DecodeError" })).toBe("DecodeError")
+  })
+
+  it("falls back to String() for untagged values", () => {
+    expect(formatIOError("plain string")).toBe("plain string")
+    expect(formatIOError(42)).toBe("42")
+    expect(formatIOError(null)).toBe("null")
+  })
+})
+
+describe("IOQueryError", () => {
+  const error: StatusError = {
+    _tag: "HttpStatusError",
+    url: "/api/limits",
+    status: 403,
+    statusText: "Forbidden",
+  }
+
+  it("is a real Error instance — the footgun this whole module exists to fix", () => {
+    const boxed = new IOQueryError(error)
+    expect(boxed instanceof Error).toBe(true)
+    expect(boxed.name).toBe("IOQueryError")
+  })
+
+  it("round-trips the raw typed error on .error", () => {
+    const boxed = new IOQueryError(error)
+    expect(boxed.error).toBe(error)
+    expect(boxed.error._tag).toBe("HttpStatusError")
+    expect(boxed.error.status).toBe(403)
+  })
+
+  it("derives a message from the boxed error by default", () => {
+    expect(new IOQueryError(error).message).toBe("HTTP 403 Forbidden — /api/limits")
+  })
+
+  it("prefers an explicit message over the derived one", () => {
+    expect(new IOQueryError(error, "you have hit your tier cap").message).toBe("you have hit your tier cap")
+  })
+
+  it("exposes the raw error as the native Error cause", () => {
+    expect(new IOQueryError(error).cause).toBe(error)
+  })
+})
+
+describe("isIOQueryError", () => {
+  it("accepts boxed errors and rejects everything else", () => {
+    expect(isIOQueryError(new IOQueryError({ _tag: "DecodeError" }))).toBe(true)
+    expect(isIOQueryError(new Error("plain"))).toBe(false)
+    expect(isIOQueryError({ _tag: "DecodeError" })).toBe(false)
+    expect(isIOQueryError(undefined)).toBe(false)
+  })
+})

--- a/packages/functype-react/test/query/IOQueryError.spec.ts
+++ b/packages/functype-react/test/query/IOQueryError.spec.ts
@@ -40,10 +40,21 @@ describe("formatIOError", () => {
     expect(formatIOError({ _tag: "DecodeError" })).toBe("DecodeError")
   })
 
-  it("falls back to String() for untagged values", () => {
+  it("falls back to String() for untagged primitives", () => {
     expect(formatIOError("plain string")).toBe("plain string")
     expect(formatIOError(42)).toBe("42")
     expect(formatIOError(null)).toBe("null")
+  })
+
+  it("renders an untagged plain object as JSON rather than [object Object]", () => {
+    expect(formatIOError({ code: "E_LIMIT", retryable: false })).toBe('{"code":"E_LIMIT","retryable":false}')
+  })
+
+  it("falls back to String() when JSON serialization fails", () => {
+    const cyclic: { self?: unknown } = {}
+    cyclic.self = cyclic
+
+    expect(formatIOError(cyclic)).toBe("[object Object]")
   })
 })
 
@@ -78,6 +89,11 @@ describe("IOQueryError", () => {
 
   it("exposes the raw error as the native Error cause", () => {
     expect(new IOQueryError(error).cause).toBe(error)
+  })
+
+  it("defaults to defect: false, and records a defect when told to", () => {
+    expect(new IOQueryError(error).defect).toBe(false)
+    expect(new IOQueryError(new Error("boom"), undefined, true).defect).toBe(true)
   })
 })
 

--- a/packages/functype-react/test/query/harness.tsx
+++ b/packages/functype-react/test/query/harness.tsx
@@ -1,14 +1,19 @@
+import type { QueryClientConfig } from "@tanstack/react-query"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
+
+type QueryDefaults = NonNullable<QueryClientConfig["defaultOptions"]>["queries"]
 
 /**
  * Fresh `QueryClient` per test with retries disabled, so a failing effect surfaces on
  * the first attempt instead of after React Query's default backoff schedule.
+ *
+ * Pass `queries` to override that default — the retry test needs the real retry path.
  */
-export const createWrapper = () => {
+export const createWrapper = (queries?: QueryDefaults) => {
   const client = new QueryClient({
     defaultOptions: {
-      queries: { retry: false },
+      queries: { retry: false, ...queries },
       mutations: { retry: false },
     },
   })

--- a/packages/functype-react/test/query/harness.tsx
+++ b/packages/functype-react/test/query/harness.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+/**
+ * Fresh `QueryClient` per test with retries disabled, so a failing effect surfaces on
+ * the first attempt instead of after React Query's default backoff schedule.
+ */
+export const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}

--- a/packages/functype-react/test/query/infiniteQuery.spec.tsx
+++ b/packages/functype-react/test/query/infiniteQuery.spec.tsx
@@ -1,0 +1,71 @@
+import type { QueryFunctionContext, QueryKey } from "@tanstack/react-query"
+import { useInfiniteQuery } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { IO } from "functype/io"
+import { describe, expect, it } from "vitest"
+
+import { ioQueryFn } from "../../src/query/ioQueryFn"
+import { IOQueryError } from "../../src/query/IOQueryError"
+import { createWrapper } from "./harness"
+
+type Page = { readonly page: number; readonly items: readonly string[] }
+
+const pageAt = (page: number): Page => ({ page, items: [`item-${page}`] })
+
+/**
+ * `ioQueryFn` is generic over the query context precisely so an infinite query's
+ * `pageParam` reaches the effect factory. That is a runtime contract, not just a
+ * typing one — these cover the behaviour the type-level specs assert in `query.test-d.ts`.
+ */
+describe("ioQueryFn with useInfiniteQuery", () => {
+  it("threads pageParam into the effect factory across pages", async () => {
+    const seen: number[] = []
+
+    const { result } = renderHook(
+      () =>
+        useInfiniteQuery({
+          queryKey: ["pages"],
+          queryFn: ioQueryFn<never, Page, QueryFunctionContext<QueryKey, number>>((context) => {
+            seen.push(context.pageParam)
+            return IO.succeed(pageAt(context.pageParam))
+          }),
+          initialPageParam: 0,
+          getNextPageParam: (last: Page) => last.page + 1,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(seen).toEqual([0])
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+
+    // The factory saw the next page's param — the thread-through this subpath advertises.
+    expect(seen).toEqual([0, 1])
+  })
+
+  it("boxes a failing page into an IOQueryError", async () => {
+    const notFound = { _tag: "HttpStatusError", url: "/pages", status: 404, statusText: "Not Found" } as const
+
+    const { result } = renderHook(
+      () =>
+        useInfiniteQuery({
+          queryKey: ["pages", "failing"],
+          queryFn: ioQueryFn<typeof notFound, Page, QueryFunctionContext<QueryKey, number>>(() => IO.fail(notFound)),
+          initialPageParam: 0,
+          getNextPageParam: (last: Page) => last.page + 1,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    const error = result.current.error
+    expect(error).toBeInstanceOf(IOQueryError)
+    expect(error).toBeInstanceOf(Error)
+    expect((error as IOQueryError<typeof notFound>).error.status).toBe(404)
+    expect(error?.message).toBe("HTTP 404 Not Found — /pages")
+  })
+})

--- a/packages/functype-react/test/query/ioQueryFn.spec.ts
+++ b/packages/functype-react/test/query/ioQueryFn.spec.ts
@@ -1,0 +1,76 @@
+import { IO } from "functype/io"
+import { describe, expect, it } from "vitest"
+
+import { ioMutationFn, ioQueryFn } from "../../src/query/ioQueryFn"
+import { IOQueryError } from "../../src/query/IOQueryError"
+
+type StatusError = {
+  readonly _tag: "HttpStatusError"
+  readonly url: string
+  readonly status: number
+  readonly statusText: string
+}
+
+const forbidden: StatusError = {
+  _tag: "HttpStatusError",
+  url: "/api/limits",
+  status: 403,
+  statusText: "Forbidden",
+}
+
+const context = () => ({ signal: new AbortController().signal })
+
+describe("ioQueryFn", () => {
+  it("resolves with the Right value", async () => {
+    const queryFn = ioQueryFn<StatusError, number>(() => IO.succeed(42))
+    await expect(queryFn(context())).resolves.toBe(42)
+  })
+
+  it("rejects with an IOQueryError carrying the Left value", async () => {
+    const queryFn = ioQueryFn<StatusError, number>(() => IO.fail(forbidden))
+
+    await expect(queryFn(context())).rejects.toBeInstanceOf(IOQueryError)
+
+    const error = await queryFn(context()).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(Error)
+    expect((error as IOQueryError<StatusError>).error).toBe(forbidden)
+    expect((error as IOQueryError<StatusError>).message).toBe("HTTP 403 Forbidden — /api/limits")
+  })
+
+  it("applies a formatError override", async () => {
+    const queryFn = ioQueryFn<StatusError, number>(() => IO.fail(forbidden), {
+      formatError: (e) => `tier cap hit (${e.status})`,
+    })
+
+    const error = await queryFn(context()).catch((e: unknown) => e)
+    expect((error as IOQueryError<StatusError>).message).toBe("tier cap hit (403)")
+  })
+
+  it("passes the AbortSignal through to the effect factory", async () => {
+    const controller = new AbortController()
+    let seen: AbortSignal | undefined
+
+    const queryFn = ioQueryFn<never, string>(({ signal }) => {
+      seen = signal
+      return IO.succeed("ok")
+    })
+
+    await queryFn({ signal: controller.signal })
+    expect(seen).toBe(controller.signal)
+  })
+})
+
+describe("ioMutationFn", () => {
+  it("resolves with the Right value and receives the variables", async () => {
+    const mutationFn = ioMutationFn<never, string, { name: string }>((vars) => IO.succeed(`created ${vars.name}`))
+    await expect(mutationFn({ name: "ci" })).resolves.toBe("created ci")
+  })
+
+  it("rejects with an IOQueryError carrying the Left value", async () => {
+    const mutationFn = ioMutationFn<StatusError, string, void>(() => IO.fail(forbidden))
+
+    const error = await mutationFn(undefined).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(IOQueryError)
+    expect((error as IOQueryError<StatusError>).error.status).toBe(403)
+  })
+})

--- a/packages/functype-react/test/query/ioQueryFn.spec.ts
+++ b/packages/functype-react/test/query/ioQueryFn.spec.ts
@@ -46,6 +46,29 @@ describe("ioQueryFn", () => {
     expect((error as IOQueryError<StatusError>).message).toBe("tier cap hit (403)")
   })
 
+  // A factory throw happens before any IO exists, so the interpreter's own defect
+  // handling never sees it. Unboxed, it would reject with a raw value while the
+  // declared error type says IOQueryError — leaving `.error` undefined.
+  it("boxes a synchronous throw from the effect factory as a defect", async () => {
+    const queryFn = ioQueryFn<StatusError, number>(() => {
+      throw new Error("factory blew up")
+    })
+
+    const error = await queryFn(context()).catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(IOQueryError)
+    expect((error as IOQueryError<unknown>).defect).toBe(true)
+    expect((error as IOQueryError<unknown>).error).toBeInstanceOf(Error)
+    expect((error as IOQueryError<unknown>).message).toBe("factory blew up")
+  })
+
+  it("marks a typed Left as a non-defect", async () => {
+    const queryFn = ioQueryFn<StatusError, number>(() => IO.fail(forbidden))
+    const error = await queryFn(context()).catch((e: unknown) => e)
+
+    expect((error as IOQueryError<StatusError>).defect).toBe(false)
+  })
+
   it("passes the AbortSignal through to the effect factory", async () => {
     const controller = new AbortController()
     let seen: AbortSignal | undefined
@@ -72,5 +95,15 @@ describe("ioMutationFn", () => {
     const error = await mutationFn(undefined).catch((e: unknown) => e)
     expect(error).toBeInstanceOf(IOQueryError)
     expect((error as IOQueryError<StatusError>).error.status).toBe(403)
+  })
+
+  it("boxes a synchronous throw from the effect factory as a defect", async () => {
+    const mutationFn = ioMutationFn<StatusError, string, void>(() => {
+      throw new Error("factory blew up")
+    })
+
+    const error = await mutationFn(undefined).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(IOQueryError)
+    expect((error as IOQueryError<unknown>).defect).toBe(true)
   })
 })

--- a/packages/functype-react/test/query/matchQuery.spec.tsx
+++ b/packages/functype-react/test/query/matchQuery.spec.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { IO } from "functype/io"
+import { describe, expect, it } from "vitest"
+
+import { Match } from "../../src/match/Match"
+import { toQueryState } from "../../src/query/queryState"
+import { useIOQuery } from "../../src/query/useIOQuery"
+import { createWrapper } from "./harness"
+
+type StatusError = { readonly _tag: "HttpStatusError"; readonly status: number }
+
+type User = { readonly name: string }
+
+/**
+ * The package thesis, exercised end to end: every lifecycle case is handled, the
+ * Success branch receives a defined `User` (no `!`, no `| undefined`), and omitting
+ * a case would not compile.
+ */
+function UserPanel({ shouldFail }: { shouldFail: boolean }) {
+  const query = useIOQuery<User, StatusError>(["user", String(shouldFail)], () =>
+    shouldFail ? IO.fail({ _tag: "HttpStatusError", status: 403 }) : IO.succeed({ name: "ada" }),
+  )
+
+  return (
+    <Match value={toQueryState(query)}>
+      {{
+        Idle: () => <p>idle</p>,
+        Pending: () => <p>loading</p>,
+        Failure: ({ error }) => <p>failed {error.error.status}</p>,
+        Success: ({ value }) => <p>hello {value.name}</p>,
+      }}
+    </Match>
+  )
+}
+
+describe("Match over a projected query", () => {
+  it("renders the Pending branch, then Success with a defined value", async () => {
+    const Wrapper = createWrapper()
+    render(
+      <Wrapper>
+        <UserPanel shouldFail={false} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByText("loading")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText("hello ada")).toBeInTheDocument())
+  })
+
+  it("renders the Failure branch with the discriminable error", async () => {
+    const Wrapper = createWrapper()
+    render(
+      <Wrapper>
+        <UserPanel shouldFail={true} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(screen.getByText("failed 403")).toBeInTheDocument())
+  })
+})

--- a/packages/functype-react/test/query/query.test-d.ts
+++ b/packages/functype-react/test/query/query.test-d.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- type-level assertions only */
+import type { QueryFunctionContext, QueryKey } from "@tanstack/react-query"
+import type { HttpError } from "functype/fetch"
+import { describe, expectTypeOf, it } from "vitest"
+
+import type { TaskState } from "../../src/async/TaskState"
+import type { MatchCases } from "../../src/match/Match"
+import type { IOQueryError } from "../../src/query/IOQueryError"
+import type { ioMutationFn, ioQueryFn } from "../../src/query/ioQueryFn"
+import { toQueryState } from "../../src/query/queryState"
+import type { UseIOQueryStateResult } from "../../src/query/useIOQueryState"
+import type { useIOMutation } from "../../src/query/useIOMutation"
+import type { useIOQuery } from "../../src/query/useIOQuery"
+
+describe("useIOQuery types", () => {
+  it("threads E through as IOQueryError<E>, not unknown", () => {
+    type Result = ReturnType<typeof useIOQuery<{ seats: number }, HttpError>>
+
+    expectTypeOf<Result["error"]>().toEqualTypeOf<IOQueryError<HttpError> | null>()
+  })
+
+  it("keeps the functype error discriminable on .error", () => {
+    expectTypeOf<IOQueryError<HttpError>["error"]>().toEqualTypeOf<HttpError>()
+  })
+
+  it("boxes into a real Error", () => {
+    expectTypeOf<IOQueryError<HttpError>>().toMatchTypeOf<Error>()
+  })
+
+  it("applies select to the data channel", () => {
+    type Result = ReturnType<typeof useIOQuery<{ seats: number }, HttpError, number>>
+
+    expectTypeOf<Result["data"]>().toEqualTypeOf<number | undefined>()
+  })
+})
+
+describe("useIOMutation types", () => {
+  it("threads E through as IOQueryError<E>", () => {
+    type Result = ReturnType<typeof useIOMutation<{ id: number }, HttpError, { name: string }>>
+
+    expectTypeOf<Result["error"]>().toEqualTypeOf<IOQueryError<HttpError> | null>()
+  })
+})
+
+describe("TaskState projection", () => {
+  it("projects onto the same TaskState the async subpath uses", () => {
+    expectTypeOf(toQueryState<IOQueryError<HttpError>, number>).returns.toEqualTypeOf<
+      TaskState<IOQueryError<HttpError>, number>
+    >()
+  })
+
+  it("hands the Success branch a defined value — no `| undefined`, no `!`", () => {
+    type Success = Extract<TaskState<IOQueryError<HttpError>, number>, { _tag: "Success" }>
+
+    expectTypeOf<Success["value"]>().toEqualTypeOf<number>()
+  })
+
+  it("keeps the functype error reachable through the Failure branch", () => {
+    type Failure = Extract<TaskState<IOQueryError<HttpError>, number>, { _tag: "Failure" }>
+
+    expectTypeOf<Failure["error"]["error"]>().toEqualTypeOf<HttpError>()
+  })
+
+  it("makes an omitted case a compile error", () => {
+    type Cases = MatchCases<TaskState<IOQueryError<HttpError>, number>>
+
+    // @ts-expect-error -- `Success` is missing; exhaustiveness must reject this.
+    const incomplete: Cases = { Idle: () => null, Pending: () => null, Failure: () => null }
+    void incomplete
+  })
+})
+
+describe("useIOQueryState types", () => {
+  it("stays exhaustively matchable despite the flags/refetch intersection", () => {
+    type Cases = MatchCases<UseIOQueryStateResult<HttpError, number>>
+
+    // @ts-expect-error -- `Success` is missing; the intersection must not weaken this.
+    const incomplete: Cases = { Idle: () => null, Pending: () => null, Failure: () => null }
+    void incomplete
+  })
+
+  it("narrows to a defined value on the Success branch", () => {
+    type Success = Extract<UseIOQueryStateResult<HttpError, number>, { _tag: "Success" }>
+
+    expectTypeOf<Success["value"]>().toEqualTypeOf<number>()
+    expectTypeOf<Success["isSuccess"]>().toEqualTypeOf<boolean>()
+  })
+
+  it("keeps the typed error reachable on the Failure branch", () => {
+    type Failure = Extract<UseIOQueryStateResult<HttpError, number>, { _tag: "Failure" }>
+
+    expectTypeOf<Failure["error"]["error"]>().toEqualTypeOf<HttpError>()
+  })
+})
+
+describe("primitive types", () => {
+  it("ioQueryFn returns a Promise of the success channel", () => {
+    expectTypeOf<ReturnType<ReturnType<typeof ioQueryFn<HttpError, number>>>>().toEqualTypeOf<Promise<number>>()
+  })
+
+  // Regression guard for the README's claim that the primitives cover infinite
+  // queries: a context carrying `pageParam` must survive into the effect factory,
+  // not be flattened to the `{ signal }` floor.
+  it("ioQueryFn threads a richer context through, including pageParam", () => {
+    type InfiniteContext = QueryFunctionContext<QueryKey, number>
+    type Fn = ReturnType<typeof ioQueryFn<HttpError, number, InfiniteContext>>
+
+    expectTypeOf<Fn>().parameter(0).toEqualTypeOf<InfiniteContext>()
+    expectTypeOf<Parameters<Fn>[0]["pageParam"]>().toEqualTypeOf<number>()
+  })
+
+  it("ioMutationFn takes the variables and returns a Promise of the success channel", () => {
+    type Fn = ReturnType<typeof ioMutationFn<HttpError, number, { name: string }>>
+
+    expectTypeOf<Fn>().parameter(0).toEqualTypeOf<{ name: string }>()
+    expectTypeOf<ReturnType<Fn>>().toEqualTypeOf<Promise<number>>()
+  })
+})

--- a/packages/functype-react/test/query/query.test-d.ts
+++ b/packages/functype-react/test/query/query.test-d.ts
@@ -72,7 +72,7 @@ describe("TaskState projection", () => {
 
 describe("useIOQueryState types", () => {
   it("stays exhaustively matchable despite the flags/refetch intersection", () => {
-    type Cases = MatchCases<UseIOQueryStateResult<HttpError, number>>
+    type Cases = MatchCases<UseIOQueryStateResult<number, HttpError>>
 
     // @ts-expect-error -- `Success` is missing; the intersection must not weaken this.
     const incomplete: Cases = { Idle: () => null, Pending: () => null, Failure: () => null }
@@ -80,14 +80,14 @@ describe("useIOQueryState types", () => {
   })
 
   it("narrows to a defined value on the Success branch", () => {
-    type Success = Extract<UseIOQueryStateResult<HttpError, number>, { _tag: "Success" }>
+    type Success = Extract<UseIOQueryStateResult<number, HttpError>, { _tag: "Success" }>
 
     expectTypeOf<Success["value"]>().toEqualTypeOf<number>()
     expectTypeOf<Success["isSuccess"]>().toEqualTypeOf<boolean>()
   })
 
   it("keeps the typed error reachable on the Failure branch", () => {
-    type Failure = Extract<UseIOQueryStateResult<HttpError, number>, { _tag: "Failure" }>
+    type Failure = Extract<UseIOQueryStateResult<number, HttpError>, { _tag: "Failure" }>
 
     expectTypeOf<Failure["error"]["error"]>().toEqualTypeOf<HttpError>()
   })

--- a/packages/functype-react/test/query/queryState.spec.tsx
+++ b/packages/functype-react/test/query/queryState.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { IO } from "functype/io"
 import { describe, expect, it } from "vitest"
 
@@ -82,6 +82,31 @@ describe("projection over live hook results", () => {
     if (state._tag === "Failure") {
       expect(state.error.error).toBe(forbidden)
     }
+  })
+
+  // Pins the documented squash: React Query holds the last successful data while
+  // reporting status "error" after a failed background refetch, and TaskState has no
+  // variant for "loaded but stale", so it projects to Failure. Change this test
+  // deliberately if that default is ever revisited.
+  it("projects a failed refetch to Failure even though data is still held", async () => {
+    let attempt = 0
+    const { result } = renderHook(
+      () =>
+        useIOQuery<{ seats: number }, StatusError>(["state", "refetch-fail"], () => {
+          attempt += 1
+          return attempt === 1 ? IO.succeed({ seats: 5 }) : IO.fail(forbidden)
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(toQueryState(result.current)).toEqual({ _tag: "Success", value: { seats: 5 } })
+
+    await act(() => result.current.refetch().then(() => undefined))
+    await waitFor(() => expect(result.current.status).toBe("error"))
+
+    expect(result.current.data).toEqual({ seats: 5 })
+    expect(toQueryState(result.current)._tag).toBe("Failure")
   })
 
   it("projects a real useIOMutation result, starting at Idle", async () => {

--- a/packages/functype-react/test/query/queryState.spec.tsx
+++ b/packages/functype-react/test/query/queryState.spec.tsx
@@ -1,0 +1,98 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { IO } from "functype/io"
+import { describe, expect, it } from "vitest"
+
+import { toMutationState, toQueryState } from "../../src/query/queryState"
+import { useIOMutation } from "../../src/query/useIOMutation"
+import { useIOQuery } from "../../src/query/useIOQuery"
+import { createWrapper } from "./harness"
+
+type StatusError = { readonly _tag: "HttpStatusError"; readonly status: number }
+
+const forbidden: StatusError = { _tag: "HttpStatusError", status: 403 }
+
+describe("toQueryState", () => {
+  it("maps a disabled, never-fetched query to Idle", () => {
+    expect(toQueryState({ status: "pending", fetchStatus: "idle" })).toEqual({ _tag: "Idle" })
+  })
+
+  it("maps an in-flight or paused query to Pending", () => {
+    expect(toQueryState({ status: "pending", fetchStatus: "fetching" })).toEqual({ _tag: "Pending" })
+    expect(toQueryState({ status: "pending", fetchStatus: "paused" })).toEqual({ _tag: "Pending" })
+  })
+
+  it("maps success to Success carrying a defined value", () => {
+    expect(toQueryState({ status: "success", data: { seats: 5 } })).toEqual({
+      _tag: "Success",
+      value: { seats: 5 },
+    })
+  })
+
+  it("maps error to Failure carrying the typed error", () => {
+    expect(toQueryState<StatusError, never>({ status: "error", error: forbidden })).toEqual({
+      _tag: "Failure",
+      error: forbidden,
+    })
+  })
+})
+
+describe("toMutationState", () => {
+  it("maps React Query's four mutation statuses onto TaskState", () => {
+    expect(toMutationState({ status: "idle" })).toEqual({ _tag: "Idle" })
+    expect(toMutationState({ status: "pending" })).toEqual({ _tag: "Pending" })
+    expect(toMutationState({ status: "success", data: 7 })).toEqual({ _tag: "Success", value: 7 })
+    expect(toMutationState<StatusError, never>({ status: "error", error: forbidden })).toEqual({
+      _tag: "Failure",
+      error: forbidden,
+    })
+  })
+})
+
+// The projection is only useful if a *real* hook result satisfies QueryResultView.
+// These guard the structural assignability that makes that true.
+describe("projection over live hook results", () => {
+  it("projects a real useIOQuery result through its lifecycle", async () => {
+    const { result } = renderHook(() => useIOQuery(["state", "ok"], () => IO.succeed({ seats: 5 })), {
+      wrapper: createWrapper(),
+    })
+
+    expect(toQueryState(result.current)._tag).toBe("Pending")
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(toQueryState(result.current)).toEqual({ _tag: "Success", value: { seats: 5 } })
+  })
+
+  it("projects a disabled useIOQuery result to Idle", () => {
+    const { result } = renderHook(() => useIOQuery(["state", "off"], () => IO.succeed(1), { enabled: false }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(toQueryState(result.current)).toEqual({ _tag: "Idle" })
+  })
+
+  it("projects a failing useIOQuery result to Failure with the boxed error", async () => {
+    const { result } = renderHook(() => useIOQuery<number, StatusError>(["state", "fail"], () => IO.fail(forbidden)), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    const state = toQueryState(result.current)
+    expect(state._tag).toBe("Failure")
+    if (state._tag === "Failure") {
+      expect(state.error.error).toBe(forbidden)
+    }
+  })
+
+  it("projects a real useIOMutation result, starting at Idle", async () => {
+    const { result } = renderHook(() => useIOMutation((n: number) => IO.succeed(n * 2)), {
+      wrapper: createWrapper(),
+    })
+
+    expect(toMutationState(result.current)).toEqual({ _tag: "Idle" })
+
+    await result.current.mutateAsync(21)
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(toMutationState(result.current)).toEqual({ _tag: "Success", value: 42 })
+  })
+})

--- a/packages/functype-react/test/query/useIOMutation.spec.tsx
+++ b/packages/functype-react/test/query/useIOMutation.spec.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { IO } from "functype/io"
+import { describe, expect, it } from "vitest"
+
+import { IOQueryError } from "../../src/query/IOQueryError"
+import { useIOMutation } from "../../src/query/useIOMutation"
+import { createWrapper } from "./harness"
+
+type StatusError = {
+  readonly _tag: "HttpStatusError"
+  readonly url: string
+  readonly status: number
+  readonly statusText: string
+}
+
+const forbidden: StatusError = {
+  _tag: "HttpStatusError",
+  url: "/api/tokens",
+  status: 403,
+  statusText: "Forbidden",
+}
+
+describe("useIOMutation", () => {
+  it("mutateAsync resolves with the effect's value", async () => {
+    const { result } = renderHook(
+      () => useIOMutation((vars: { name: string }) => IO.succeed({ id: 1, name: vars.name })),
+      { wrapper: createWrapper() },
+    )
+
+    const created = await act(() => result.current.mutateAsync({ name: "ci" }))
+    expect(created).toEqual({ id: 1, name: "ci" })
+  })
+
+  it("mutateAsync rejects with a boxed IOQueryError", async () => {
+    const { result } = renderHook(() => useIOMutation<number, StatusError>(() => IO.fail(forbidden)), {
+      wrapper: createWrapper(),
+    })
+
+    const error = await act(() => result.current.mutateAsync().catch((e: unknown) => e))
+
+    expect(error).toBeInstanceOf(IOQueryError)
+    expect((error as IOQueryError<StatusError>).error.status).toBe(403)
+  })
+
+  it("onError receives the boxed error with a discriminable .error", async () => {
+    let captured: IOQueryError<StatusError> | undefined
+
+    const { result } = renderHook(
+      () =>
+        useIOMutation<number, StatusError>(() => IO.fail(forbidden), {
+          onError: (e) => {
+            captured = e
+          },
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    act(() => result.current.mutate())
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(captured).toBeInstanceOf(Error)
+    expect(captured?.error._tag).toBe("HttpStatusError")
+    expect(captured?.message).toBe("HTTP 403 Forbidden — /api/tokens")
+  })
+})

--- a/packages/functype-react/test/query/useIOQuery.spec.tsx
+++ b/packages/functype-react/test/query/useIOQuery.spec.tsx
@@ -1,4 +1,5 @@
-import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { Http, type HttpError, HttpErrors } from "functype/fetch"
 import { IO } from "functype/io"
 import { describe, expect, it, vi } from "vitest"
@@ -95,6 +96,64 @@ describe("useIOQuery", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(seen).toBeInstanceOf(AbortSignal)
+  })
+
+  // Rejection is what React Query's retry machinery keys off, so boxing the Left has
+  // to leave retry intact — an effect that failed once must be re-run, not latched.
+  it("retries a failing effect and surfaces the boxed error after the last attempt", async () => {
+    let attempts = 0
+
+    const { result } = renderHook(
+      () =>
+        useIOQuery<number, StatusError>(["limits", "retry"], () => {
+          attempts += 1
+          return IO.fail(forbidden)
+        }),
+      { wrapper: createWrapper({ retry: 2, retryDelay: 0 }) },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(attempts).toBe(3) // initial attempt + 2 retries
+    expect(result.current.error).toBeInstanceOf(IOQueryError)
+    expect(result.current.error?.error).toBe(forbidden)
+    expect(result.current.error?.defect).toBe(false)
+  })
+
+  // The signal is only useful if aborting it actually reaches the effect. Cancellation
+  // must also stay out of the error channel: a cancelled query reverts to its previous
+  // state rather than rendering a failure the user never caused.
+  it("aborts the in-flight effect when the query is cancelled, without surfacing an error", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    let aborted = false
+
+    const { result } = renderHook(
+      () =>
+        useIOQuery<string, unknown>(["limits", "cancel"], ({ signal }) =>
+          IO.async(
+            () =>
+              new Promise<string>((resolve, reject) => {
+                const timer = setTimeout(() => resolve("late"), 300)
+                signal.addEventListener("abort", () => {
+                  aborted = true
+                  clearTimeout(timer)
+                  reject(new Error("aborted"))
+                })
+              }),
+          ),
+        ),
+      { wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider> },
+    )
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("fetching"))
+    await act(async () => {
+      await client.cancelQueries({ queryKey: ["limits", "cancel"] })
+    })
+
+    expect(aborted).toBe(true)
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"))
+    expect(result.current.status).toBe("pending")
+    expect(result.current.error).toBeNull()
   })
 
   // The scenario from issue #239: an Http 403 must arrive as something a generic

--- a/packages/functype-react/test/query/useIOQuery.spec.tsx
+++ b/packages/functype-react/test/query/useIOQuery.spec.tsx
@@ -1,0 +1,130 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { Http, type HttpError, HttpErrors } from "functype/fetch"
+import { IO } from "functype/io"
+import { describe, expect, it, vi } from "vitest"
+
+import { IOQueryError } from "../../src/query/IOQueryError"
+import { useIOQuery } from "../../src/query/useIOQuery"
+import { createWrapper } from "./harness"
+
+type StatusError = {
+  readonly _tag: "HttpStatusError"
+  readonly url: string
+  readonly status: number
+  readonly statusText: string
+}
+
+const forbidden: StatusError = {
+  _tag: "HttpStatusError",
+  url: "/api/limits",
+  status: 403,
+  statusText: "Forbidden",
+}
+
+describe("useIOQuery", () => {
+  it("populates data from a succeeding effect", async () => {
+    const { result } = renderHook(() => useIOQuery(["limits"], () => IO.succeed({ seats: 5 })), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({ seats: 5 })
+    expect(result.current.error).toBeNull()
+  })
+
+  it("populates error as a boxed, discriminable IOQueryError", async () => {
+    const { result } = renderHook(
+      () => useIOQuery<{ seats: number }, StatusError>(["limits"], () => IO.fail(forbidden)),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    const error = result.current.error
+    expect(error).toBeInstanceOf(IOQueryError)
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.error._tag).toBe("HttpStatusError")
+    expect(error?.error.status).toBe(403)
+  })
+
+  it("honours a formatError override", async () => {
+    const { result } = renderHook(
+      () =>
+        useIOQuery<number, StatusError>(["limits"], () => IO.fail(forbidden), {
+          formatError: (e) => `tier cap (${e.status})`,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe("tier cap (403)")
+  })
+
+  it("passes through enabled: false and never runs the effect", async () => {
+    const effect = vi.fn(() => IO.succeed(1))
+
+    const { result } = renderHook(() => useIOQuery(["limits", "off"], effect, { enabled: false }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(effect).not.toHaveBeenCalled()
+  })
+
+  it("passes through select", async () => {
+    const { result } = renderHook(
+      () => useIOQuery(["limits", "select"], () => IO.succeed({ seats: 5 }), { select: (d) => d.seats }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBe(5)
+  })
+
+  it("hands the query's AbortSignal to the effect factory", async () => {
+    let seen: AbortSignal | undefined
+
+    const { result } = renderHook(
+      () =>
+        useIOQuery(["limits", "signal"], ({ signal }) => {
+          seen = signal
+          return IO.succeed("ok")
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(seen).toBeInstanceOf(AbortSignal)
+  })
+
+  // The scenario from issue #239: an Http 403 must arrive as something a generic
+  // `error instanceof Error ? error.message : fallback` handler can read, while the
+  // 403 branch stays discriminable.
+  it("end-to-end: a 403 from Http is both a real Error and a tagged HttpStatusError", async () => {
+    const api = Http.client({
+      baseUrl: "https://api.example.com",
+      fetch: () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ message: "tier cap" }), { status: 403, statusText: "Forbidden" }),
+        ),
+    })
+
+    const { result } = renderHook(
+      () => useIOQuery<unknown, HttpError>(["limits", "403"], ({ signal }) => api.get("/limits", { signal })),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    const error = result.current.error
+    expect(error instanceof Error).toBe(true)
+    expect(error?.message.length).toBeGreaterThan(0)
+
+    const branch = HttpErrors.match(error!.error, {
+      NetworkError: () => "network",
+      HttpStatusError: (e) => (e.status === 403 ? "tier-cap" : `status-${e.status}`),
+      DecodeError: () => "decode",
+    })
+    expect(branch).toBe("tier-cap")
+  })
+})

--- a/packages/functype-react/test/query/useIOQueryState.spec.tsx
+++ b/packages/functype-react/test/query/useIOQueryState.spec.tsx
@@ -1,0 +1,130 @@
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react"
+import { IO } from "functype/io"
+import { describe, expect, it } from "vitest"
+
+import { Match } from "../../src/match/Match"
+import { useIOMutationState } from "../../src/query/useIOMutationState"
+import { useIOQueryState } from "../../src/query/useIOQueryState"
+import { createWrapper } from "./harness"
+
+type StatusError = { readonly _tag: "HttpStatusError"; readonly status: number }
+
+const forbidden: StatusError = { _tag: "HttpStatusError", status: 403 }
+
+describe("useIOQueryState", () => {
+  it("returns the ADT directly, transitioning Pending → Success", async () => {
+    const { result } = renderHook(() => useIOQueryState(["qs", "ok"], () => IO.succeed({ seats: 5 })), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current._tag).toBe("Pending")
+    expect(result.current.isPending).toBe(true)
+
+    await waitFor(() => expect(result.current._tag).toBe("Success"))
+    expect(result.current.isSuccess).toBe(true)
+    if (result.current._tag === "Success") {
+      expect(result.current.value).toEqual({ seats: 5 })
+    }
+  })
+
+  it("returns Idle for a disabled query", () => {
+    const { result } = renderHook(() => useIOQueryState(["qs", "off"], () => IO.succeed(1), { enabled: false }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current._tag).toBe("Idle")
+    expect(result.current.isIdle).toBe(true)
+  })
+
+  it("returns Failure carrying the boxed, discriminable error", async () => {
+    const { result } = renderHook(
+      () => useIOQueryState<number, StatusError>(["qs", "fail"], () => IO.fail(forbidden)),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current._tag).toBe("Failure"))
+    expect(result.current.isFailure).toBe(true)
+    if (result.current._tag === "Failure") {
+      expect(result.current.error).toBeInstanceOf(Error)
+      expect(result.current.error.error).toBe(forbidden)
+    }
+  })
+
+  it("exposes a working refetch", async () => {
+    let runs = 0
+    const { result } = renderHook(
+      () =>
+        useIOQueryState(["qs", "refetch"], () => {
+          runs += 1
+          return IO.succeed(runs)
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current._tag).toBe("Success"))
+    expect(runs).toBe(1)
+
+    await act(() => result.current.refetch().then(() => undefined))
+    await waitFor(() => expect(runs).toBe(2))
+  })
+
+  it("is matchable with no projection call", async () => {
+    function Panel() {
+      const user = useIOQueryState(["qs", "match"], () => IO.succeed({ name: "ada" }))
+
+      return (
+        <Match value={user}>
+          {{
+            Idle: () => <p>idle</p>,
+            Pending: () => <p>loading</p>,
+            Failure: ({ error }) => <p>failed {error.message}</p>,
+            Success: ({ value }) => <p>hello {value.name}</p>,
+          }}
+        </Match>
+      )
+    }
+
+    const Wrapper = createWrapper()
+    render(
+      <Wrapper>
+        <Panel />
+      </Wrapper>,
+    )
+
+    expect(screen.getByText("loading")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText("hello ada")).toBeInTheDocument())
+  })
+})
+
+describe("useIOMutationState", () => {
+  it("starts Idle and reaches Success, keeping the trigger usable", async () => {
+    const { result } = renderHook(() => useIOMutationState((n: number) => IO.succeed(n * 2)), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current._tag).toBe("Idle")
+    expect(result.current.isIdle).toBe(true)
+
+    await act(() => result.current.mutateAsync(21).then(() => undefined))
+
+    await waitFor(() => expect(result.current._tag).toBe("Success"))
+    if (result.current._tag === "Success") {
+      expect(result.current.value).toBe(42)
+    }
+  })
+
+  it("reaches Failure with the boxed error, and reset returns to Idle", async () => {
+    const { result } = renderHook(() => useIOMutationState<number, StatusError>(() => IO.fail(forbidden)), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => result.current.mutate())
+    await waitFor(() => expect(result.current._tag).toBe("Failure"))
+    if (result.current._tag === "Failure") {
+      expect(result.current.error.error).toBe(forbidden)
+    }
+
+    act(() => result.current.reset())
+    await waitFor(() => expect(result.current._tag).toBe("Idle"))
+  })
+})

--- a/packages/functype/CHANGELOG.md
+++ b/packages/functype/CHANGELOG.md
@@ -6,6 +6,18 @@ Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions: writ
 
 ## Unreleased
 
+**`functype-react` — new `functype-react/query` subpath: TanStack Query adapters for `IO` (closes #239).**
+
+`Http.get(...)` returns `IO<never, HttpError, HttpResponse<T>>`, and neither `IO` terminal fits React Query's contract. `.run()` returns `Promise<Either<E, A>>` and never throws, so React Query never observes a failure — every call site hand-writes the `Either` → throw bridge. `.runOrThrow()` throws the _raw_ tagged object (`{ _tag: "NetworkError", url, method, cause }`), which is not an `Error` instance, so the ubiquitous `error instanceof Error ? error.message : fallback` handler silently degrades to the fallback and status-based branching has no clean equivalent. Migrating a real app off axios onto `functype/fetch` required a bespoke per-app `apiRequest()` shim to close exactly this gap.
+
+The new subpath owns that glue. `useIOQuery` / `useIOMutation` cover the common path; `ioQueryFn` / `ioMutationFn` are framework-agnostic primitives for `useQuery`, `useSuspenseQuery`, `useInfiniteQuery`, and `queryClient.prefetchQuery`. Failures are boxed as `IOQueryError<E> extends Error` — `instanceof Error` and `.message` behave as any React Query consumer expects, while `.error` preserves the fully discriminable functype error (`HttpErrors.match(error.error, { ... })`). `Error.message` is derived structurally by `formatIOError`, so the bridge stays generic over any `IO<never, E, A>` rather than being HTTP-specific; pass `formatError` to override. React Query's `AbortSignal` is handed to the effect factory for cancellation, and the full `useQuery` / `useMutation` options surface passes through untouched.
+
+`useIOQueryState` / `useIOMutationState` return that ADT directly — `TaskState` plus the `isIdle`/`isPending`/`isSuccess`/`isFailure` flags and the trigger (`refetch`, or `mutate`/`mutateAsync`/`reset`), mirroring the shape `useTask` already returns from `functype-react/async`. They read only the fields they project, so React Query's tracked-properties render optimization still applies.
+
+`toQueryState` / `toMutationState` project a React Query result onto the `TaskState` ADT that `functype-react/async` already returns, so a query composes with the `<Match>` family instead of being read through the `data && !error && !isLoading` flag soup this package exists to eliminate. The `Success` branch yields a defined `A` rather than `A | undefined`, and omitting a lifecycle case is a compile error. A disabled query projects to `Idle`, in-flight or paused to `Pending`; React Query's own mutation `idle` status maps directly. Both are pure functions over the result, so `refetch` / `isFetching` / `invalidate` remain available on the original object.
+
+`@tanstack/react-query` (`>=5.0.0`) is an **optional** peer dependency, matching the existing `react-dom` treatment — consumers who don't import `functype-react/query` neither install nor bundle it. Strictly additive; no changes to any existing export.
+
 ## 1.6.3 - 2026-07-13
 
 **`eslint-plugin-functype` — `prefer-fold` no longer false-positives on nullable ternaries that yield `undefined`/`null`.**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
 
   packages/functype-react:
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.5
+        version: 5.101.4(react@19.2.8)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -1765,6 +1768,14 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
+  '@tanstack/react-query@5.101.4':
+    resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -2971,9 +2982,6 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
   flatted@3.4.3:
     resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
 
@@ -4095,10 +4103,6 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
-
-  remark-smartypants@3.0.2:
-    resolution: {integrity: sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==}
-    engines: {node: '>=16.0.0'}
 
   remark-smartypants@3.0.3:
     resolution: {integrity: sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==}
@@ -5251,7 +5255,7 @@ snapshots:
       remark-gfm: 4.0.1(supports-color@7.2.0)
       remark-parse: 11.0.0(supports-color@7.2.0)
       remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
+      remark-smartypants: 3.0.3
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -6381,6 +6385,13 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
+  '@tanstack/query-core@5.101.4': {}
+
+  '@tanstack/react-query@5.101.4(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      react: 19.2.8
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -6773,7 +6784,7 @@ snapshots:
     dependencies:
       '@vitest/utils': 4.1.10
       fflate: 0.8.3
-      flatted: 3.4.2
+      flatted: 3.4.3
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.17
@@ -7864,8 +7875,6 @@ snapshots:
     dependencies:
       flatted: 3.4.3
       keyv: 4.5.4
-
-  flatted@3.4.2: {}
 
   flatted@3.4.3: {}
 
@@ -9320,13 +9329,6 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
-
-  remark-smartypants@3.0.2:
-    dependencies:
-      retext: 9.0.0
-      retext-smartypants: 6.2.0
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
 
   remark-smartypants@3.0.3:
     dependencies:


### PR DESCRIPTION
Closes #239.

## Problem

`Http.get(...)` returns `IO<never, HttpError, HttpResponse<T>>`, and neither `IO` terminal fits TanStack Query:

- **`.run()`** → `Promise<Either<E, A>>` never throws, so React Query never observes a failure. Every call site hand-writes the `Either` → throw bridge.
- **`.runOrThrow()`** → throws the *raw* tagged object (`{ _tag: "NetworkError", url, method, cause }`). That is not an `Error` instance, so `error instanceof Error ? error.message : fallback` silently degrades to the fallback, and status branching has no clean equivalent.

Migrating `agent-todo-ui` off axios required a bespoke per-app `apiRequest()` shim to close exactly this gap. This PR makes the library own it.

## Surface — `functype-react/query`

| Export | Purpose |
|---|---|
| `ioQueryFn` / `ioMutationFn` | Framework-agnostic primitives for `useQuery`, `useSuspenseQuery`, `useInfiniteQuery`, `prefetchQuery` |
| `useIOQuery` / `useIOMutation` | Common path; full TanStack options surface passes through |
| `useIOQueryState` / `useIOMutationState` | Return the `TaskState` ADT directly |
| `toQueryState` / `toMutationState` | Pure projections onto `TaskState` |
| `IOQueryError` / `isIOQueryError` / `formatIOError` | The boxed error and its helpers |

## Design decisions worth reviewing

**Errors are boxed, not raw.** `IOQueryError<E> extends Error` carries the typed error on `.error`. `instanceof Error` and `.message` behave as any React Query consumer expects, while `.error` stays discriminable via `HttpErrors.match`. This is the standard FP edge pattern — Effect-TS resolves the same tension identically, rejecting with `FiberFailure` wrapping the typed `Cause`. A raw-`E` variant would reproduce the exact footgun that motivated the issue.

**The ADT projection is the idiomatic path.** Returning React Query's result alone would be the `data && !error && !isLoading` flag soup this package exists to eliminate, and inconsistent with its own `useTask`. `toQueryState` reuses the existing `TaskState` rather than introducing a parallel ADT, so Tier 3 and Tier 5 read alike and both compose with `<Match>`. The `Success` branch yields a defined `A` — no `!`.

**State hooks preserve React Query's render optimization.** They read only `status` / `fetchStatus` / `data` / `error` / the trigger, so tracked-properties still applies. Spreading the whole result would subscribe the component to every field — which is why `useIOQuery` + `toQueryState` remains the path when you need `isFetching` / `dataUpdatedAt`.

**Structural typing throughout.** The query context and result views are typed structurally, so the primitives and projections carry no `@tanstack` type dependency and are insulated from its major-version churn. `ioQueryFn` is generic over the context, so `pageParam` reaches the effect factory for infinite queries.

**Optional peer.** `@tanstack/react-query` (`>=5.0.0`) is optional, matching the existing `react-dom` treatment. Verified: `@tanstack` appears in `dist/` only under `query/`, so consumers who don't import the subpath neither install nor bundle it.

## One suppression to review

`src/query/ioQueryFn.ts` carries a file-level `eslint-disable functype/prefer-either`. The `throw` is the module's entire purpose — React Query signals failure only by rejection, which is precisely why `.run()` is unusable as a `queryFn`. Documented inline rather than restructured to dodge the rule. The package gates at `--max-warnings 0`, so this is deliberate.

## Verification

- 46 new tests in `test/query/`, all passing; 12/12 workspace `turbo run validate` tasks green.
- End-to-end test of the motivating scenario: a stubbed 403 through `Http.client({ fetch })` arrives as `instanceof Error === true` with a non-empty `.message`, while `HttpErrors.match(error.error, ...)` still branches on the 403.
- Type-level specs use `@ts-expect-error` to prove omitting a match case genuinely fails to compile — including across the `TaskState & { flags }` intersection, where exhaustiveness surviving was not obvious.
- Live-result tests pass real hook returns into the projections, guarding the structural assignability that would break if TanStack changes its result shape.

## Notes

- CHANGELOG entry added under `## Unreleased` in `packages/functype/CHANGELOG.md` (the release-flow-managed family changelog), not the legacy changesets file.
- The lockfile carries two incidental transitive patch bumps (`flatted`, `remark-smartypants`) from re-resolution during install — confirmed acceptable.

**Deferred:** wiring the `AbortSignal` to IO-level *interruption*. Today the signal reaches `fetch`, so HTTP genuinely aborts, but a non-HTTP effect keeps running after cancellation. Closing that needs an `.interruptOn(signal)` combinator that IO doesn't expose — a core change, better as its own issue than a shim here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)