### PR TITLE
docs: correct stale release-flow references (CLAUDE.md + functype-eval CHANGELOG)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,20 +35,20 @@ pnpm turbo run validate            # format + lint + typecheck + test + build ac
 pnpm turbo run build               # parallel build of every package (respects deps)
 pnpm -F functype test              # run one package's test suite
 pnpm -F functype-react dev         # dev mode for one package
-pnpm changeset                     # author a new changeset for the next release
-pnpm changeset status              # see what's queued
+pnpm release patch|minor|major     # bump all 8 packages, cut CHANGELOG, commit + tag
+git push --follow-tags             # push the tag to trigger the CI publish
 ```
 
 ## Working across packages
 
 - Workspace deps use `workspace:^`. When you change `packages/functype` and a dependent like `packages/functype-react` would consume that change, you don't need to publish — pnpm symlinks the in-tree version.
 - Adding a new sibling: create `packages/<name>/`, mirror the conventions in `packages/functype-os/` or `packages/functype-react/`, and add to `pnpm-workspace.yaml` (covered by `packages/*` glob automatically).
-- Cross-package PRs are encouraged: changesets handle the version bump for every affected package in one shot.
+- Cross-package PRs are encouraged: the release script bumps every affected package in one shot, so a change spanning packages ships as a single version.
 
 ## Workflows
 
 - **`.github/workflows/ci.yml`** — runs on PR + push to main. `pnpm turbo run validate`. Includes a path-filtered bundle-size job for `packages/functype/**`.
-- **`.github/workflows/publish.yml`** — runs on push to main. Uses `changesets/action@v1` to either open a "Version Packages" PR (when changesets are queued) or run `pnpm -r publish` when that PR merges. Provenance + OIDC for `functype`, `functype-os`, `functype-log`, `functype-react`, `functype-eval`; token auth for `functype-mcp-server`.
+- **`.github/workflows/publish.yml`** — runs on push of a `v*` tag (not on push to main). Re-runs `turbo run validate`, then `check-publish-safety` as the final gate, then `pnpm -r publish`, which publishes any package whose local version differs from npm `latest`. Publishes with provenance; auth is npm OIDC trusted publishing where configured, with `NPM_TOKEN` as the fallback. See the header comment in `publish.yml` for the current per-package split — that file is the source of truth, not this line.
 - **`.github/workflows/deploy-docs.yml`** — builds the Astro site + TypeDoc on push to main, publishes to GitHub Pages.
 - **`.github/workflows/auto-merge-dependabot.yml`** — auto-merges patch/minor Dependabot PRs.
 
@@ -59,4 +59,4 @@ pnpm changeset status              # see what's queued
 - **functype patterns when modeling state.** Option for nullables, Either/Try for errors, IO/Task for effects, Validated for accumulating errors. (`packages/functype/CLAUDE.md` covers the full library.)
 - **Functional style.** Immutable data; constructor functions over classes; method chaining or pipe.
 - **Tests are tightly colocated** — `test/` mirrors `src/` per package. Use `vitest`.
-- **CHANGELOG via changesets only.** Don't hand-edit CHANGELOG files.
+- **CHANGELOG: add to `## Unreleased`.** User-facing changes go under the `## Unreleased` heading in `packages/functype/CHANGELOG.md` — the family changelog for all 8 packages. `pnpm release` cuts that section into `## {version} - {date}`. It touches **only** that file — the other per-package CHANGELOGs are not maintained by the release flow (most sit frozen at the changesets-era `1.0.1` / `2.100.1`), so don't add entries there and don't hand-edit already-released sections.

--- a/packages/functype-eval/CHANGELOG.md
+++ b/packages/functype-eval/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-`functype-eval` is part of the 5-package functype family and bumps in lockstep with `functype`. The
-canonical changelog for the family is [`packages/functype/CHANGELOG.md`](../functype/CHANGELOG.md).
-Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions; `pnpm release` cuts the
-`## Unreleased` section into a dated version header.
+`functype-eval` is part of the 6-package functype family and bumps in lockstep with `functype`.
 
-## Unreleased
+**Write new entries in [`packages/functype/CHANGELOG.md`](../functype/CHANGELOG.md), not here.** That
+is the canonical changelog for the family, and the only one `pnpm release` cuts — `scripts/release.ts`
+rewrites that file alone, so an `## Unreleased` section in *this* file would never be dated or
+released. This file is kept as a historical record of the package's own initial release.
+
+## 1.6.0 - 2026-07-01
 
 ### Added
 

--- a/packages/functype-eval/CLAUDE.md
+++ b/packages/functype-eval/CLAUDE.md
@@ -90,7 +90,9 @@ test/scorers/             # mirrors src/scorers
 - **Don't couple scoring to an LLM.** The scorer is pure static analysis; Phase 2 `bench` calls LLMs
   but scoring stays deterministic.
 - **No `any`.** Use `unknown` and narrow. functype patterns for state (Option/Either/List).
-- **Don't hand-edit CHANGELOG.** The tag-driven release flow (`pnpm release`) manages versions.
+- **Don't hand-edit this package's CHANGELOG.** Write entries under `## Unreleased` in
+  [`packages/functype/CHANGELOG.md`](../functype/CHANGELOG.md) — the family changelog, and the only
+  one `pnpm release` cuts.
 
 ## Conventions
 
@@ -99,6 +101,6 @@ test/scorers/             # mirrors src/scorers
 - **Runtime deps** (`eslint-plugin-functype`, `@typescript-eslint/parser`, `ts-morph`,
   `type-coverage-core`) — this package evaluates code that _uses_ functype, so functype itself is a
   **devDep only**, not a peer.
-- **Versioning:** part of the 5-package functype family on the `1.x` line. It must be listed in
+- **Versioning:** part of the 6-package functype family on the `1.x` line. It must be listed in
   `FAMILY_PACKAGE_DIRS` in [`scripts/release.ts`](../../scripts/release.ts). Release with
   `pnpm release patch|minor|major` from the repo root (tag-driven).


### PR DESCRIPTION
The repo moved from `@changesets/cli` to the tag-driven release flow, but several docs still described the old one. Surfaced while reviewing #240, where the stale convention line would have flagged a *correct* `## Unreleased` CHANGELOG entry as a mistake.

## Verified before rewriting

- `.changeset/` does not exist
- root `package.json` has no `changeset` script — `pnpm changeset` was a dead command
- `publish.yml` triggers on `v*` tags, not push-to-main
- `scripts/release.ts:149` cuts `## Unreleased` from `packages/functype/CHANGELOG.md`, and **only** that file
- `FAMILY_PACKAGE_DIRS` lists **6** packages
- functype-eval 1.6.0 published 2026-07-01 (npm), matching `## 1.6.0 - 2026-07-01` in the family changelog

## 1. Monorepo `CLAUDE.md`

| Spot | Was | Now |
|---|---|---|
| Quick commands | `pnpm changeset` / `changeset status` | `pnpm release patch\|minor\|major` + `git push --follow-tags` |
| Working across packages | "changesets handle the version bump" | the release script bumps affected packages in one shot |
| Workflows → `publish.yml` | "push to main, `changesets/action@v1`" | tag-triggered `validate` → `check-publish-safety` → `pnpm -r publish` |
| Conventions | "CHANGELOG via changesets only. Don't hand-edit" | entries go under `## Unreleased` in `packages/functype/CHANGELOG.md` |

The Conventions line was the consequential one — it directly contradicted the Versioning bullet a few lines above it.

**The per-package OIDC/token split is no longer restated.** The old line claimed OIDC for `functype-eval` and omitted the eslint packages' token auth, disagreeing with `publish.yml`'s own header — that restatement had itself drifted. The workflow file is now cited as the source of truth rather than maintaining a third copy.

## 2. `packages/functype-eval/CHANGELOG.md`

Its initial-release notes sat under `## Unreleased`, but `release.ts` rewrites only the canonical family changelog — so that section could never be dated. The entry described shipped code (1.6.0–1.6.3 are all on npm) while claiming to be unreleased. Filed under `## 1.6.0 - 2026-07-01`.

Also: the header claimed `pnpm release` cuts *this* file's `## Unreleased` section. It doesn't — and that claim is what would invite the next stranded entry, so it now says where entries actually go. And "5-package family" → 6, here and in the package's `CLAUDE.md`.

Checked the other six per-package changelogs: functype-eval was the only one with a stray `## Unreleased` or a false cut claim.

## Safety

Docs-only; no code or workflow behavior changes. Verified no tooling depends on the edited files — `release.ts` is the only script that touches a CHANGELOG, and `check-publish-safety` has no changelog invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
