### PR TITLE
fix(io): add Exit.Die so defects stop masquerading as typed errors (#258, #259)

### DIFF
--- a/packages/functype-react/README.md
+++ b/packages/functype-react/README.md
@@ -213,7 +213,7 @@ Both read only the fields they project. For **queries** that matters: React Quer
 Two behaviours worth knowing before you rely on the ADT:
 
 - **A failed background refetch projects to `Failure` even though React Query still holds the last successful `data`.** `TaskState` has no "loaded but stale" variant. This is the deliberate default — it never silently hides a failure — but it does mean a transient refetch error flips a loaded view to the error branch. To keep rendering stale data, read `query.data` alongside the projection or branch on `query.isRefetchError` before projecting.
-- **If your effect factory throws synchronously** (before an `IO` is produced), the rejection is still boxed, but with `defect: true` and `.error` holding the raw thrown value rather than an `E`. Check `defect` before matching on `_tag` if that's reachable in your code.
+- **`defect: true` means `.error` is not an `E`** — check it before matching on `_tag`. It is set when the effect factory throws before an `IO` is produced, when the effect produces a defect (`Exit.Die`: a throwing `IO.sync` thunk, a throwing `map`/`flatMap`/`mapError` callback, or `IO.die`), or when the effect is interrupted. Conversely `defect: false` genuinely means `.error` is an `E`; before 1.8.0 it did not, because a defect reached the bridge as an ordinary `Left` indistinguishable from a typed failure.
 
 Mutations mirror the shape (React Query supplies no `AbortSignal` to mutations, so the callback takes only the variables):
 
@@ -250,7 +250,7 @@ useInfiniteQuery({
 })
 ```
 
-Both the hooks and the primitives are generic over any `IO<never, E, A>` — nothing here is HTTP-specific. `Error.message` is derived structurally (`formatIOError`); pass `formatError` to override it.
+Both the hooks and the primitives are generic over any `IO<never, E, A>` — nothing here is HTTP-specific. `Error.message` is derived structurally (`formatIOError`); pass `formatError` to override it. The derivation prefers, in order: a raw `Error`'s `.message`, the HTTP shape (`HTTP 403 Forbidden — /api/x`) for anything carrying a numeric `status`, a tagged error's own `message`, then the bare `_tag`, then JSON.
 
 ## Compatibility
 

--- a/packages/functype-react/src/query/IOQueryError.ts
+++ b/packages/functype-react/src/query/IOQueryError.ts
@@ -19,6 +19,7 @@ type TaggedError = {
   readonly url?: unknown
   readonly status?: unknown
   readonly statusText?: unknown
+  readonly message?: unknown
 }
 
 const isTaggedError = (e: unknown): e is TaggedError =>
@@ -45,6 +46,16 @@ export const formatIOError = (error: unknown): string => {
       const statusText =
         typeof error.statusText === "string" && error.statusText.length > 0 ? ` ${error.statusText}` : ""
       return `HTTP ${error.status}${statusText}${where}`
+    }
+
+    // A tagged error carrying its own `message` is the normal shape for a domain error
+    // in the `IO` channel, and that message is what the author wrote for a human to
+    // read. Falling back to the bare tag was the one case where information already
+    // present got discarded — a raw `Error` gets `.message`, an untagged object gets
+    // JSON, but a tagged one got neither. None of functype's own `HttpError` variants
+    // carry a `message`, so the HTTP renderings above are unaffected.
+    if (typeof error.message === "string" && error.message.length > 0) {
+      return error.message
     }
 
     return `${error._tag}${where}`
@@ -79,17 +90,26 @@ export class IOQueryError<E> extends Error {
   /**
    * The raw functype error channel value — discriminable via its own `_tag`.
    *
-   * When {@link defect} is `true` this is **not** an `E`: it is whatever the effect
-   * factory threw before an `IO` was ever produced. Check `defect` before matching
-   * on `_tag` if your factory can throw synchronously.
+   * When {@link defect} is `true` this is **not** an `E`. Check `defect` before
+   * matching on `_tag`.
    */
   readonly error: E
 
   /**
-   * `true` when this wraps an unexpected throw rather than a value from the effect's
-   * typed error channel — i.e. the effect factory itself threw. Kept as an explicit
-   * flag rather than widening `E` to `unknown`, which would force every consumer to
-   * handle a case that should never occur.
+   * `true` when {@link error} is *not* a value from the effect's typed error channel.
+   * Three things set it:
+   *
+   * - the effect factory threw before an `IO` was ever produced
+   * - the effect produced a defect (`Exit.Die`) — a throwing `IO.sync` thunk, a
+   *   throwing `map` / `flatMap` / `mapError` callback, or `IO.die`
+   * - the effect was interrupted, so `error` is an `InterruptedError`
+   *
+   * Kept as an explicit flag rather than widening `E` to `unknown`, which would force
+   * every consumer to handle a case that should never occur.
+   *
+   * `defect: false` genuinely means `error` is an `E`. Before 1.8.0 it did not: a
+   * defect reached the adapter as an ordinary `Left` and was indistinguishable from a
+   * typed failure, so the documented guard didn't guard anything (#259).
    */
   readonly defect: boolean
 

--- a/packages/functype-react/src/query/ioQueryFn.ts
+++ b/packages/functype-react/src/query/ioQueryFn.ts
@@ -7,7 +7,7 @@
  * `throw` because the rule also fires on the enclosing function: three scattered
  * suppressions would read as incidental exceptions rather than one deliberate design. */
 import { Try } from "functype"
-import type { IO } from "functype/io"
+import { InterruptedError, type IO } from "functype/io"
 
 import { IOQueryError } from "./IOQueryError"
 
@@ -33,28 +33,47 @@ export type IOBridgeOptions<E> = {
 /**
  * Runs an effect and returns its value, or throws a boxed {@link IOQueryError}.
  *
- * Two failure paths converge here:
- * - the effect's typed error channel (`Left`) → boxed with `defect: false`
+ * Three failure paths converge here:
+ * - the effect's typed error channel (`Failure`) → boxed with `defect: false`
+ * - a defect raised *inside* the effect (`Die`) → boxed with `defect: true`
  * - the factory throwing before an `IO` exists → boxed with `defect: true`
  *
- * The second matters because `.run()` itself never throws (defects raised *inside*
- * the effect are folded into `Left` by the interpreter), but `io(input)` is ordinary
- * user code that can throw while building the effect. Without this, that throw would
- * escape unboxed and `error.error` would be `undefined` despite the declared type.
+ * The third matters because running an effect never throws, but `io(input)` is
+ * ordinary user code that can throw while building the effect. Without this, that
+ * throw would escape unboxed and `error.error` would be `undefined` despite the
+ * declared type.
+ *
+ * The second is why this uses `runExit()` rather than `run()`. `run()` returns
+ * `Either<E, A>`, which has nowhere to put a defect — a throwing `mapError` handler or
+ * `IO.sync` thunk arrived as `Left` and was indistinguishable from a genuine `E`, so
+ * `defect` read `false` while `.error` held something that was not an `E` at all
+ * (#259). `Exit` keeps the two apart, so the flag can be accurate.
  */
 const runBoxed = async <E, A>(effect: () => IO<never, E, A>, options?: IOBridgeOptions<E>): Promise<A> => {
-  const result = await Try(() => effect()).fold(
+  const exit = await Try(() => effect()).fold(
     (thrown) => {
       throw new IOQueryError(thrown as E, undefined, true)
     },
-    (io) => io.run(),
+    (io) => io.runExit(),
   )
 
-  if (result.isLeft()) {
-    throw new IOQueryError(result.value, options?.formatError?.(result.value))
+  if (exit.isFailure()) {
+    const { error } = exit.toValue() as { error: E }
+    throw new IOQueryError(error, options?.formatError?.(error))
   }
 
-  return result.value
+  if (exit.isDie()) {
+    throw new IOQueryError((exit.toValue() as { defect: unknown }).defect as E, undefined, true)
+  }
+
+  if (exit.isInterrupted()) {
+    // An `InterruptedError` is no more an `E` than a defect is, so it carries the same
+    // flag. `run()` put it in the `Left` with `defect: false`, which had the same problem
+    // the rest of this fix is about.
+    throw new IOQueryError(new InterruptedError() as E, undefined, true)
+  }
+
+  return exit.orThrow()
 }
 
 /**

--- a/packages/functype-react/test/query/errorBoxing.spec.ts
+++ b/packages/functype-react/test/query/errorBoxing.spec.ts
@@ -1,0 +1,189 @@
+import { IO } from "functype/io"
+import { describe, expect, it } from "vitest"
+
+import { formatIOError, IOQueryError, ioMutationFn } from "../../src/query"
+
+/**
+ * Two guarantees the query bridge makes about errors, both of which it used to break.
+ */
+describe("error boxing", () => {
+  /**
+   * `formatIOError` supplies `IOQueryError.message` by default, so whatever it discards
+   * is what the user reads in the UI. A raw `Error` already had `.message` preferred and
+   * an untagged object already got a JSON rendering — a *tagged* object with a `message`
+   * was the one shape where information already present was thrown away (#258).
+   */
+  describe("formatIOError", () => {
+    it("prefers a tagged error's own message over its tag", () => {
+      expect(formatIOError({ _tag: "AuthError", message: "No session" })).toBe("No session")
+    })
+
+    it("still renders the HTTP variants structurally", () => {
+      const httpStatus = {
+        _tag: "HttpStatusError",
+        url: "/api/x",
+        method: "GET",
+        status: 403,
+        statusText: "Forbidden",
+        body: "{}",
+      }
+
+      expect(formatIOError(httpStatus)).toBe("HTTP 403 Forbidden — /api/x")
+    })
+
+    // No `HttpError` variant carries a `message`, so a status-bearing error can never
+    // reach the message branch — but a status must win even if one ever did.
+    it("prefers the status rendering over a message when both are present", () => {
+      expect(formatIOError({ _tag: "HttpStatusError", url: "/api/x", status: 500, message: "ignored" })).toBe(
+        "HTTP 500 — /api/x",
+      )
+    })
+
+    it("falls back to the tag when there is no usable message", () => {
+      expect(formatIOError({ _tag: "AuthError" })).toBe("AuthError")
+      expect(formatIOError({ _tag: "AuthError", message: "" })).toBe("AuthError")
+      expect(formatIOError({ _tag: "AuthError", message: 42 })).toBe("AuthError")
+    })
+
+    it("leaves the non-tagged paths alone", () => {
+      expect(formatIOError(new Error("boom"))).toBe("boom")
+      expect(formatIOError({ foo: "bar" })).toBe('{"foo":"bar"}')
+      expect(formatIOError("plain")).toBe("plain")
+    })
+
+    it("reaches the message through the hook path, not just direct calls", async () => {
+      const fn = ioMutationFn(() => IO.fail({ _tag: "AuthError" as const, message: "No session" }))
+
+      await expect(fn()).rejects.toThrow("No session")
+    })
+  })
+
+  /**
+   * `defect: false` is documented to mean "`.error` really is an `E`", and consumers are
+   * told to check it before matching on `_tag`. That guard was unsound: anything that
+   * reached the error channel without being a typed failure — a throwing error-mapper, a
+   * throwing `IO.sync` thunk, `IO.die` — arrived as an ordinary `Left` and read
+   * `defect: false` while carrying something that was not an `E` (#259).
+   */
+  describe("IOQueryError.defect", () => {
+    const boxedFrom = async (fn: () => Promise<unknown>): Promise<IOQueryError<unknown>> => {
+      try {
+        await fn()
+      } catch (e) {
+        if (e instanceof IOQueryError) return e as IOQueryError<unknown>
+        throw e
+      }
+      throw new Error("expected the effect to reject")
+    }
+
+    it("is false for a genuine typed failure, which is an E", async () => {
+      const boxed = await boxedFrom(ioMutationFn(() => IO.fail({ _tag: "AuthError" as const, message: "no session" })))
+
+      expect(boxed.defect).toBe(false)
+      expect(boxed.error).toEqual({ _tag: "AuthError", message: "no session" })
+    })
+
+    it("is true when the effect factory throws", async () => {
+      const boxed = await boxedFrom(
+        ioMutationFn(() => {
+          throw new Error("factory bug")
+        }),
+      )
+
+      expect(boxed.defect).toBe(true)
+    })
+
+    // The reported case.
+    it("is true when the catch handler throws", async () => {
+      const boxed = await boxedFrom(
+        ioMutationFn(() =>
+          IO.tryPromise({
+            try: () => Promise.reject(new Error("original")),
+            catch: () => {
+              throw new Error("mapper bug")
+            },
+          }),
+        ),
+      )
+
+      expect(boxed.defect).toBe(true)
+      expect((boxed.error as Error).message).toBe("mapper bug")
+    })
+
+    it("is true for a throwing IO.sync thunk", async () => {
+      const boxed = await boxedFrom(
+        ioMutationFn(() =>
+          IO.sync<number>(() => {
+            throw new Error("thunk bug")
+          }),
+        ),
+      )
+
+      expect(boxed.defect).toBe(true)
+    })
+
+    it("is true for IO.die", async () => {
+      const boxed = await boxedFrom(ioMutationFn(() => IO.die(new Error("died"))))
+
+      expect(boxed.defect).toBe(true)
+    })
+
+    it("is true for interruption, whose InterruptedError is no more an E than a defect", async () => {
+      const boxed = await boxedFrom(ioMutationFn(() => IO.interrupt()))
+
+      expect(boxed.defect).toBe(true)
+    })
+
+    /**
+     * The invariant itself, stated as the docs state it: whenever `defect` is `false`,
+     * following the prescribed guard and matching on `_tag` must actually work.
+     */
+    it("holds the documented invariant across every path", async () => {
+      const paths = [
+        () => IO.fail({ _tag: "AuthError" as const, message: "no session" }),
+        () => {
+          throw new Error("factory bug")
+        },
+        () =>
+          IO.tryPromise({
+            try: () => Promise.reject(new Error("original")),
+            catch: () => {
+              throw new Error("mapper bug")
+            },
+          }),
+        () =>
+          IO.sync<number>(() => {
+            throw new Error("thunk bug")
+          }),
+        () => IO.die(new Error("died")),
+        () => IO.interrupt(),
+      ]
+
+      for (const path of paths) {
+        const boxed = await boxedFrom(ioMutationFn(path as () => IO<never, unknown, unknown>))
+
+        if (!boxed.defect) {
+          expect(typeof (boxed.error as { _tag?: unknown })._tag).toBe("string")
+        }
+      }
+    })
+
+    it("still lets a defect be recovered before it ever reaches the bridge", async () => {
+      const fn = ioMutationFn(() =>
+        IO.sync<number>(() => {
+          throw new Error("thunk bug")
+        }).recover(42),
+      )
+
+      await expect(fn()).resolves.toBe(42)
+    })
+
+    it("still boxes an Error subclass so React Query's handlers keep working", async () => {
+      const boxed = await boxedFrom(ioMutationFn(() => IO.fail({ _tag: "AuthError" as const, message: "no session" })))
+
+      expect(boxed).toBeInstanceOf(Error)
+      expect(boxed.name).toBe("IOQueryError")
+      expect(boxed.message).toBe("no session")
+    })
+  })
+})

--- a/packages/functype/CHANGELOG.md
+++ b/packages/functype/CHANGELOG.md
@@ -6,6 +6,56 @@ Entries follow [Keep a Changelog](https://keepachangelog.com/) conventions: writ
 
 ## Unreleased
 
+**`functype` — `Exit` gains a `Die` variant so defects stop masquerading as typed errors (fixes #259).**
+
+`IO.sync` and `IO.die` are `IO<never, never, A>`: the declared error channel is `never`, so nothing they put there can be an `E`. `Exit` had nowhere to say that — a throwing `IO.sync` thunk, a throwing `map` / `flatMap` / `mapError` callback, and `IO.die` all collapsed into `Failure`, indistinguishable from `IO.fail(e)`:
+
+```ts
+await IO.die(new Error("boom")).runExit() // was Failure(Error), now Die(Error)
+await IO.sync(() => {
+  throw x
+}).runExit() // was Failure(x), now Die(x)
+```
+
+`Exit` now has `isDie()`, `Exit.die(defect)`, an `Exit.isDie` companion guard, an optional fourth `onDie` argument on `fold`, and an optional `Die` key on `match`. Both are appended/optional and fall back to the failure handler, so existing three-argument `fold` calls and three-key `match` objects keep compiling **and** keep receiving defects where they received them before.
+
+Defects stay **recoverable** — `recover` / `recoverWith` / `fold` / `mapError` treat a `Die` exactly as they treated it before, and `mapError` over a defect produces a `Failure` because the supplied mapper returns a genuine `E`. This is where functype parts company with ZIO: promoting defects to uncatchable would silently change what every existing `.recover()` catches. `Die` is an observability fix, not a control-flow one.
+
+The `Either` terminals are unchanged: `run()`, `runSync()`, and `runOrThrow()` still surface a defect as the raw value, because `Either` has no third branch. `runExit()` is the terminal that carries the distinction.
+
+The dividing line is the _declared_ channel, not whether something threw. `IO.async` and the `IO(...)` constructor are `IO<never, unknown, A>`, so their rejections are legitimate errors and remain `Failure` — necessary as well as correct, since `IO.tryPromise` is `async(...).mapError(catch)` and a defect would sail past `mapError`, leaving every `catch` handler in the library uninvoked.
+
+Also supersedes a note in 1.7.0: the sync `bracketExit` now reports `UnsupportedSyncOperationError` to `release` as `Die` rather than `Failure`. It remains the only defect the sync interpreter can name with certainty — `runSync` returns `Either`, and the sync interpreter signals `Fail` and `Die` with the same bare `throw`, so `Die` is observable through the async terminals and through a `bracketExit` release.
+
+**`functype-react` — `IOQueryError.defect` is now accurate (fixes #259).**
+
+`defect: false` is documented to mean "`.error` really is an `E`", and consumers are told to check it before matching on `_tag`. The guard was unsound: `ioQueryFn` / `ioMutationFn` read `run()`, whose `Either` cannot express a defect, so a throwing error-mapper landed in the `Left` and read `defect: false` while carrying something that was not an `E`:
+
+```ts
+ioMutationFn(() =>
+  IO.tryPromise({
+    try: () => Promise.reject(new Error("original")),
+    catch: () => {
+      throw new Error("mapper bug")
+    },
+  }),
+)
+// caught: defect was false, .error was Error("mapper bug") with no _tag
+```
+
+The bridge now reads `runExit()` and sets `defect: true` for a `Die`, for a factory that throws before an `IO` exists, and for interruption (whose `InterruptedError` is no more an `E` than a defect is). `defect: false` now genuinely implies `.error` is an `E`.
+
+**`functype-react` — `formatIOError` no longer discards a tagged error's `message` (fixes #258).**
+
+A raw `Error` had `.message` preferred and an untagged object got a JSON rendering, but a _tagged_ object carrying a `message` fell back to the bare tag — the one shape where information already present was thrown away. Since `formatIOError` supplies `IOQueryError.message`, a dead session surfaced to the user as `"AuthError"` rather than `"No session"`:
+
+```ts
+formatIOError({ _tag: "AuthError", message: "No session" })
+// was "AuthError", now "No session"
+```
+
+The HTTP renderings are unaffected — no `HttpError` variant carries a `message`, and a numeric `status` still wins.
+
 ## 1.7.0 - 2026-07-27
 
 **`functype` — `bracketExit` reports interruption to `release` as `Interrupted` on the sync interpreter.**

--- a/packages/functype/docs/io-design.md
+++ b/packages/functype/docs/io-design.md
@@ -55,7 +55,10 @@ type IO<R, E, A> = {
 
 // Exit type for capturing full outcome
 type Exit<E, A> =
-  { _tag: "Success"; value: A } | { _tag: "Failure"; error: E } | { _tag: "Interrupted"; fiberId: string }
+  | { _tag: "Success"; value: A }
+  | { _tag: "Failure"; error: E } // a value from the declared E channel
+  | { _tag: "Die"; defect: unknown } // a defect — not an E (throwing thunk/callback, IO.die)
+  | { _tag: "Interrupted"; fiberId: string }
 ```
 
 ### Constructors
@@ -278,7 +281,7 @@ Users can choose which to use based on their needs. Integration/migration can be
 ### New Files - Core IO
 
 - `src/io/IO.ts` - Main IO<R, E, A> implementation
-- `src/io/Exit.ts` - Exit<E, A> type (Success/Failure/Interrupted)
+- `src/io/Exit.ts` - Exit<E, A> type (Success/Failure/Die/Interrupted)
 - `src/io/Runtime.ts` - Effect runtime and executors
 - `src/io/index.ts` - Module exports
 

--- a/packages/functype/src/io/Exit.ts
+++ b/packages/functype/src/io/Exit.ts
@@ -15,13 +15,34 @@ import type { Type } from "@/types"
 /**
  * Possible outcome types for an Exit
  */
-export type ExitTag = "Success" | "Failure" | "Interrupted"
+export type ExitTag = "Success" | "Failure" | "Die" | "Interrupted"
 
 /**
  * Exit represents the outcome of running an IO effect.
  * - Success: The effect completed successfully with a value
- * - Failure: The effect failed with a typed error
+ * - Failure: The effect failed with a typed error — a value from the declared `E` channel
+ * - Die: The effect produced a *defect* — a value that is **not** an `E`
  * - Interrupted: The effect was cancelled/interrupted
+ *
+ * `Die` exists so the error channel stops lying. `IO.sync` and `IO.die` declare
+ * `E = never`, so nothing they put in the error channel can be an `E`: a throwing
+ * `IO.sync` thunk, a throwing `map`/`flatMap`/`mapError` callback, and `IO.die` all
+ * produce values the declared type says cannot exist. Before `Die` these collapsed
+ * into `Failure`, so a consumer that pattern-matched on `error._tag` got `undefined`
+ * with no runtime signal that anything was wrong.
+ *
+ * Defects remain **recoverable** — `recover` / `recoverWith` / `fold` / `mapError`
+ * treat `Die` exactly as they treat `Failure`. That is deliberate, and it is where
+ * functype parts company with ZIO: promoting defects to uncatchable would silently
+ * change what every existing `.recover()` catches. `Die` is an *observability* fix,
+ * not a control-flow one — it records what the outcome really was when nothing
+ * recovered it.
+ *
+ * Note the sync interpreter cannot distinguish the two. `runSync` returns
+ * `Either<E, A>`, which has no third branch to put a defect in, and the sync
+ * interpreter signals failure by throwing the raw value — so `Fail` and `Die` arrive
+ * identically. `Die` is observable through the async terminals (`runExit`) and
+ * through the `Exit` handed to a `bracketExit` release.
  */
 export interface Exit<E extends Type, A extends Type> {
   readonly [Symbol.toStringTag]: string
@@ -36,6 +57,11 @@ export interface Exit<E extends Type, A extends Type> {
    * Type guard to check if this is a Failure
    */
   isFailure(): this is Exit<E, A> & { readonly _tag: "Failure"; error: E }
+
+  /**
+   * Type guard to check if this is a Die (a defect — the carried value is not an `E`)
+   */
+  isDie(): this is Exit<E, A> & { readonly _tag: "Die"; defect: unknown }
 
   /**
    * Type guard to check if this is Interrupted
@@ -63,14 +89,32 @@ export interface Exit<E extends Type, A extends Type> {
   flatMap<B extends Type>(f: (a: A) => Exit<E, B>): Exit<E, B>
 
   /**
-   * Pattern matches over the Exit
+   * Pattern matches over the Exit.
+   *
+   * `onDie` is optional and appended rather than inserted so existing three-argument
+   * calls keep compiling. Omitting it routes a defect to `onFailure` — the pre-`Die`
+   * behaviour, where defects were indistinguishable from typed failures. Supply it
+   * when the distinction matters; note the value it receives is `unknown`, not `E`.
    */
-  fold<T>(onFailure: (e: E) => T, onSuccess: (a: A) => T, onInterrupted?: (fiberId: string) => T): T
+  fold<T>(
+    onFailure: (e: E) => T,
+    onSuccess: (a: A) => T,
+    onInterrupted?: (fiberId: string) => T,
+    onDie?: (defect: unknown) => T,
+  ): T
 
   /**
-   * Pattern matches over the Exit with object patterns
+   * Pattern matches over the Exit with object patterns.
+   *
+   * `Die` is optional for the same back-compat reason as {@link fold}'s `onDie`, and
+   * falls back to `Failure` when absent.
    */
-  match<T>(patterns: { Success: (value: A) => T; Failure: (error: E) => T; Interrupted: (fiberId: string) => T }): T
+  match<T>(patterns: {
+    Success: (value: A) => T
+    Failure: (error: E) => T
+    Interrupted: (fiberId: string) => T
+    Die?: (defect: unknown) => T
+  }): T
 
   /**
    * Returns the success value or throws
@@ -90,13 +134,16 @@ export interface Exit<E extends Type, A extends Type> {
   /**
    * Converts to Either (Right for Success, Left for Failure)
    * Throws if Interrupted
+   *
+   * A `Die` becomes `Left(defect)`, which widens the Left beyond `E` — the same
+   * lossiness `IO.run()` already has. Use {@link isDie} first if the distinction matters.
    */
   toEither(): Either<E, A>
 
   /**
    * Returns the raw value for inspection
    */
-  toValue(): { _tag: ExitTag; value?: A; error?: E; fiberId?: string }
+  toValue(): { _tag: ExitTag; value?: A; error?: E; defect?: unknown; fiberId?: string }
 
   /**
    * String representation
@@ -106,7 +153,7 @@ export interface Exit<E extends Type, A extends Type> {
   /**
    * JSON serialization
    */
-  toJSON(): { _tag: ExitTag; value?: A; error?: E; fiberId?: string }
+  toJSON(): { _tag: ExitTag; value?: A; error?: E; defect?: unknown; fiberId?: string }
 }
 
 /**
@@ -121,6 +168,10 @@ const SuccessExit = <E extends Type, A extends Type>(value: A): Exit<E, A> => ({
   },
 
   isFailure(): this is Exit<E, A> & { readonly _tag: "Failure"; error: E } {
+    return false
+  },
+
+  isDie(): this is Exit<E, A> & { readonly _tag: "Die"; defect: unknown } {
     return false
   },
 
@@ -144,11 +195,21 @@ const SuccessExit = <E extends Type, A extends Type>(value: A): Exit<E, A> => ({
     return f(value)
   },
 
-  fold<T>(_onFailure: (e: E) => T, onSuccess: (a: A) => T, _onInterrupted?: (fiberId: string) => T): T {
+  fold<T>(
+    _onFailure: (e: E) => T,
+    onSuccess: (a: A) => T,
+    _onInterrupted?: (fiberId: string) => T,
+    _onDie?: (defect: unknown) => T,
+  ): T {
     return onSuccess(value)
   },
 
-  match<T>(patterns: { Success: (value: A) => T; Failure: (error: E) => T; Interrupted: (fiberId: string) => T }): T {
+  match<T>(patterns: {
+    Success: (value: A) => T
+    Failure: (error: E) => T
+    Interrupted: (fiberId: string) => T
+    Die?: (defect: unknown) => T
+  }): T {
     return patterns.Success(value)
   },
 
@@ -196,6 +257,10 @@ const FailureExit = <E extends Type, A extends Type>(error: E): Exit<E, A> => ({
     return true
   },
 
+  isDie(): this is Exit<E, A> & { readonly _tag: "Die"; defect: unknown } {
+    return false
+  },
+
   isInterrupted(): this is Exit<E, A> & { readonly _tag: "Interrupted"; fiberId: string } {
     return false
   },
@@ -216,11 +281,21 @@ const FailureExit = <E extends Type, A extends Type>(error: E): Exit<E, A> => ({
     return FailureExit(error)
   },
 
-  fold<T>(onFailure: (e: E) => T, _onSuccess: (a: A) => T, _onInterrupted?: (fiberId: string) => T): T {
+  fold<T>(
+    onFailure: (e: E) => T,
+    _onSuccess: (a: A) => T,
+    _onInterrupted?: (fiberId: string) => T,
+    _onDie?: (defect: unknown) => T,
+  ): T {
     return onFailure(error)
   },
 
-  match<T>(patterns: { Success: (value: A) => T; Failure: (error: E) => T; Interrupted: (fiberId: string) => T }): T {
+  match<T>(patterns: {
+    Success: (value: A) => T
+    Failure: (error: E) => T
+    Interrupted: (fiberId: string) => T
+    Die?: (defect: unknown) => T
+  }): T {
     return patterns.Failure(error)
   },
 
@@ -254,6 +329,101 @@ const FailureExit = <E extends Type, A extends Type>(error: E): Exit<E, A> => ({
 })
 
 /**
+ * Creates a Die Exit — an effect that produced a defect rather than a typed error.
+ *
+ * Mirrors {@link FailureExit} everywhere the payload can be treated opaquely. It
+ * diverges on {@link Exit.mapError}, which is typed `(e: E) => E2`: a defect is not an
+ * `E`, so handing it to that callback would be the exact type lie `Die` exists to end.
+ * A defect passes through `mapError` unchanged, as an interruption does.
+ *
+ * (`IO`'s own `.mapError` *does* rewrite a defect — it reads the error channel
+ * directly rather than through this method, and its callback is documented to receive
+ * `unknown`. That keeps the pre-`Die` behaviour of `.mapError` intact for callers.)
+ */
+const DieExit = <E extends Type, A extends Type>(defect: unknown): Exit<E, A> => ({
+  [Symbol.toStringTag]: "Exit",
+  _tag: "Die",
+
+  isSuccess(): this is Exit<E, A> & { readonly _tag: "Success"; value: A } {
+    return false
+  },
+
+  isFailure(): this is Exit<E, A> & { readonly _tag: "Failure"; error: E } {
+    return false
+  },
+
+  isDie(): this is Exit<E, A> & { readonly _tag: "Die"; defect: unknown } {
+    return true
+  },
+
+  isInterrupted(): this is Exit<E, A> & { readonly _tag: "Interrupted"; fiberId: string } {
+    return false
+  },
+
+  map<B extends Type>(_f: (a: A) => B): Exit<E, B> {
+    return DieExit(defect)
+  },
+
+  mapError<E2 extends Type>(_f: (e: E) => E2): Exit<E2, A> {
+    return DieExit(defect)
+  },
+
+  mapBoth<E2 extends Type, B extends Type>(_onError: (e: E) => E2, _onSuccess: (a: A) => B): Exit<E2, B> {
+    return DieExit(defect)
+  },
+
+  flatMap<B extends Type>(_f: (a: A) => Exit<E, B>): Exit<E, B> {
+    return DieExit(defect)
+  },
+
+  fold<T>(
+    onFailure: (e: E) => T,
+    _onSuccess: (a: A) => T,
+    _onInterrupted?: (fiberId: string) => T,
+    onDie?: (defect: unknown) => T,
+  ): T {
+    return onDie ? onDie(defect) : onFailure(defect as E)
+  },
+
+  match<T>(patterns: {
+    Success: (value: A) => T
+    Failure: (error: E) => T
+    Interrupted: (fiberId: string) => T
+    Die?: (defect: unknown) => T
+  }): T {
+    return patterns.Die ? patterns.Die(defect) : patterns.Failure(defect as E)
+  },
+
+  orThrow(): A {
+    throw defect
+  },
+
+  orElse(defaultValue: A): A {
+    return defaultValue
+  },
+
+  toOption(): Option<A> {
+    return None()
+  },
+
+  toEither(): Either<E, A> {
+    return Left(defect as E)
+  },
+
+  toValue() {
+    return { _tag: "Die" as const, defect }
+  },
+
+  toString() {
+    return `Exit.Die(${safeStringify(defect)})`
+  },
+
+  toJSON() {
+    return { _tag: "Die" as const, defect }
+  },
+})
+
+/**
  * Creates an Interrupted Exit
  */
 const InterruptedExit = <E extends Type, A extends Type>(fiberId: string): Exit<E, A> => ({
@@ -265,6 +435,10 @@ const InterruptedExit = <E extends Type, A extends Type>(fiberId: string): Exit<
   },
 
   isFailure(): this is Exit<E, A> & { readonly _tag: "Failure"; error: E } {
+    return false
+  },
+
+  isDie(): this is Exit<E, A> & { readonly _tag: "Die"; defect: unknown } {
     return false
   },
 
@@ -288,14 +462,24 @@ const InterruptedExit = <E extends Type, A extends Type>(fiberId: string): Exit<
     return InterruptedExit(fiberId)
   },
 
-  fold<T>(_onFailure: (e: E) => T, _onSuccess: (a: A) => T, onInterrupted?: (fiberId: string) => T): T {
+  fold<T>(
+    _onFailure: (e: E) => T,
+    _onSuccess: (a: A) => T,
+    onInterrupted?: (fiberId: string) => T,
+    _onDie?: (defect: unknown) => T,
+  ): T {
     if (onInterrupted) {
       return onInterrupted(fiberId)
     }
     throw new Error(`Effect was interrupted: ${fiberId}`)
   },
 
-  match<T>(patterns: { Success: (value: A) => T; Failure: (error: E) => T; Interrupted: (fiberId: string) => T }): T {
+  match<T>(patterns: {
+    Success: (value: A) => T
+    Failure: (error: E) => T
+    Interrupted: (fiberId: string) => T
+    Die?: (defect: unknown) => T
+  }): T {
     return patterns.Interrupted(fiberId)
   },
 
@@ -343,6 +527,11 @@ const ExitCompanion = {
   fail: <E extends Type, A extends Type>(error: E): Exit<E, A> => FailureExit(error),
 
   /**
+   * Creates a Die Exit carrying a defect — a value that is not an `E`
+   */
+  die: <E extends Type, A extends Type>(defect: unknown): Exit<E, A> => DieExit(defect),
+
+  /**
    * Creates an Interrupted Exit with a fiber ID
    */
   interrupt: <E extends Type, A extends Type>(fiberId: string): Exit<E, A> => InterruptedExit(fiberId),
@@ -365,6 +554,12 @@ const ExitCompanion = {
   isFailure: <E extends Type, A extends Type>(
     exit: Exit<E, A>,
   ): exit is Exit<E, A> & { readonly _tag: "Failure"; error: E } => exit.isFailure(),
+
+  /**
+   * Type guard for Die
+   */
+  isDie: <E extends Type, A extends Type>(exit: Exit<E, A>): exit is Exit<E, A> & { readonly _tag: "Die" } =>
+    exit.isDie(),
 
   /**
    * Type guard for Interrupted
@@ -394,6 +589,8 @@ const ExitCompanion = {
   ): Exit<E, readonly [A, B]> => {
     if (exitA.isInterrupted()) return exitA as unknown as Exit<E, readonly [A, B]>
     if (exitB.isInterrupted()) return exitB as unknown as Exit<E, readonly [A, B]>
+    if (exitA.isDie()) return exitA as unknown as Exit<E, readonly [A, B]>
+    if (exitB.isDie()) return exitB as unknown as Exit<E, readonly [A, B]>
     if (exitA.isFailure()) return exitA as unknown as Exit<E, readonly [A, B]>
     if (exitB.isFailure()) return exitB as unknown as Exit<E, readonly [A, B]>
     return SuccessExit([exitA.orThrow(), exitB.orThrow()] as const)
@@ -406,6 +603,7 @@ const ExitCompanion = {
     const results: A[] = []
     for (const exit of exits) {
       if (exit.isInterrupted()) return exit as unknown as Exit<E, readonly A[]>
+      if (exit.isDie()) return exit as unknown as Exit<E, readonly A[]>
       if (exit.isFailure()) return exit as unknown as Exit<E, readonly A[]>
       results.push(exit.orThrow())
     }

--- a/packages/functype/src/io/IO.ts
+++ b/packages/functype/src/io/IO.ts
@@ -821,9 +821,11 @@ const createIO = <R extends Type, E extends Type, A extends Type>(effect: IOEffe
       if (exit.isSuccess()) {
         return Right(exit.orThrow())
       }
-      // All errors including InterruptedError go to Left
-      const error = exit.isFailure() ? (exit.toValue() as { error: E }).error : new InterruptedError()
-      return Left(error as E)
+      // All errors including InterruptedError go to Left. A defect lands here too, as the
+      // raw thrown value — `Either` has no third branch for it. `runExit()` is the
+      // terminal that keeps the distinction.
+      const channel = errorChannel(exit)
+      return Left((channel ? channel.value : new InterruptedError()) as E)
     },
 
     async runOrThrow(this: IO<never, E, A>): Promise<A> {
@@ -831,7 +833,8 @@ const createIO = <R extends Type, E extends Type, A extends Type>(effect: IOEffe
       if (exit.isSuccess()) {
         return exit.orThrow()
       }
-      throw exit.isFailure() ? (exit.toValue() as { error: E }).error : new InterruptedError()
+      const channel = errorChannel(exit)
+      throw channel ? channel.value : new InterruptedError()
     },
 
     runSync(this: IO<never, E, A>): Either<E, A> {
@@ -863,7 +866,8 @@ const createIO = <R extends Type, E extends Type, A extends Type>(effect: IOEffe
       if (exit.isSuccess()) {
         return unsafeCoerce(Try(() => exit.orThrow()))
       }
-      const error = exit.isFailure() ? (exit.toValue() as { error: E }).error : new Error("Effect was interrupted")
+      const channel = errorChannel(exit)
+      const error = channel ? channel.value : new Error("Effect was interrupted")
       return unsafeCoerce(
         Try(() => {
           throw error
@@ -921,13 +925,33 @@ const createIO = <R extends Type, E extends Type, A extends Type>(effect: IOEffe
  * Both must pass through every recovery boundary unchanged, so callers see the real
  * outcome rather than a plausible-looking substitute.
  *
- * The async interpreter gets this for free by branching on `Exit.isFailure()`; the sync
- * path needs it stated explicitly.
+ * The async interpreter gets this for free by branching on {@link errorChannel}, which
+ * excludes Interrupted; the sync path needs it stated explicitly.
  */
 const rethrowIfNonRecoverable = (e: unknown): void => {
   if (e instanceof InterruptedError || e instanceof UnsupportedSyncOperationError) {
     throw e
   }
+}
+
+/**
+ * The value in an Exit's error channel, if it has one: the typed error of a `Failure`,
+ * or the defect of a `Die`. `undefined` for `Success` and `Interrupted`, which carry
+ * neither.
+ *
+ * Wrapped in a box rather than returned bare because a `Failure` may legitimately carry
+ * `undefined` as its error — `errorChannel(exit) === undefined` must mean "no error
+ * channel", not "an error channel holding `undefined`".
+ *
+ * This is what makes a defect recoverable: every recovery combinator branches on this
+ * rather than on `isFailure()`, so `recover` / `recoverWith` / `fold` / `mapError` see a
+ * `Die` exactly as they saw it before `Die` existed. Interruption stays excluded (#243).
+ */
+const errorChannel = (exit: ExitType<unknown, unknown>): { readonly value: unknown } | undefined => {
+  const raw = exit.toValue()
+  if (raw._tag === "Failure") return { value: raw.error }
+  if (raw._tag === "Die") return { value: raw.defect }
+  return undefined
 }
 
 /**
@@ -1033,9 +1057,18 @@ const runEffectSync = <R extends Type, E extends Type, A extends Type>(
         // interrupted `use` must arrive as Interrupted rather than Failure — otherwise a
         // release that branches on cancellation (distinct rollback, telemetry) can't see
         // it. The async interpreter already passes the real Exit through; this keeps the
-        // sync path in agreement. `UnsupportedSyncOperationError` stays a Failure: it is
-        // a defect, not a cancellation, and Exit has no defect variant.
-        exit = e instanceof InterruptedError ? unsafeCoerce(Exit.interrupted()) : unsafeCoerce(Exit.fail(e as E))
+        // sync path in agreement.
+        //
+        // `UnsupportedSyncOperationError` is the one defect the sync interpreter can name
+        // with certainty, so it arrives as Die. Everything else is ambiguous here: the
+        // sync interpreter signals `Fail` and `Die` with the same bare `throw`, so a
+        // thrown value could be either and Failure stays the honest default.
+        exit =
+          e instanceof InterruptedError
+            ? unsafeCoerce(Exit.interrupted())
+            : e instanceof UnsupportedSyncOperationError
+              ? unsafeCoerce(Exit.die(e))
+              : unsafeCoerce(Exit.fail(e as E))
         throw e
       } finally {
         runEffectSync(_fx(effect.release(resource, exit!)), context)
@@ -1062,19 +1095,34 @@ const runEffect = async <R extends Type, E extends Type, A extends Type>(
       case "Fail":
         return unsafeCoerce(Exit.fail(effect.error))
       case "Die":
-        throw effect.defect
+        return unsafeCoerce(Exit.die(effect.defect))
       case "Sync":
+        // `IO.sync` is `IO<never, never, A>` — a throw here cannot be an `E`, so it falls
+        // to the outer catch and becomes a defect.
         return unsafeCoerce(Exit.succeed(effect.thunk()))
       case "Async": {
-        const result = await effect.thunk()
-        return unsafeCoerce(Exit.succeed(result))
+        // `IO.async` is `IO<never, unknown, A>`: a rejection *is* the declared error
+        // channel, not a defect. Caught here so the outer catch doesn't reclassify it —
+        // `IO.tryPromise` is `async(...).mapError(catch)`, and a `Die` would sail past
+        // `MapError`'s error-channel branch, leaving the `catch` handler never invoked.
+        try {
+          const result = await effect.thunk()
+          return unsafeCoerce(Exit.succeed(result))
+        } catch (e) {
+          return unsafeCoerce(Exit.fail(e))
+        }
       }
       case "Auto": {
-        const result = effect.thunk()
-        if (result instanceof Promise) {
-          return unsafeCoerce(Exit.succeed(await result))
-        } else {
-          return unsafeCoerce(Exit.succeed(result))
+        // Same reasoning as `Async` — the `IO(...)` constructor also declares `E = unknown`.
+        try {
+          const result = effect.thunk()
+          if (result instanceof Promise) {
+            return unsafeCoerce(Exit.succeed(await result))
+          } else {
+            return unsafeCoerce(Exit.succeed(result))
+          }
+        } catch (e) {
+          return unsafeCoerce(Exit.fail(e))
         }
       }
       case "Map": {
@@ -1094,21 +1142,21 @@ const runEffect = async <R extends Type, E extends Type, A extends Type>(
       }
       case "MapError": {
         const exitA = await runEffect(_fx(effect.effect), context)
-        if (exitA.isSuccess()) {
+        const channel = errorChannel(exitA)
+        if (!channel) {
           return unsafeCoerce(exitA)
         }
-        if (exitA.isFailure()) {
-          return unsafeCoerce(Exit.fail(effect.f((exitA.toValue() as { error: unknown }).error)))
-        }
-        return unsafeCoerce(exitA)
+        // A mapped defect becomes a `Failure`: the caller's mapper returns a genuine `E`,
+        // so the outcome really is a typed failure from here on.
+        return unsafeCoerce(Exit.fail(effect.f(channel.value)))
       }
       case "Recover": {
         const exitA = await runEffect(_fx(effect.effect), context)
-        // Only a *failure* is recoverable. Success passes through, and so does
-        // Interrupted — interruption is control flow, not a domain error, so a
+        // Only something in the error channel is recoverable. Success passes through, and
+        // so does Interrupted — interruption is control flow, not a domain error, so a
         // fallback must never convert a cancelled effect into a successful value.
-        // Matches the isFailure() guard in MapError / RecoverWith / Fold below.
-        if (!exitA.isFailure()) {
+        // Matches the errorChannel guard in MapError / RecoverWith / Fold.
+        if (!errorChannel(exitA)) {
           return unsafeCoerce(exitA)
         }
         return Exit.succeed(effect.fallback)
@@ -1117,22 +1165,21 @@ const runEffect = async <R extends Type, E extends Type, A extends Type>(
         // effect.effect is IO<R, unknown, unknown> (E-erased for variance). Exit branches
         // are re-wrapped via unsafeCoerce — outer A/E are preserved by RecoverWith's semantics.
         const exitA = await runEffect(_fx(effect.effect), context)
-        if (exitA.isSuccess()) {
+        const channel = errorChannel(exitA)
+        if (!channel) {
           return unsafeCoerce(exitA)
         }
-        if (exitA.isFailure()) {
-          const recoveryIO = effect.f((exitA.toValue() as { error: unknown }).error)
-          return runEffect(_fx(recoveryIO), context)
-        }
-        return unsafeCoerce(exitA)
+        const recoveryIO = effect.f(channel.value)
+        return runEffect(_fx(recoveryIO), context)
       }
       case "Fold": {
         const exitA = await runEffect(_fx(effect.effect), context)
+        const channel = errorChannel(exitA)
+        if (channel) {
+          return Exit.succeed(effect.onFailure(channel.value))
+        }
         if (exitA.isSuccess()) {
           return Exit.succeed(effect.onSuccess(exitA.orThrow()))
-        }
-        if (exitA.isFailure()) {
-          return Exit.succeed(effect.onFailure((exitA.toValue() as { error: unknown }).error))
         }
         return exitA as ExitType<E, A>
       }
@@ -1190,8 +1237,11 @@ const runEffect = async <R extends Type, E extends Type, A extends Type>(
       }
     }
   } catch (e) {
-    // Unhandled defects
-    return Exit.fail(e as E)
+    // Everything reaching here threw out of a callback the type system said could not
+    // produce an `E`: a `Sync` thunk, a `map` / `flatMap` / `mapError` function, a `Fold`
+    // handler, a `bracket` release. `Async` and `Auto` rejections are caught at their own
+    // cases above, because those constructors *do* declare `E = unknown`.
+    return Exit.die(e)
   }
 }
 

--- a/packages/functype/test/io/io-defect-channel.spec.ts
+++ b/packages/functype/test/io/io-defect-channel.spec.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "vitest"
+
+import type { IO as IOType } from "@/io"
+import { Exit, InterruptedError, IO } from "@/io"
+
+/**
+ * `Exit.Die` separates a *defect* — a value in the error channel that the declared `E`
+ * says cannot exist — from a genuine typed failure.
+ *
+ * Before it, both collapsed into `Failure`, so a consumer asking "is `.error` really an
+ * `E`?" had no way to find out: `IO.sync(() => { throw x })` and `IO.fail(e)` produced
+ * indistinguishable outcomes despite `IO.sync` declaring `E = never` (#259).
+ *
+ * The dividing line is the *declared* error channel, not whether something threw:
+ * `IO.async` and the `IO(...)` constructor declare `E = unknown`, so their rejections
+ * are legitimate errors and must stay `Failure`.
+ */
+describe("defects are distinguishable from typed failures", () => {
+  describe("what produces a Die", () => {
+    it("IO.die", async () => {
+      const defect = new Error("died")
+      const exit = await IO.die(defect).runExit()
+
+      expect(exit.isDie()).toBe(true)
+      expect(exit.isFailure()).toBe(false)
+      expect(exit.toValue().defect).toBe(defect)
+    })
+
+    it("a throwing IO.sync thunk", async () => {
+      const exit = await IO.sync(() => {
+        throw new Error("thunk bug")
+      }).runExit()
+
+      expect(exit.isDie()).toBe(true)
+    })
+
+    it("a throwing map callback", async () => {
+      const exit = await IO.succeed(1)
+        .map(() => {
+          throw new Error("map bug")
+        })
+        .runExit()
+
+      expect(exit.isDie()).toBe(true)
+    })
+
+    it("a throwing flatMap callback", async () => {
+      const exit = await IO.succeed(1)
+        .flatMap((): IOType<never, never, number> => {
+          throw new Error("flatMap bug")
+        })
+        .runExit()
+
+      expect(exit.isDie()).toBe(true)
+    })
+
+    // The reported repro: the error-*mapper* itself has a bug. Its declared return is an
+    // `E`, so what it throws instead cannot be one.
+    it("a throwing tryPromise catch handler", async () => {
+      const exit = await IO.tryPromise({
+        try: () => Promise.reject(new Error("original")),
+        catch: () => {
+          throw new Error("mapper bug")
+        },
+      }).runExit()
+
+      expect(exit.isDie()).toBe(true)
+      expect((exit.toValue().defect as Error).message).toBe("mapper bug")
+    })
+
+    it("a throwing mapError handler", async () => {
+      const exit = await IO.fail(new Error("boom"))
+        .mapError(() => {
+          throw new Error("mapper bug")
+        })
+        .runExit()
+
+      expect(exit.isDie()).toBe(true)
+    })
+  })
+
+  describe("what stays a Failure", () => {
+    it("IO.fail", async () => {
+      const exit = await IO.fail({ _tag: "AuthError" as const }).runExit()
+
+      expect(exit.isFailure()).toBe(true)
+      expect(exit.isDie()).toBe(false)
+    })
+
+    // `IO.async` is `IO<never, unknown, A>` — a rejection *is* the declared channel.
+    it("an IO.async rejection", async () => {
+      const exit = await IO.async(() => Promise.reject(new Error("rejected"))).runExit()
+
+      expect(exit.isFailure()).toBe(true)
+      expect(exit.isDie()).toBe(false)
+    })
+
+    it("an IO(...) constructor rejection", async () => {
+      const exit = await IO(() => Promise.reject(new Error("rejected"))).runExit()
+
+      expect(exit.isFailure()).toBe(true)
+    })
+
+    /**
+     * The load-bearing regression. `IO.tryPromise` is `async(...).mapError(catch)`, so if
+     * a rejection were classified as a defect it would sail straight past `MapError`'s
+     * error-channel branch and the `catch` handler would never run — silently disabling
+     * every typed error mapping in the library.
+     */
+    it("a tryPromise rejection reaches its catch handler and stays a Failure", async () => {
+      const exit = await IO.tryPromise({
+        try: () => Promise.reject(new Error("original")),
+        catch: () => ({ _tag: "NetworkError" as const }),
+      }).runExit()
+
+      expect(exit.isFailure()).toBe(true)
+      expect(exit.toValue().error).toEqual({ _tag: "NetworkError" })
+    })
+
+    it("interruption is Interrupted, not Die", async () => {
+      const exit = await IO.interrupt().runExit()
+
+      expect(exit.isInterrupted()).toBe(true)
+      expect(exit.isDie()).toBe(false)
+    })
+  })
+
+  /**
+   * Deliberate: `Die` is an observability fix, not a control-flow one. Promoting defects
+   * to uncatchable (the ZIO model) would silently change what every existing `.recover()`
+   * catches, so recovery treats a defect exactly as it treated one before.
+   */
+  describe("defects remain recoverable", () => {
+    const dies = () =>
+      IO.sync<number>(() => {
+        throw new Error("defect")
+      })
+
+    it("recover turns a defect into the fallback", async () => {
+      const exit = await dies().recover(42).runExit()
+
+      expect(exit.isSuccess()).toBe(true)
+      expect(exit.orThrow()).toBe(42)
+    })
+
+    it("recoverWith receives the defect", async () => {
+      const seen: unknown[] = []
+      const exit = await dies()
+        .recoverWith((e) => {
+          seen.push(e)
+          return IO.succeed(7)
+        })
+        .runExit()
+
+      expect(exit.orThrow()).toBe(7)
+      expect((seen[0] as Error).message).toBe("defect")
+    })
+
+    it("fold routes a defect to onFailure", async () => {
+      const exit = await dies()
+        .fold(
+          () => "recovered",
+          () => "ok",
+        )
+        .runExit()
+
+      expect(exit.orThrow()).toBe("recovered")
+    })
+
+    // Mapping a defect yields a *Failure*: the caller's mapper returns a genuine `E`, so
+    // from that point on the outcome really is a typed failure.
+    it("mapError rewrites a defect into a typed failure", async () => {
+      const exit = await dies()
+        .mapError(() => ({ _tag: "Mapped" as const }))
+        .runExit()
+
+      expect(exit.isFailure()).toBe(true)
+      expect(exit.isDie()).toBe(false)
+      expect(exit.toValue().error).toEqual({ _tag: "Mapped" })
+    })
+  })
+
+  /**
+   * `Either` has no third branch, so `run()` cannot express a defect. It keeps putting the
+   * raw value in the `Left` exactly as before — `runExit()` is the terminal that carries
+   * the distinction, and no existing caller changes behaviour.
+   */
+  describe("the Either terminals are unchanged", () => {
+    it("run puts a defect in the Left, raw", async () => {
+      const defect = new Error("defect")
+      const result = await IO.sync(() => {
+        throw defect
+      }).run()
+
+      expect(result.isLeft()).toBe(true)
+      expect(result.isLeft() && result.value).toBe(defect)
+    })
+
+    it("runOrThrow throws the defect itself", async () => {
+      const defect = new Error("defect")
+
+      await expect(
+        IO.sync(() => {
+          throw defect
+        }).runOrThrow(),
+      ).rejects.toBe(defect)
+    })
+
+    it("runSync puts a defect in the Left, raw", () => {
+      const defect = new Error("defect")
+      const result = IO.sync(() => {
+        throw defect
+      }).runSync()
+
+      expect(result.isLeft() && result.value).toBe(defect)
+    })
+
+    it("run still surfaces interruption as InterruptedError", async () => {
+      const result = await IO.interrupt().run()
+
+      expect(result.isLeft() && result.value).toBeInstanceOf(InterruptedError)
+    })
+  })
+
+  describe("Exit.Die as a value", () => {
+    const die = Exit.die<string, number>(new Error("boom"))
+
+    it("is guarded by both the method and the companion", () => {
+      expect(die.isDie()).toBe(true)
+      expect(Exit.isDie(die)).toBe(true)
+      expect(Exit.isDie(Exit.fail<string, number>("e"))).toBe(false)
+    })
+
+    it("fold routes to onDie when supplied", () => {
+      const seen = die.fold(
+        () => "failure",
+        () => "success",
+        () => "interrupted",
+        () => "die",
+      )
+
+      expect(seen).toBe("die")
+    })
+
+    // Back-compat: the pre-Die three-argument call still compiles and still sees the
+    // defect, because that is where it used to arrive.
+    it("fold falls back to onFailure when onDie is omitted", () => {
+      const seen = die.fold(
+        (e) => `failure:${(e as unknown as Error).message}`,
+        () => "success",
+      )
+
+      expect(seen).toBe("failure:boom")
+    })
+
+    it("match routes to Die when supplied, and to Failure when not", () => {
+      const patterns = {
+        Success: () => "success",
+        Failure: () => "failure",
+        Interrupted: () => "interrupted",
+      }
+
+      expect(die.match({ ...patterns, Die: () => "die" })).toBe("die")
+      expect(die.match(patterns)).toBe("failure")
+    })
+
+    it("passes through the mapping combinators untouched", () => {
+      expect(die.map((n) => n + 1).isDie()).toBe(true)
+      expect(die.flatMap(() => Exit.succeed<string, number>(1)).isDie()).toBe(true)
+      // `mapError` is typed `(e: E) => E2` and a defect is not an `E`, so the callback
+      // must not see it — the same reason Interrupted passes through.
+      expect(die.mapError(() => "mapped").isDie()).toBe(true)
+      expect(
+        die
+          .mapBoth(
+            () => "mapped",
+            (n) => n,
+          )
+          .isDie(),
+      ).toBe(true)
+    })
+
+    it("extracts like a Failure", () => {
+      expect(() => die.orThrow()).toThrow("boom")
+      expect(die.orElse(9)).toBe(9)
+      expect(die.toOption().isEmpty).toBe(true)
+      expect(die.toEither().isLeft()).toBe(true)
+    })
+
+    it("renders and serializes with its own tag", () => {
+      expect(die._tag).toBe("Die")
+      expect(die.toString()).toContain("Exit.Die")
+      expect(die.toJSON()._tag).toBe("Die")
+    })
+
+    it("short-circuits zip and all", () => {
+      expect(Exit.zip(Exit.succeed<string, number>(1), die).isDie()).toBe(true)
+      expect(Exit.all([Exit.succeed<string, number>(1), die]).isDie()).toBe(true)
+    })
+  })
+
+  /**
+   * `bracketExit`'s release is contracted to receive the Exit describing how `use` ended,
+   * so a defect must arrive as one rather than masquerading as a typed failure.
+   */
+  it("bracketExit release sees a Die when use produces a defect", async () => {
+    const seen: string[] = []
+
+    await IO.bracketExit(
+      IO.succeed("resource"),
+      () =>
+        IO.sync<string>(() => {
+          throw new Error("use blew up")
+        }),
+      (_resource, exit) =>
+        IO.sync<void>(() => {
+          seen.push(exit._tag)
+        }),
+    ).runExit()
+
+    expect(seen).toEqual(["Die"])
+  })
+})

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -1,4 +1,4 @@
-# Functype v1.6.3
+# Functype v1.7.0
 
 > A functional programming library for TypeScript with immutable data structures, type-safe error handling, and Scala-inspired patterns.
 


### PR DESCRIPTION
Fixes #258. Fixes #259.

## #259 — `IOQueryError.defect` was unsound

`defect: false` is documented to mean "`.error` really is an `E`", and consumers are told to check it before matching on `_tag`. It didn't hold. Reproduced before touching anything:

| path | `defect` | `.error` | correct? |
|---|---|---|---|
| `IO.fail({_tag:"AuthError"})` | `false` | the `AuthError` | ✅ |
| effect factory throws | `true` | raw `Error` | ✅ |
| **`catch` handler throws** | **`false`** | **raw `Error`** | ❌ |
| **`IO.die`** | **`false`** | **raw `Error`** | ❌ |

The root cause is upstream of the adapter, exactly as the issue diagnoses. `IO.sync` and `IO.die` are `IO<never, never, A>` — the declared error channel is `never`, so nothing they put there can be an `E`. `Exit` had nowhere to say that: both interpreters did `case "Die": throw effect.defect` and the outer catch folded it into `Exit.fail`. By the time `ioQueryFn` saw the `Either`, the distinction was gone.

### The fix

`Exit` gains a `Die` variant: `isDie()`, `Exit.die(defect)`, an `Exit.isDie` companion guard, an optional fourth `onDie` argument on `fold`, and an optional `Die` key on `match`. Both are appended/optional and fall back to the failure handler, so existing three-argument `fold` calls and three-key `match` objects keep compiling **and** keep receiving defects where they received them before.

`ioQueryFn` / `ioMutationFn` now read `runExit()` instead of `run()` and set `defect: true` for a `Die`, for a factory that throws before an `IO` exists, and for interruption (whose `InterruptedError` is no more an `E` than a defect is).

### Two judgement calls worth reviewing

**Defects stay recoverable.** `recover` / `recoverWith` / `fold` / `mapError` treat a `Die` exactly as they treated it before, and `mapError` over a defect produces a `Failure` because the supplied mapper returns a genuine `E`. This is where functype parts company with ZIO — promoting defects to uncatchable would silently change what every existing `.recover()` catches. `Die` is an observability fix, not a control-flow one.

**The dividing line is the *declared* channel, not whether something threw.** `IO.async` and the `IO(...)` constructor are `IO<never, unknown, A>`, so their rejections are legitimate errors and stay `Failure`. That's required as well as correct: `IO.tryPromise` is `async(...).mapError(catch)`, so classifying a rejection as a defect would send it sailing past `mapError`, leaving every `catch` handler in the library uninvoked. There's a test pinning this.

The `Either` terminals are unchanged — `run()`, `runSync()`, `runOrThrow()` still surface a defect as the raw value, because `Either` has no third branch. `runExit()` is the terminal that carries the distinction.

### Sync interpreter

`runSync` returns `Either`, and the sync interpreter signals `Fail` and `Die` with the same bare `throw`, so it can't tell them apart in general. `UnsupportedSyncOperationError` is the one defect it can name with certainty, so the sync `bracketExit` now reports that to `release` as `Die` — superseding a note in the 1.7.0 changelog that said `Exit` had no defect variant. Documented honestly rather than pretending parity.

## #258 — `formatIOError` discarded a tagged error's message

A raw `Error` had `.message` preferred and an untagged object got a JSON rendering, but a *tagged* object carrying a `message` fell back to the bare tag — the one shape where information already present was thrown away. Since `formatIOError` supplies `IOQueryError.message`, a dead session surfaced to the user as `"AuthError"` rather than `"No session"`.

Checked all three `HttpError` variants (`NetworkError`, `HttpStatusError`, `DecodeError`) — none carries a `message`, so the HTTP renderings can't regress, and a numeric `status` still wins regardless.

## Verification

- All **1835** existing functype tests and **127** functype-react tests pass unchanged — the zero-breakage claim is measured, not asserted.
- 43 new tests (28 core, 15 adapter).
- Stashed the four source files, rebuilt, and re-ran: **8 of the 15** new adapter tests fail against the pre-fix source. The 7 that pass are the regression cases, which should pass on both sides.
- `pnpm turbo run validate` → 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)