### PR TITLE
fix(IO): bracketExit reports interruption to release as Interrupted

### DIFF
--- a/packages/functype/CHANGELOG.md
+++ b/packages/functype/CHANGELOG.md
@@ -6,6 +6,19 @@ Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions: writ
 
 ## Unreleased
 
+**`functype` — `bracketExit` reports interruption to `release` as `Interrupted` on the sync interpreter.**
+
+`bracketExit`'s contract is that `release` receives the `Exit` describing how `use` ended, so cleanup can branch on cancellation — a distinct rollback path, or telemetry that shouldn't count cancellations as failures. The sync interpreter built that `Exit` from a caught throw and so always reported `Failure`:
+
+```ts
+IO.bracketExit(acquire, () => IO.interrupt(), release).runSync()
+// release saw Exit.fail(InterruptedError); now sees Exit.interrupted()
+```
+
+The async interpreter already passed the real `Exit` through, so this only brings the sync path into agreement — no new semantics, and `release` implementations already had to handle an interrupted `Exit`. `UnsupportedSyncOperationError` stays a `Failure`: it is a defect, not a cancellation, and `Exit` has no defect variant.
+
+No error was ever lost (the `catch` rethrows, and the interruption still propagates to the caller); only `release`'s view of _why_ was wrong. Success and genuine-failure reporting are unchanged, covered by regression tests. Noted on #242, where externally-triggered cancellation will make an interrupted `use` ordinary rather than exotic.
+
 **`functype` — interruption is no longer swallowed by recovery combinators (fixes #243).**
 
 `.recover(fallback)` treated any non-success outcome as recoverable, so an interrupted effect silently resolved with the fallback:

--- a/packages/functype/src/io/IO.ts
+++ b/packages/functype/src/io/IO.ts
@@ -1029,7 +1029,13 @@ const runEffectSync = <R extends Type, E extends Type, A extends Type>(
         exit = unsafeCoerce(Exit.succeed(useResult))
         return useResult
       } catch (e) {
-        exit = unsafeCoerce(Exit.fail(e as E))
+        // `release` is contracted to receive the Exit describing how `use` ended, so an
+        // interrupted `use` must arrive as Interrupted rather than Failure — otherwise a
+        // release that branches on cancellation (distinct rollback, telemetry) can't see
+        // it. The async interpreter already passes the real Exit through; this keeps the
+        // sync path in agreement. `UnsupportedSyncOperationError` stays a Failure: it is
+        // a defect, not a cancellation, and Exit has no defect variant.
+        exit = e instanceof InterruptedError ? unsafeCoerce(Exit.interrupted()) : unsafeCoerce(Exit.fail(e as E))
         throw e
       } finally {
         runEffectSync(_fx(effect.release(resource, exit!)), context)

--- a/packages/functype/test/io/io-bracketexit-interrupt.spec.ts
+++ b/packages/functype/test/io/io-bracketexit-interrupt.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import { IO } from "@/io"
+
+/**
+ * `bracketExit`'s contract is that `release` receives the `Exit` describing how `use`
+ * ended, so cleanup can branch on cancellation — a distinct rollback path, or telemetry
+ * that shouldn't count cancellations as failures.
+ *
+ * The sync interpreter built that Exit from a caught throw and so always reported
+ * `Failure`, disagreeing with the async interpreter, which passes the real Exit through.
+ * Recorded on #242; the error itself was never lost (the catch rethrows), only
+ * `release`'s view of *why*.
+ */
+describe("bracketExit reports interruption to release", () => {
+  const spy = () => {
+    const seen: string[] = []
+    const release = (_resource: string, exit: { isSuccess: () => boolean; isInterrupted: () => boolean }) =>
+      IO.sync(() => {
+        seen.push(exit.isInterrupted() ? "interrupted" : exit.isSuccess() ? "success" : "failure")
+      })
+    return { seen, release }
+  }
+
+  it("sync: release sees Interrupted, not Failure", () => {
+    const { seen, release } = spy()
+
+    IO.bracketExit(IO.succeed("resource"), () => IO.interrupt(), release).runSync()
+
+    expect(seen).toEqual(["interrupted"])
+  })
+
+  it("async: release sees Interrupted (unchanged)", async () => {
+    const { seen, release } = spy()
+
+    await IO.bracketExit(IO.succeed("resource"), () => IO.interrupt(), release).runExit()
+
+    expect(seen).toEqual(["interrupted"])
+  })
+
+  // Regressions: the other two outcomes must still be reported as they were.
+  it("sync: release still sees Failure for a genuine failure", () => {
+    const { seen, release } = spy()
+
+    IO.bracketExit(IO.succeed("resource"), () => IO.fail(new Error("boom")), release).runSync()
+
+    expect(seen).toEqual(["failure"])
+  })
+
+  it("sync: release still sees Success when use succeeds", () => {
+    const { seen, release } = spy()
+
+    IO.bracketExit(IO.succeed("resource"), () => IO.succeed("ok"), release).runSync()
+
+    expect(seen).toEqual(["success"])
+  })
+
+  it("sync: the interruption still propagates to the caller", () => {
+    const { release } = spy()
+
+    const result = IO.bracketExit(IO.succeed("resource"), () => IO.interrupt(), release).runSync()
+
+    expect(result.isLeft()).toBe(true)
+  })
+})


### PR DESCRIPTION
`bracketExit` contracts that `release` receives the `Exit` describing how `use` ended, so cleanup can branch on cancellation — a distinct rollback path, or telemetry that shouldn't count cancellations as failures.

The **sync** interpreter built that `Exit` from a caught throw, so it always reported `Failure` (`IO.ts:1031-1033`):

```ts
IO.bracketExit(acquire, () => IO.interrupt(), release).runSync()
// release saw Exit.fail(InterruptedError) — now sees Exit.interrupted()
```

The **async** interpreter already passes the real `useExit` through (`IO.ts:1166`), so this only brings sync into agreement. **There is no new semantics to adopt** — `release` implementations already had to handle an interrupted `Exit`, because async has always produced one. That's what makes this safe rather than a behavioural change to weigh.

`UnsupportedSyncOperationError` deliberately stays a `Failure`: it's a defect, not a cancellation, and `Exit` has no defect variant.

## Scope

One line in the sync `BracketExit` catch. No error was ever lost here — the catch rethrows, and the interruption still reaches the caller — only `release`'s view of *why* was wrong.

## Why now rather than folded into #242

Initially deferred to #242 and [recorded there](https://github.com/jordanburke/functype/issues/242#issuecomment-5092351625). On reflection that was the wrong call:

- It's a **pre-existing** sync/async divergence, not part of *adding* external cancellation — so fixing it here makes #242 smaller, not larger.
- "Only reachable by composing `IO.interrupt()` explicitly" is the same argument that applied to #243 and #246, both of which were fixed anyway. Deferring on that basis was an inconsistent standard.
- The "verify what `release` expects" concern was moot once I checked: async already hands it an interrupted `Exit`.

## Tests

`test/io/io-bracketexit-interrupt.spec.ts` — asserts `release`'s view on **both** interpreters, plus regressions that success and genuine-failure reporting are unchanged, and that the interruption still propagates to the caller.

Verified the sync test fails without the fix (`expected [ 'failure' ] to deeply equal [ 'interrupted' ]`) and that the async test passed already — confirming async was correct and only sync moved.

Workspace `turbo run validate`: 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)